### PR TITLE
Add Gastro Acid/Core Enforcer as a bad 'status' in the statusTable.

### DIFF
--- a/src/battle-animations.ts
+++ b/src/battle-animations.ts
@@ -2275,6 +2275,7 @@ class PokemonSprite extends Sprite {
 			}
 		}
 		let statusTable = {
+			endability: '<span class="bad">Gastro&nbsp;Acid</span> ',
 			throatchop: '<span class="bad">Throat&nbsp;Chop</span> ',
 			confusion: '<span class="bad">Confused</span> ',
 			healblock: '<span class="bad">Heal&nbsp;Block</span> ',


### PR DESCRIPTION
It always bothered me that Gastro Acid and Core Enforcer were not added in as Status effects. Apparently, the effects are Baton Passable and they do not de-activate when the ability is changed as seen in this replay:

http://replay.pokemonshowdown.com/gen7balancedhackmons-797571348

Turn 29, Darmanitan gets hit with Core Enforcer, but turn 31 Mega Gengar turns Darmanitan's ability to Normalize. Even though Darmanitan had it's ability changed, it was still de-activated. I feel like that is unintuitive because many players don't know that the effect is still up. Throat Chop is pretty uncommon too but that got added in as a status effect...

While this is not a huge problem in many tiers, Core Enforcer is exceptionally common in Balanced Hackmons. I tried implementing Gastro Acid's and Core Enforcer's effects as a bad 'status'. I can't test it for myself to see if it works because I don't know how to. I'd appreciate if you could take a look and perhaps implement (and fix?) this.