### PR TITLE
Allow the effect of damage weakening berries to be activated

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -4350,11 +4350,9 @@ var Battle = (function () {
 					poke.prevItemEffect = 'eaten';
 					if (!this.fastForward) BattleOtherAnims.consume.anim(this, [poke.sprite]);
 					actions += '' + poke.getName() + ' ate its ' + item.name + '!';
-					this.lastmove = item.id;
-				} else if (kwargs.weaken) {
+				} else if (kwargs.weaken) { // Deprecated, now uses -activate
 					poke.prevItemEffect = 'eaten';
 					actions += 'The ' + item.name + ' weakened the damage to ' + poke.getLowerName() + '!';
-					this.lastmove = item.id;
 				} else if (effect.id) switch (effect.id) {
 				case 'fling':
 					poke.prevItemEffect = 'flung';
@@ -5409,6 +5407,8 @@ var Battle = (function () {
 					if (kwargs.broken) { // for custom moves that break protection
 						this.resultAnim(poke, 'Protection broken', 'bad');
 						actions += "It broke through " + poke.getLowerName() + "'s protection!";
+					} else if (kwargs.weaken) { // for damage-reducing berries
+						actions += 'The ' + effect.name + ' weakened the damage to ' + poke.getLowerName() + '!';
 					} else if (effect.effectType !== 'Ability') {
 						actions += "" + poke.getName() + "'s " + effect.name + " activated!";
 					}


### PR DESCRIPTION
As mentioned in PR #780.

(I don't know what `this.lastmove = item.id;` is doing here; it dates back to the creation of `battle.js`.)
