### PR TITLE
Chat: make hidden message reveal staff-only

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1231,7 +1231,7 @@
 						$messages = this.$chat.find('.chatmessage-' + user);
 						if (!$messages.length) break;
 						$messages.hide().addClass('revealed').find('button').parent().remove();
-						this.$chat.children().last().append(' <button name="toggleMessages" value="' + user + '" class="subtle"><small>(' + $messages.length + ' line' + ($messages.length > 1 ? 's' : '') + ' from ' + user + ' hidden)</small></button>');
+						if (this.rankOrder[app.user.get('name').charAt(0)] > 3) this.$chat.children().last().append(' <button name="toggleMessages" value="' + user + '" class="subtle"><small>(' + $messages.length + ' line' + ($messages.length > 1 ? 's' : '') + ' from ' + user + ' hidden)</small></button>');
 					}
 					break;
 

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1231,7 +1231,7 @@
 						$messages = this.$chat.find('.chatmessage-' + user);
 						if (!$messages.length) break;
 						$messages.hide().addClass('revealed').find('button').parent().remove();
-						if (this.rankOrder[app.user.get('name').charAt(0)] > 3) this.$chat.children().last().append(' <button name="toggleMessages" value="' + user + '" class="subtle"><small>(' + $messages.length + ' line' + ($messages.length > 1 ? 's' : '') + ' from ' + user + ' hidden)</small></button>');
+						if (row[1] !== "perma" || this.rankOrder[app.user.get('name').charAt(0)] > 3) this.$chat.children().last().append(' <button name="toggleMessages" value="' + user + '" class="subtle"><small>(' + $messages.length + ' line' + ($messages.length > 1 ? 's' : '') + ' from ' + user + ' hidden)</small></button>');
 					}
 					break;
 


### PR DESCRIPTION
This is in tandem with https://github.com/Zarel/Pokemon-Showdown/pull/2645, and makes regular users unable to unhide text from banned users if the text is cleared using /unlogtext. Staff (moderator and up) retain this ability.
