### PR TITLE
Place ranks/groups in a pillbox to further distinguish from status

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -2494,8 +2494,12 @@ function toId() {
 			var status = offline ? '(Offline)' : '(Online)';
 			if (data.status && !offline) status = data.status.startsWith('!') ? data.status.slice(1) : data.status;
 			buf += '<span class="userstatus' + (offline ? ' offline' : '') + '">' + BattleLog.escapeHTML(status) + '</span><br />';
-			buf += '<small>' + (group || '&nbsp;') + '</small>';
-			if (globalgroup) buf += '<br /><small>' + globalgroup + '</small>';
+			if (group) {
+				buf += '<small class="usergroup roomgroup">' + group + '</small>';
+			} else {
+				buf += '<small>&nbsp;</small>';
+			}
+			if (globalgroup) buf += '<br /><small class="usergroup globalgroup">' + globalgroup + '</small>';
 			if (data.rooms) {
 				var battlebuf = '';
 				var chatbuf = '';

--- a/style/client.css
+++ b/style/client.css
@@ -3057,8 +3057,8 @@ a.ilink.yours {
 }
 .usergroup {
 	border: 1px solid #000;
-	padding: 2px 4px;
-	border-radius: 11px;
+	padding: 1px 5px;
+	border-radius: 5px;
 	display: inline-block;
 }
 .roomgroup {

--- a/style/client.css
+++ b/style/client.css
@@ -3057,7 +3057,7 @@ a.ilink.yours {
 }
 .usergroup {
 	border: 1px solid #000;
-	padding: 4px;
+	padding: 2px 4px;
 	border-radius: 11px;
 	display: inline-block;
 }

--- a/style/client.css
+++ b/style/client.css
@@ -3052,8 +3052,18 @@ a.ilink.yours {
 .userstatus {
 	font-style: italic;
 	font-size: 8pt;
+	display: inline-block;
+	margin-bottom: 5px;
 }
-
+.usergroup {
+	border: 1px solid #000;
+	padding: 4px;
+	border-radius: 11px;
+	display: inline-block;
+}
+.roomgroup {
+	margin-bottom: 2px;
+}
 .userdetails {
 	min-height: 80px;
 	width: 191px;
@@ -3212,6 +3222,10 @@ a.ilink.yours {
 	border-color: #888;
 
 	box-shadow: 2px 2px 3px rgba(0,0,0,.2);
+}
+
+.dark .usergroup {
+	border: 1px solid #FFF;
 }
 
 .dark .popupmenu button,


### PR DESCRIPTION
>> Can we better differentiate statuses from rank/group display such that its more difficult to confuse the two?
>
> Rank/group could be pills? Like how Discord does them.

_Originally posted by @Zarel in https://github.com/Zarel/Pokemon-Showdown/issues/5590#issuecomment-508913502_

<img width="295" alt="Screen Shot 2019-07-07 at 14 35 37" src="https://user-images.githubusercontent.com/117249/60774298-3636ae00-a0c7-11e9-8a9e-46d7f102280e.png">
