### PR TITLE
Fix weird behavior of client commands in multiline inputs

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -93,7 +93,8 @@
 			}
 			this.tabComplete.reset();
 			this.chatHistory.push(text);
-			text = this.parseCommand(text);
+			// make sure commands in multiline inputs are handled correctly
+			text = text.split('\n').map(this.parseCommand, this).filter(function (line) {return (line !== false);}).join('\n');
 			if (this.battle && this.battle.ignoreSpects && app.user.get('userid') !== this.battle.p1.id && app.user.get('userid') !== this.battle.p2.id) {
 				this.add("You can't chat in this battle as you're currently ignoring spectators");
 			} else if (text.length > 80000) {


### PR DESCRIPTION
Almsot every client command is parsed incorrectly in a multiline context currently, by having it go through to the server or by having all the remaining lines being interpreted as the argument of a single command.
The biggest issue with this was probably that a `/nick [name]` followed by a newline could lead to the login token being posted in the chat because the newline is happily passed along to the /trn command, splitting it in the process. At least it was usually blocked due to being too long of a message, unless you can bypassall.

Both Array#map and Array#filter are used elsewhere in the client so I assumed they're fine to use. The other half of the client uses the lodash equivalents though.