### PR TITLE
Display base power of Hidden Power/Frustration/Return in Pokemon tooltip if not max

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -2472,7 +2472,7 @@
 			buf += '<strong><a href="//pokemonshowdown.com/users/' + userid + '" target="_blank">' + BattleLog.escapeHTML(name) + '</a></strong><br />';
 			var offline = data.rooms === false;
 			if (data.status || offline) {
-				buf += '<span class="userstatus' + (offline ? ' offline' : '') + '">' + (offline ? 'Offline' : BattleLog.escapeHTML(data.status)) + '</span><br />';
+				buf += '<span class="userstatus' + (offline ? ' offline' : '') + '">' + (offline ? '(Offline)' : BattleLog.escapeHTML(data.status)) + '</span><br />';
 			}
 			buf += '<small>' + (group || '&nbsp;') + '</small>';
 			if (globalgroup) buf += '<br /><small>' + globalgroup + '</small>';

--- a/src/battle-dex.ts
+++ b/src/battle-dex.ts
@@ -259,7 +259,7 @@ const Dex = new class implements ModdedDex {
 		return new PureEffect(id, name);
 	}
 
-	getMove(nameOrMove: string | Move | null | undefined): Move {
+	getMove(nameOrMove: string | Move | null | undefined, gen = 7): Move {
 		if (nameOrMove && typeof nameOrMove !== 'string') {
 			// TODO: don't accept Moves here
 			return nameOrMove;
@@ -278,7 +278,7 @@ const Dex = new class implements ModdedDex {
 			let [, hpWithType, hpPower] = /([a-z]*)([0-9]*)/.exec(id)!;
 			data = {
 				...(window.BattleMovedex[hpWithType] || {}),
-				basePower: Number(hpPower) || 60,
+				basePower: Number(hpPower) || (gen < 6 ? 70 : 60),
 			};
 		}
 		if (!data && id.substr(0, 6) === 'return' && id.length > 6) {
@@ -714,7 +714,7 @@ class ModdedDex {
 		}
 		if (this.cache.Moves.hasOwnProperty(id)) return this.cache.Moves[id];
 
-		let data = {...Dex.getMove(name)};
+		let data = {...Dex.getMove(name, this.gen)};
 
 		const table = window.BattleTeambuilderTable[this.modid];
 		if (id in table.overrideAcc) data.accuracy = table.overrideAcc[id];

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -702,11 +702,12 @@ class BattleTooltips {
 			let battlePokemon = this.battle.getPokemon(pokemon.ident, pokemon.details);
 			for (const moveid of serverPokemon.moves) {
 				let move = Dex.getMove(moveid);
-				let moveName = '&#8226; ' + move.name;
+				let moveDisplay = this.getMoveDisplay(move, serverPokemon);
+				let moveName = '&#8226; ' + moveDisplay;
 				if (battlePokemon && battlePokemon.moveTrack) {
 					for (const row of battlePokemon.moveTrack) {
 						if (moveName === row[0]) {
-							moveName = this.getPPUseText(row, true);
+							moveName = this.getPPUseText(row, true, moveDisplay);
 							break;
 						}
 					}
@@ -731,6 +732,14 @@ class BattleTooltips {
 			text += '</p>';
 		}
 		return text;
+	}
+
+	getMoveDisplay(move: Move, pokemon: ServerPokemon) {
+		if (((move.id === 'frustration' || move.id === 'return') && move.basePower !== 102) ||
+			(move.id.startsWith('hiddenpower') && this.battle.gen < 7 && move.basePower !== 70)) {
+			return `${move.name} - ${move.basePower}BP`;
+		}
+		return move.name;
 	}
 
 	calculateModifiedStats(clientPokemon: Pokemon | null, serverPokemon: ServerPokemon) {
@@ -998,7 +1007,7 @@ class BattleTooltips {
 		return buf;
 	}
 
-	getPPUseText(moveTrackRow: [string, number], showKnown?: boolean) {
+	getPPUseText(moveTrackRow: [string, number], showKnown?: boolean, moveDisplay?: string) {
 		let [moveName, ppUsed] = moveTrackRow;
 		let move;
 		let maxpp;
@@ -1012,12 +1021,12 @@ class BattleTooltips {
 		}
 		const bullet = moveName.charAt(0) === '*' || move.isZ ? '<span style="color:#888">&#8226;</span>' : '&#8226;';
 		if (ppUsed === Infinity) {
-			return `${bullet} ${move.name} <small>(0/${maxpp})</small>`;
+			return `${bullet} ${moveDisplay || move.name} <small>(0/${maxpp})</small>`;
 		}
 		if (ppUsed || moveName.charAt(0) === '*') {
-			return `${bullet} ${move.name} <small>(${maxpp - ppUsed}/${maxpp})</small>`;
+			return `${bullet} ${moveDisplay || move.name} <small>(${maxpp - ppUsed}/${maxpp})</small>`;
 		}
-		return `${bullet} ${move.name} ${showKnown ? ' <small>(revealed)</small>' : ''}`;
+		return `${bullet} ${moveDisplay || move.name} ${showKnown ? ' <small>(revealed)</small>' : ''}`;
 	}
 
 	ppUsed(move: Move, pokemon: Pokemon) {

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -701,8 +701,8 @@ class BattleTooltips {
 			text += '<p class="section">';
 			let battlePokemon = this.battle.getPokemon(pokemon.ident, pokemon.details);
 			for (const moveid of serverPokemon.moves) {
-				let move = Dex.getMove(moveid);
-				let moveDisplay = this.getMoveDisplay(move, serverPokemon);
+				let move = this.battle.dex.getMove(moveid);
+				let moveDisplay = this.getMoveDisplay(move);
 				let moveName = '&#8226; ' + moveDisplay;
 				if (battlePokemon && battlePokemon.moveTrack) {
 					for (const row of battlePokemon.moveTrack) {
@@ -734,10 +734,10 @@ class BattleTooltips {
 		return text;
 	}
 
-	getMoveDisplay(move: Move, pokemon: ServerPokemon) {
+	getMoveDisplay(move: Move) {
 		if (((move.id === 'frustration' || move.id === 'return') && move.basePower !== 102) ||
-			(move.id.startsWith('hiddenpower') && this.battle.gen < 7 && move.basePower !== 70)) {
-			return `${move.name} - ${move.basePower}BP`;
+			(move.id.startsWith('hiddenpower') && this.battle.gen < 6 && move.basePower !== 70)) {
+			return `${move.name} ${move.basePower}`;
 		}
 		return move.name;
 	}


### PR DESCRIPTION
Won't do anything without https://github.com/Zarel/Pokemon-Showdown/pull/5519 which plumbs through happiness as part of the `|request|`.