### PR TITLE
Teambuilder: support set notes

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -761,7 +761,7 @@
 		 * Send team to sim server
 		 */
 		sendTeam: function (team) {
-			this.send('/utm ' + Storage.getPackedTeam(team));
+			this.send('/utm ' + Storage.getPackedTeam(team, true));
 		},
 		/**
 		 * Receive from sim server

--- a/style/client.css
+++ b/style/client.css
@@ -2524,12 +2524,14 @@ a.ilink.yours {
 	border: 1px solid #999999;
 	background: #DAE5F0 no-repeat scroll 10px 5px none;
 	border-radius: 5px;
-	padding: 2px 0 0 3px;
-	height: 127px;
-	width: 626px;
+	width: 629px;
 	margin-top: 8px;
 
 	box-shadow: inset 1px 1px 0 rgba(255,255,255,.6);
+}
+.setdata {
+	padding: 2px 0 0 3px;
+	height: 127px;
 }
 .setcol {
 	height: 127px;
@@ -2755,6 +2757,17 @@ a.ilink.yours {
 }
 .setchart .setcol-moves input {
 	width: 129px;
+}
+.setnotes {
+	padding: 2px 4px;
+	display: none;
+}
+.setnotes textarea {
+	width: 612px;
+	height: auto;
+	min-height: 25px;
+	margin-top: 2px;
+	overflow: hidden;
 }
 
 .teambuilder-clipboard-container {


### PR DESCRIPTION
Allowing users to attach notes to themselves on certain sets is a feature that [I've](http://www.smogon.com/forums/threads/3495758/page-66#post-6944260) [often](http://www.smogon.com/forums/threads/3495758/page-63#post-6858968) [seen](http://www.smogon.com/forums/threads/3495758/page-61#post-6828633) [requ](http://www.smogon.com/forums/threads3495758/page-58#post-6770459)[ested](http://www.smogon.com/forums/threads/3495758/page-67#post-6944269), so here we go.  This way, people can conveniently write down the reasons for spreads and weird set decisions.

I initially went for "team notes", but that really wouldn't have meshed well with the way exporting/importing/packing teams is implemented, set-specific notes worked better.

There's now an additional button next to move/copy/delete: 
![grafik](https://cloud.githubusercontent.com/assets/5814184/23534473/6f1b57aa-ffb8-11e6-87e2-7fb314e987b3.png)
Clicking it will append the notes textbox to the bottom of the set like this: 
![grafik](https://cloud.githubusercontent.com/assets/5814184/23534496/a478d29c-ffb8-11e6-82df-21ab847a864b.png)
The textbox changes height automatically when lines are added/removed (no scrollbars!), and is hidden entirely when focus is lost while it's empty. Notes are also not displayed in the set view (with the move/item/stat selection) due to lack of space.

In packed teams, the set notes are appended to the end of each pokemon, every note (line) separated by a |. This has the unfortunate side effect of preventing anything else from being reasonably appended with that separator, because of the possible variable amount of comments for each mon. I'd have used \n to separate comment lines of the same pokemon, but those are also already in use for separating teams.

In exported teams, set notes look like this (importing them works as well of course):
![grafik](https://cloud.githubusercontent.com/assets/5814184/23534350/abcc2752-ffb7-11e6-93eb-3582d2fcee40.png)

Team notes are not sent to the server, they're cut out beforehand.


