### PR TITLE
Implement automatic IVs

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2218,7 +2218,36 @@
 			this.save();
 		},
 		updateIVs: function () {
-			// TODO: What to do with this code
+			var set = this.curSet;
+			if (!set.moves || this.canHyperTrain(set)) return;
+			var hasHiddenPower = false;
+			for (var i = 0; i < set.moves.length; i++) {
+				if (toID(set.moves[i]).slice(0, 11) === 'hiddenpower') {
+					hasHiddenPower = true;
+					break;
+				}
+			}
+			if (!hasHiddenPower) return;
+			var hpTypes = ['Fighting', 'Flying', 'Poison', 'Ground', 'Rock', 'Bug', 'Ghost', 'Steel', 'Fire', 'Water', 'Grass', 'Electric', 'Psychic', 'Ice', 'Dragon', 'Dark'];
+			var hpType;
+			if (this.curTeam.gen <= 2) {
+				// TODO: Old gens
+			} else {
+				var hpTypeX = 0;
+				var i = 1;
+				var autoIVs = this.getAutoIVs();
+				for (var stat in autoIVs) {
+					hpTypeX += i * (autoIVs[stat] % 2);
+					i *= 2;
+				}
+				hpType = hpTypes[Math.floor(hpTypeX * 15 / 63)];
+			}
+			for (var i = 0; i < set.moves.length; i++) {
+				if (toID(set.moves[i]).slice(0, 11) === 'hiddenpower') {
+					set.moves[i] = "Hidden Power " + hpType;
+					if (i < 4) this.$('input[name=move' + (i + 1) + ']').val("Hidden Power " + hpType);
+				}
+			}
 		},
 		statSlide: function (e) {
 			var slider = e.currentTarget;

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2202,13 +2202,8 @@
 				var changed = set.ivs[stat] !== val && (val !== 31 || set.ivs[stat] !== undefined);
 				if (changed) {
 					if (val === 31) {
-						// We don't store 31 IVs in the `ivs` structure so that it won't show up in the export.
-						// If the user accidentally adjusts the HP IV and readjusts it to 31, there is no reason to
-						// add "IVs: 31 HP" to the export.
-						// The only way we will export an explicit 31 IVs in a stat is if the user imported the set
-						// from text with "IVs: 31 <stat>" in the first place, as we don't check for 31 in importTeam.
-						// They may want to do this if (for example) they wanted to give a Pokemon w/ Gyro Ball max
-						// speed IVs for some reason. But this doesn't represent the majority use case.
+						// Assume the user wants to keep this IV implicit (eg. if they change to 31 speed
+						// but add Gyro Ball later, they would want it adjusted to 0 speed)
 						delete set.ivs[stat];
 					} else {
 						set.ivs[stat] = val;

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2390,7 +2390,7 @@
 
 				for (var stat in set.ivs) {
 					var input = this.$chart.find('input[name=iv-' + stat + ']');
-					input.val('' + set.ivs[stat])
+					input.val('' + set.ivs[stat]);
 					input.prop('disabled', false);
 				}
 

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -47,6 +47,7 @@
 			'change select[name=ivspread]': 'ivSpreadChange',
 			'change .evslider': 'statSlided',
 			'input .evslider': 'statSlide',
+			'change .autoivs': 'autoIVsChange',
 
 			// teambuilder events
 			'click .utilichart a': 'chartClick',
@@ -2074,7 +2075,7 @@
 
 					buf += '</select>';
 				}
-				buf += '<input type="checkbox"> Automatic IVs'
+				buf += '<input type="checkbox" name="autoivs" checked> Automatic IVs'
 				buf += '</div>';
 				buf += '</div>';
 			} else {
@@ -2351,6 +2352,18 @@
 
 			this.save();
 			this.updateStatGraph();
+		},
+		autoIVsChange: function (e) {
+			if (!e.currentTarget.checked) {
+				// Was unchecked
+				// Explicitly encode as 31 / 31 / 31 ... etc
+				// assert(this.curSet.ivs === null)
+				// TODO
+			} else {
+				// Was checked
+				// Reset all IVs to defaults, inferring from context
+				// TODO
+			}
 		},
 
 		/*********************************************************

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2926,7 +2926,7 @@
 			}
 
 			if (stat === 'atk') {
-				if (gen > 2) {
+				if (gen > 2 && set.ability !== 'Battle Bond') { // Ash-Greninja is only available through an event with 31 Atk IVs
 					useMaxValue = false; // Default to 0 Atk IVs if we don't have a physical attacking move
 					for (var i = 0; i < moves.length; ++i) {
 						if (!moves[i]) continue;

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2074,7 +2074,7 @@
 
 					buf += '</select>';
 				}
-				buf += '<input type="checkbox" name="autoivs" chekced> Use automatic IVs'
+				buf += '<input type="checkbox" name="autoivs" ' + (isEmpty(set.ivs) ? 'checked' : '') + '> Use automatic IVs';
 				buf += '</div>';
 				buf += '</div>';
 			} else {
@@ -2206,6 +2206,7 @@
 					this.updateIVs();
 					this.updateStatGraph();
 				}
+				$(".autoivs").prop("checked", false);
 			}
 			this.save();
 		},
@@ -2328,7 +2329,7 @@
 					var iv = '' + autoIVs[stat];
 					this.$chart.find('input[name=iv-' + stat + ']').val(iv);
 				}
-				
+
 				this.save();
 				this.updateStatGraph();
 			} else {

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -47,7 +47,7 @@
 			'change select[name=ivspread]': 'ivSpreadChange',
 			'change .evslider': 'statSlided',
 			'input .evslider': 'statSlide',
-			'change .autoivs': 'autoIVsChange',
+			'change .autoivs': 'useAutoIVsChange',
 
 			// teambuilder events
 			'click .utilichart a': 'chartClick',
@@ -2074,7 +2074,7 @@
 
 					buf += '</select>';
 				}
-				buf += '<input type="checkbox" name="autoivs" checked> Automatic IVs'
+				buf += '<input type="checkbox" name="autoivs" chekced> Use automatic IVs'
 				buf += '</div>';
 				buf += '</div>';
 			} else {
@@ -2318,16 +2318,32 @@
 			this.save();
 			this.updateStatGraph();
 		},
-		autoIVsChange: function (e) {
-			if (!e.currentTarget.checked) {
-				// Was unchecked
-				// Explicitly encode as 31 / 31 / 31 ... etc
-				// assert(this.curSet.ivs === null)
-				// TODO
+		useAutoIVsChange: function (e) {
+			var set = this.curSet;
+			var newValue = e.currentTarget.checked;
+			if (newValue) {
+				set.ivs = {};
+				var autoIVs = this.getAutoIVs();
+				for (var stat in autoIVs) {
+					var iv = '' + autoIVs[stat];
+					this.$chart.find('input[name=iv-' + stat + ']').val(iv);
+				}
+				
+				this.save();
+				this.updateStatGraph();
 			} else {
-				// Was checked
-				// Reset all IVs to defaults, inferring from context
-				// TODO
+				if (!isEmpty(set.ivs)) return; // TODO: Should never happen
+
+				var autoIVs = this.getAutoIVs();
+				for (var stat in autoIVs) {
+					var iv = autoIVs[stat];
+					if (iv !== 31) {
+						set.ivs[stat] = iv;
+					}
+				}
+
+				this.save();
+				// We don't have to update the stat graph since we're not actually changing the IVs, just how they're stored
 			}
 		},
 

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2074,7 +2074,7 @@
 
 					buf += '</select>';
 				}
-				buf += '<input type="checkbox" name="autoivs" ' + (isEmpty(set.ivs) ? 'checked' : '') + '> Use automatic IVs';
+				buf += '<input type="checkbox" name="autoivs" ' + (this.isEmpty(set.ivs) ? 'checked' : '') + '> Use automatic IVs';
 				buf += '</div>';
 				buf += '</div>';
 			} else {
@@ -2206,7 +2206,7 @@
 					this.updateIVs();
 					this.updateStatGraph();
 				}
-				$(".autoivs").prop("checked", false);
+				$("input[name=autoivs]").prop("checked", false);
 			}
 			this.save();
 		},
@@ -2333,7 +2333,7 @@
 				this.save();
 				this.updateStatGraph();
 			} else {
-				if (!isEmpty(set.ivs)) return; // TODO: Should never happen
+				if (!this.isEmpty(set.ivs)) return; // TODO: Should never happen
 
 				var autoIVs = this.getAutoIVs();
 				for (var stat in autoIVs) {
@@ -2820,8 +2820,7 @@
 			if (!set.level) set.level = 100;
 
 			var baseStat = (this.getBaseStats(template))[stat];
-			// TODO
-			var iv = this.getAutoIV(stat);
+			var iv = this.getAutoIV(stat, set);
 			if (this.curTeam.gen <= 2) iv &= 30;
 			var ev = set.evs[stat];
 			if (evOverride !== undefined) ev = evOverride;
@@ -2850,24 +2849,29 @@
 			return Math.floor(val);
 		},
 
-		getAutoIVs: function () {
+		getAutoIVs: function (set) {
 			return {
-				hp: this.getAutoIV('hp'),
-				atk: this.getAutoIV('atk'),
-				def: this.getAutoIV('def'),
-				spa: this.getAutoIV('spa'),
-				spd: this.getAutoIV('spd'),
-				spe: this.getAutoIV('spe')
+				hp: this.getAutoIV('hp', set),
+				atk: this.getAutoIV('atk', set),
+				def: this.getAutoIV('def', set),
+				spa: this.getAutoIV('spa', set),
+				spd: this.getAutoIV('spd', set),
+				spe: this.getAutoIV('spe', set)
 			};
 		},
 
-		getAutoIV: function (stat) {
-			var set = this.curSet;
+		getAutoIV: function (stat, set) {
+			if (!set) set = this.curSet;
 			if (set.ivs[stat] !== undefined) return set.ivs[stat];
 
 			// TODO
 
 			return 31;
+		},
+
+		// TODO: This should be a static helper function
+		isEmpty: function (obj) {
+			return Object.keys(obj).length === 0;
 		},
 
 		// initialization

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2074,7 +2074,7 @@
 
 					buf += '</select>';
 				}
-				buf += '<input type="checkbox" name="autoivs" ' + (this.isEmpty(set.ivs) ? 'checked' : '') + '> Use automatic IVs';
+				buf += '<input type="checkbox" name="autoivs" ' + (Object.keys(set.ivs).length ? '' : 'checked') + '> Use automatic IVs';
 				buf += '</div>';
 				buf += '</div>';
 			} else {
@@ -2373,7 +2373,7 @@
 				// We are currently using the default IVs (and still will), but transcribe any
 				// non-31 default IVs into `ivs` so that they will be included in the export
 
-				if (!this.isEmpty(set.ivs)) return; // Should never happen
+				if (Object.keys(set.ivs).length !== 0) return; // Should never happen
 
 				var autoIVs = this.getAutoIVs();
 				for (var stat in autoIVs) {
@@ -2782,8 +2782,6 @@
 			} else if (moveName === 'Frustration') {
 				set.happiness = 0;
 			}
-
-			// TODO: Finish moving IV logic to getAutoIVs
 		},
 		setPokemon: function (val, selectNext) {
 			var set = this.curSet;
@@ -2955,11 +2953,6 @@
 			}
 
 			return '';
-		},
-
-		// TODO: This should be a static helper function elsewhere?
-		isEmpty: function (obj) {
-			return Object.keys(obj).length === 0;
 		},
 
 		// initialization

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2006,7 +2006,8 @@
 					case 'fighting':
 						hpIVs = ['001000', '110000', '100000']; break;
 					}
-					buf += '<div style="margin-left:-80px;text-align:right"><select name="ivspread">';
+					buf += '<div style="display:inline-block;margin-left:-80px;text-align:right">';
+					buf += '<select name="ivspread">';
 					buf += '<option value="" selected>HP ' + hpType.charAt(0).toUpperCase() + hpType.slice(1) + ' IVs</option>';
 
 					var minStat = this.curTeam.gen >= 6 ? 0 : 2;
@@ -2052,9 +2053,10 @@
 					}
 					buf += '</optgroup>';
 
-					buf += '</select></div>';
+					buf += '</select>';
 				} else {
-					buf += '<div style="margin-left:-80px;text-align:right"><select name="ivspread">';
+					buf += '<div style="display:inline-block;margin-left:-80px;text-align:right">';
+					buf += '<select name="ivspread">';
 					buf += '<option value="" selected>IV spreads</option>';
 
 					buf += '<optgroup label="min Atk">';
@@ -2070,8 +2072,10 @@
 					buf += '<option value="31/31/31/31/31/0">31/31/31/31/31/0</option>';
 					buf += '</optgroup>';
 
-					buf += '</select></div>';
+					buf += '</select>';
 				}
+				buf += '<input type="checkbox"> Automatic IVs'
+				buf += '</div>';
 				buf += '</div>';
 			} else {
 				buf += '<div class="col ivcol"><div><strong>DVs</strong></div>';

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2502,7 +2502,6 @@
 					var $inputEl = this.$('input[name=move' + i + ']');
 					var curVal = $inputEl.val();
 					if (curVal === val) {
-						this.unChooseMove(curVal);
 						$inputEl.val('');
 						delete this.search.cur[toID(val)];
 					} else if (curVal) {
@@ -2706,14 +2705,12 @@
 				if (selectNext) this.$('input[name=move1]').select();
 				break;
 			case 'move1':
-				this.unChooseMove(this.curSet.moves[0]);
 				this.curSet.moves[0] = val;
 				this.chooseMove(val);
 				if (selectNext) this.$('input[name=move2]').select();
 				break;
 			case 'move2':
 				if (!this.curSet.moves[0]) this.curSet.moves[0] = '';
-				this.unChooseMove(this.curSet.moves[1]);
 				this.curSet.moves[1] = val;
 				this.chooseMove(val);
 				if (selectNext) this.$('input[name=move3]').select();
@@ -2721,7 +2718,6 @@
 			case 'move3':
 				if (!this.curSet.moves[0]) this.curSet.moves[0] = '';
 				if (!this.curSet.moves[1]) this.curSet.moves[1] = '';
-				this.unChooseMove(this.curSet.moves[2]);
 				this.curSet.moves[2] = val;
 				this.chooseMove(val);
 				if (selectNext) this.$('input[name=move4]').select();
@@ -2730,7 +2726,6 @@
 				if (!this.curSet.moves[0]) this.curSet.moves[0] = '';
 				if (!this.curSet.moves[1]) this.curSet.moves[1] = '';
 				if (!this.curSet.moves[2]) this.curSet.moves[2] = '';
-				this.unChooseMove(this.curSet.moves[3]);
 				this.curSet.moves[3] = val;
 				this.chooseMove(val);
 				if (selectNext) {
@@ -2740,9 +2735,6 @@
 				break;
 			}
 			this.save();
-		},
-		unChooseMove: function (moveName) {
-			// TODO: Delete this and usage sites
 		},
 		canHyperTrain: function (set) {
 			if (this.curTeam.gen < 7 || this.curTeam.format === 'gen7hiddentype') return false;

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2084,6 +2084,9 @@
 					var val = '' + Math.floor(autoIVs[i] / 2);
 					buf += '<div><input type="number" name="iv-' + i + '" value="' + BattleLog.escapeHTML(val) + '" class="textbox inputform numform" min="0" max="15" step="1" /></div>';
 				}
+				buf += '<div style="display:inline-block;margin-left:-80px;text-align:right">';
+				buf += '<input type="checkbox" name="autoivs" ' + (Object.keys(set.ivs).length ? '' : 'checked') + '> Use automatic DVs';
+				buf += '</div>';
 				buf += '</div>';
 			}
 
@@ -2232,23 +2235,9 @@
 			var hpType;
 			if (this.curTeam.gen <= 2) {
 				var autoIVs = this.getAutoIVs();
-				var hpDV = Math.floor(autoIVs.hp / 2);
 				var atkDV = Math.floor(autoIVs.atk / 2);
 				var defDV = Math.floor(autoIVs.def / 2);
-				var speDV = Math.floor(autoIVs.spe / 2);
-				var spcDV = Math.floor(autoIVs.spa / 2);
 				hpType = hpTypes[4 * (atkDV % 4) + (defDV % 4)];
-
-				var expectedHpDV = (atkDV % 2) * 8 + (defDV % 2) * 4 + (speDV % 2) * 2 + (spcDV % 2);
-				if (expectedHpDV !== hpDV) {
-					var newHpIV = expectedHpDV * 2;
-					if (newHpIV === 30) {
-						delete set.ivs.hp;
-					} else {
-						set.ivs.hp = newHpIV;
-					}
-					this.$chart.find('input[name=iv-hp]').val(expectedHpDV);
-				}
 			} else {
 				var hpTypeX = 0;
 				var i = 1;
@@ -2380,8 +2369,13 @@
 				set.ivs = {};
 				var autoIVs = this.getAutoIVs();
 				for (var stat in autoIVs) {
-					var iv = '' + autoIVs[stat];
-					this.$chart.find('input[name=iv-' + stat + ']').val(iv);
+					if (this.curTeam.gen > 2) {
+						var iv = '' + autoIVs[stat];
+						this.$chart.find('input[name=iv-' + stat + ']').val(iv);
+					} else {
+						var dv = '' + Math.floor(autoIVs[stat] / 2);
+						this.$chart.find('input[name=iv-' + stat + ']').val(dv);
+					}
 				}
 
 				this.save();

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -817,6 +817,10 @@
 				// Chrome is dumb and doesn't support data URLs in HTTPS
 				urlprefix = "https://play.pokemonshowdown.com/action.php?act=dlteam&team=";
 			}
+			for (var i = 0; i < team.team.length; i++) {
+				var set = team.team[i];
+				set.autoIVs = this.getAutoIVs(set);
+			}
 			var contents = Storage.exportTeam(team.team).replace(/\n/g, '\r\n');
 			var downloadurl = "text/plain:" + filename + ":" + urlprefix + encodeURIComponent(window.btoa(unescape(encodeURIComponent(contents))));
 			console.log(downloadurl);
@@ -1052,6 +1056,11 @@
 
 			var buf = '';
 			if (this.exportMode) {
+				for (var i = 0; i < this.curSetList.length; i++) {
+					var set = this.curSetList[i];
+					set.autoIVs = this.getAutoIVs(set);
+				}
+
 				buf = '<div class="pad"><button name="back"><i class="fa fa-chevron-left"></i> List</button> <input class="textbox teamnameedit" type="text" class="teamnameedit" size="30" value="' + BattleLog.escapeHTML(this.curTeam.name) + '" /> <button name="saveImport"><i class="fa fa-upload"></i> Import/Export</button> <button name="saveImport" class="savebutton"><i class="fa fa-floppy-o"></i> Save</button></div>';
 				buf += '<div class="teamedit"><textarea class="textbox" rows="17">' + BattleLog.escapeHTML(Storage.exportTeam(this.curSetList)) + '</textarea></div>';
 			} else {
@@ -1441,6 +1450,8 @@
 				this.wasViewingPokemon = false;
 				this.selectPokemon(i);
 			}
+
+			this.curSet.autoIVs = this.getAutoIVs();
 
 			this.$('li').find('input, button').prop('disabled', true);
 			this.$chart.hide();

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -817,7 +817,7 @@
 				// Chrome is dumb and doesn't support data URLs in HTTPS
 				urlprefix = "https://play.pokemonshowdown.com/action.php?act=dlteam&team=";
 			}
-			var contents = Storage.exportTeam(team.team).replace(/\n/g, '\r\n');
+			var contents = Storage.exportTeam(team.team, team.format).replace(/\n/g, '\r\n');
 			var downloadurl = "text/plain:" + filename + ":" + urlprefix + encodeURIComponent(window.btoa(unescape(encodeURIComponent(contents))));
 			console.log(downloadurl);
 			dataTransfer.setData("DownloadURL", downloadurl);
@@ -1053,7 +1053,7 @@
 			var buf = '';
 			if (this.exportMode) {
 				buf = '<div class="pad"><button name="back"><i class="fa fa-chevron-left"></i> List</button> <input class="textbox teamnameedit" type="text" class="teamnameedit" size="30" value="' + BattleLog.escapeHTML(this.curTeam.name) + '" /> <button name="saveImport"><i class="fa fa-upload"></i> Import/Export</button> <button name="saveImport" class="savebutton"><i class="fa fa-floppy-o"></i> Save</button></div>';
-				buf += '<div class="teamedit"><textarea class="textbox" rows="17">' + BattleLog.escapeHTML(Storage.exportTeam(this.curSetList)) + '</textarea></div>';
+				buf += '<div class="teamedit"><textarea class="textbox" rows="17">' + BattleLog.escapeHTML(Storage.exportTeam(this.curSetList, this.curTeam.format)) + '</textarea></div>';
 			} else {
 				buf = '<div class="pad"><button name="back"><i class="fa fa-chevron-left"></i> List</button> <input class="textbox teamnameedit" type="text" class="teamnameedit" size="30" value="' + BattleLog.escapeHTML(this.curTeam.name) + '" /> <button name="import"><i class="fa fa-upload"></i> Import/Export</button></div>';
 				buf += '<div class="teamchartbox">';
@@ -1447,7 +1447,7 @@
 			this.$('.teambuilder-pokemon-import')
 				.show()
 				.find('textarea')
-				.val(Storage.exportTeam([this.curSet]).trim())
+				.val(Storage.exportTeam([this.curSet], this.curTeam.format).trim())
 				.focus()
 				.select();
 		},
@@ -2849,7 +2849,7 @@
 			if (!set.level) set.level = 100;
 
 			var baseStat = (this.getBaseStats(template))[stat];
-			var iv = set.ivs ? set.ivs[stat] : this.getAutoIV(stat, set);
+			var iv = set.ivs ? set.ivs[stat] : getAutoIV(stat, set, this.curTeam.format);
 			if (this.curTeam.gen <= 2) iv &= 30;
 			var ev = set.evs[stat];
 			if (evOverride !== undefined) ev = evOverride;

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -19,7 +19,7 @@
 		focus: function () {
 			if (this.curTeam) {
 				this.curTeam.iconCache = '!';
-				this.curTeam.gen = this.getGen(this.curTeam.format);
+				this.curTeam.gen = getGen(this.curTeam.format);
 				Storage.activeSetList = this.curSetList;
 			}
 		},
@@ -665,7 +665,7 @@
 			i = +i;
 			this.curTeam = teams[i];
 			this.curTeam.iconCache = '!';
-			this.curTeam.gen = this.getGen(this.curTeam.format);
+			this.curTeam.gen = getGen(this.curTeam.format);
 			Storage.activeSetList = this.curSetList = Storage.unpackTeam(this.curTeam.team);
 			this.curTeamIndex = i;
 			this.update();
@@ -817,11 +817,7 @@
 				// Chrome is dumb and doesn't support data URLs in HTTPS
 				urlprefix = "https://play.pokemonshowdown.com/action.php?act=dlteam&team=";
 			}
-			for (var i = 0; i < team.team.length; i++) {
-				var set = team.team[i];
-				set.autoIVs = this.getAutoIVs(set);
-			}
-			var contents = Storage.exportTeam(team.team).replace(/\n/g, '\r\n');
+			var contents = Storage.exportTeam(team.team, team.format).replace(/\n/g, '\r\n');
 			var downloadurl = "text/plain:" + filename + ":" + urlprefix + encodeURIComponent(window.btoa(unescape(encodeURIComponent(contents))));
 			console.log(downloadurl);
 			dataTransfer.setData("DownloadURL", downloadurl);
@@ -1056,13 +1052,8 @@
 
 			var buf = '';
 			if (this.exportMode) {
-				for (var i = 0; i < this.curSetList.length; i++) {
-					var set = this.curSetList[i];
-					set.autoIVs = this.getAutoIVs(set);
-				}
-
 				buf = '<div class="pad"><button name="back"><i class="fa fa-chevron-left"></i> List</button> <input class="textbox teamnameedit" type="text" class="teamnameedit" size="30" value="' + BattleLog.escapeHTML(this.curTeam.name) + '" /> <button name="saveImport"><i class="fa fa-upload"></i> Import/Export</button> <button name="saveImport" class="savebutton"><i class="fa fa-floppy-o"></i> Save</button></div>';
-				buf += '<div class="teamedit"><textarea class="textbox" rows="17">' + BattleLog.escapeHTML(Storage.exportTeam(this.curSetList)) + '</textarea></div>';
+				buf += '<div class="teamedit"><textarea class="textbox" rows="17">' + BattleLog.escapeHTML(Storage.exportTeam(this.curSetList, this.curTeam.format)) + '</textarea></div>';
 			} else {
 				buf = '<div class="pad"><button name="back"><i class="fa fa-chevron-left"></i> List</button> <input class="textbox teamnameedit" type="text" class="teamnameedit" size="30" value="' + BattleLog.escapeHTML(this.curTeam.name) + '" /> <button name="import"><i class="fa fa-upload"></i> Import/Export</button></div>';
 				buf += '<div class="teamchartbox">';
@@ -1302,7 +1293,7 @@
 		},
 		changeFormat: function (format) {
 			this.curTeam.format = format;
-			this.curTeam.gen = this.getGen(this.curTeam.format);
+			this.curTeam.gen = getGen(this.curTeam.format);
 			this.save();
 			if (this.curTeam.gen === 5 && !Dex.loadedSpriteData['bw']) Dex.loadSpriteData('bw');
 			this.update();
@@ -1451,14 +1442,12 @@
 				this.selectPokemon(i);
 			}
 
-			this.curSet.autoIVs = this.getAutoIVs();
-
 			this.$('li').find('input, button').prop('disabled', true);
 			this.$chart.hide();
 			this.$('.teambuilder-pokemon-import')
 				.show()
 				.find('textarea')
-				.val(Storage.exportTeam([this.curSet]).trim())
+				.val(Storage.exportTeam([this.curSet], this.curTeam.format).trim())
 				.focus()
 				.select();
 		},
@@ -1967,7 +1956,7 @@
 
 			if (this.curTeam.gen > 2) {
 				buf += '<div class="col ivcol"><div><strong>IVs</strong></div>';
-				var ivs = set.ivs || this.getAutoIVs();
+				var ivs = set.ivs || getAutoIVs(set, this.curTeam.format);
 				for (var i in stats) {
 					var val = '' + (ivs[i]);
 					buf += '<div><input type="number" name="iv-' + i + '" value="' + BattleLog.escapeHTML(val) + '" class="textbox inputform numform" min="0" max="31" step="1" ' + (set.ivs ? '' : 'disabled') + ' /></div>';
@@ -1981,7 +1970,7 @@
 						}
 					}
 				}
-				if (hpType && !this.canHyperTrain(set)) {
+				if (hpType && !canHyperTrain(set, this.curTeam.format)) {
 					var hpIVs;
 					switch (hpType) {
 					case 'dark':
@@ -2090,7 +2079,7 @@
 				buf += '</div>';
 			} else {
 				buf += '<div class="col ivcol"><div><strong>DVs</strong></div>';
-				var ivs = set.ivs || this.getAutoIVs();
+				var ivs = set.ivs || getAutoIVs(set, this.curTeam.format);
 				for (var i in stats) {
 					var val = '' + Math.floor(ivs[i] / 2);
 					buf += '<div><input type="number" name="iv-' + i + '" value="' + BattleLog.escapeHTML(val) + '" class="textbox inputform numform" min="0" max="15" step="1" ' + (set.ivs ? '' : 'disabled') + ' /></div>';
@@ -2225,7 +2214,7 @@
 		},
 		updateIVs: function () {
 			var set = this.curSet;
-			if (!set.moves || this.canHyperTrain(set)) return;
+			if (!set.moves || canHyperTrain(set, this.curTeam.format)) return;
 			var hasHiddenPower = false;
 			for (var i = 0; i < set.moves.length; i++) {
 				if (toID(set.moves[i]).slice(0, 11) === 'hiddenpower') {
@@ -2237,7 +2226,7 @@
 			var hpTypes = ['Fighting', 'Flying', 'Poison', 'Ground', 'Rock', 'Bug', 'Ghost', 'Steel', 'Fire', 'Water', 'Grass', 'Electric', 'Psychic', 'Ice', 'Dragon', 'Dark'];
 			var hpType;
 			if (this.curTeam.gen <= 2) {
-				var ivs = set.ivs || this.getAutoIVs();
+				var ivs = set.ivs || getAutoIVs(set, this.curTeam.format);
 				var atkDV = Math.floor(ivs.atk / 2);
 				var defDV = Math.floor(ivs.def / 2);
 				hpType = hpTypes[4 * (atkDV % 4) + (defDV % 4)];
@@ -2259,7 +2248,7 @@
 			} else {
 				var hpTypeX = 0;
 				var i = 1;
-				var ivs = set.ivs || this.getAutoIVs();
+				var ivs = set.ivs || getAutoIVs(set, this.curTeam.format);
 				for (var s in ivs) {
 					hpTypeX += i * (ivs[s] % 2);
 					i *= 2;
@@ -2383,7 +2372,7 @@
 			if (newValue) {
 				// Reset the IVs to their defaults
 				set.ivs = null;
-				var autoIVs = this.getAutoIVs();
+				var autoIVs = getAutoIVs(set, this.curTeam.format);
 				for (var stat in autoIVs) {
 					var val = this.curTeam.gen > 2 ? autoIVs[stat] : Math.floor(autoIVs[stat] / 2);
 					var input = this.$chart.find('input[name=iv-' + stat + ']');
@@ -2397,7 +2386,7 @@
 				// We are still using the same IVs, but this causes them to become "hardcoded" instead
 				// of automatically inferred. For example, if the user adds Gyro Ball to the moveset afterwards,
 				// we will not adjust their speed. Also, we will include any non-31 IVs in the export.
-				if (!set.ivs) set.ivs = this.getAutoIVs();
+				if (!set.ivs) set.ivs = getAutoIVs(set, this.curTeam.format);
 
 				for (var stat in set.ivs) {
 					var input = this.$chart.find('input[name=iv-' + stat + ']');
@@ -2788,16 +2777,6 @@
 			}
 			this.save();
 		},
-		canHyperTrain: function (set) {
-			if (this.curTeam.gen < 7 || this.curTeam.format === 'gen7hiddentype') return false;
-			var format = this.curTeam.format;
-			if (!set.level || set.level === 100) return true;
-			if (format.substr(0, 3) === 'gen') format = format.substr(4);
-			if (format.substr(0, 10) === 'battlespot' || format.substr(0, 3) === 'vgc' || format === 'ultrasinnohclassic') {
-				if (set.level === 50) return true;
-			}
-			return false;
-		},
 		chooseMove: function (moveName) {
 			var set = this.curSet;
 			if (moveName === 'Return') {
@@ -2870,7 +2849,7 @@
 			if (!set.level) set.level = 100;
 
 			var baseStat = (this.getBaseStats(template))[stat];
-			var iv = set.ivs ? set.ivs[stat] : this.getAutoIV(stat, set);
+			var iv = set.ivs ? set.ivs[stat] : getAutoIV(stat, set, this.curTeam.format);
 			if (this.curTeam.gen <= 2) iv &= 30;
 			var ev = set.evs[stat];
 			if (evOverride !== undefined) ev = evOverride;
@@ -2898,88 +2877,6 @@
 			}
 			return Math.floor(val);
 		},
-
-		getAutoIVs: function (set) {
-			return {
-				hp: this.getAutoIV('hp', set),
-				atk: this.getAutoIV('atk', set),
-				def: this.getAutoIV('def', set),
-				spa: this.getAutoIV('spa', set),
-				spd: this.getAutoIV('spd', set),
-				spe: this.getAutoIV('spe', set)
-			};
-		},
-
-		getAutoIV: function (stat, set) {
-			if (!set) set = this.curSet;
-			var minValue = 0;
-			var maxValue = 31;
-			var useMaxValue = true;
-
-			var moves = set.moves;
-			var gen = this.curTeam.gen;
-			var hpType = this.getDesiredHPType(moves);
-			var canHyperTrain = this.canHyperTrain(set);
-
-			if (hpType) {
-				if (gen > 2) {
-					minValue = (exports.BattleTypeChart[hpType].HPivs[stat] || 31) % 2;
-					if (!canHyperTrain) {
-						// Must have matching parity for the correct Hidden Power type
-						maxValue = 30 + minValue;
-					}
-				} else if (stat === 'atk' || stat === 'def') { // Gen 2 only uses atk/def to calc HP type
-					minValue = ((exports.BattleTypeChart[hpType].HPdvs[stat] || 15) % 4) * 2; // Results in 0, 2, 4, or 6
-					maxValue = (minValue === 6 ? 31 : 24 + minValue);
-				}
-			}
-
-			if (stat === 'atk') {
-				if (gen > 2 && set.ability !== 'Battle Bond') { // Ash-Greninja is only available through an event with 31 Atk IVs
-					useMaxValue = false; // Default to 0 Atk IVs if we don't have a physical attacking move
-					for (var i = 0; i < moves.length; ++i) {
-						if (!moves[i]) continue;
-						var move = Dex.forGen(gen).getMove(moves[i]);
-						if (move.category === 'Physical' &&
-							!move.damage && !move.ohko && move.id !== 'rapidspin' && move.id !== 'foulplay' && move.id !== 'endeavor' && move.id !== 'counter') {
-							useMaxValue = true;
-							break;
-						} else if (move.id === 'metronome' || move.id === 'assist' || move.id === 'copycat' || move.id === 'mefirst') {
-							useMaxValue = true;
-							break;
-						}
-					}
-				}
-			} else if (stat === 'spe') {
-				for (var i = 0; i < moves.length; ++i) {
-					if (moves[i] === 'Gyro Ball') {
-						useMaxValue = false;
-						break;
-					}
-				}
-			}
-
-			return useMaxValue ? maxValue : minValue;
-		},
-
-		getDesiredHPType: function (moves) {
-			for (var i = 0; i < moves.length; ++i) {
-				if (moves[i] && moves[i].substr(0, 13) === 'Hidden Power ') {
-					return moves[i].substr(13);
-				}
-			}
-
-			return '';
-		},
-
-		// initialization
-
-		getGen: function (format) {
-			format = '' + format;
-			if (!format) return 7;
-			if (format.substr(0, 3) !== 'gen') return 6;
-			return parseInt(format.substr(3, 1), 10) || 6;
-		}
 	});
 
 	var MoveSetPopup = exports.MoveSetPopup = Popup.extend({

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -19,7 +19,7 @@
 		focus: function () {
 			if (this.curTeam) {
 				this.curTeam.iconCache = '!';
-				this.curTeam.gen = getGen(this.curTeam.format);
+				this.curTeam.gen = Storage.getGen(this.curTeam.format);
 				Storage.activeSetList = this.curSetList;
 			}
 		},
@@ -665,7 +665,7 @@
 			i = +i;
 			this.curTeam = teams[i];
 			this.curTeam.iconCache = '!';
-			this.curTeam.gen = getGen(this.curTeam.format);
+			this.curTeam.gen = Storage.getGen(this.curTeam.format);
 			Storage.activeSetList = this.curSetList = Storage.unpackTeam(this.curTeam.team);
 			this.curTeamIndex = i;
 			this.update();
@@ -1293,7 +1293,7 @@
 		},
 		changeFormat: function (format) {
 			this.curTeam.format = format;
-			this.curTeam.gen = getGen(this.curTeam.format);
+			this.curTeam.gen = Storage.getGen(this.curTeam.format);
 			this.save();
 			if (this.curTeam.gen === 5 && !Dex.loadedSpriteData['bw']) Dex.loadSpriteData('bw');
 			this.update();
@@ -1956,7 +1956,7 @@
 
 			if (this.curTeam.gen > 2) {
 				buf += '<div class="col ivcol"><div><strong>IVs</strong></div>';
-				var ivs = set.ivs || getAutoIVs(set, this.curTeam.format);
+				var ivs = set.ivs || Storage.getAutoIVs(set, this.curTeam.format);
 				for (var i in stats) {
 					var val = '' + (ivs[i]);
 					buf += '<div><input type="number" name="iv-' + i + '" value="' + BattleLog.escapeHTML(val) + '" class="textbox inputform numform" min="0" max="31" step="1" ' + (set.ivs ? '' : 'disabled') + ' /></div>';
@@ -1970,7 +1970,7 @@
 						}
 					}
 				}
-				if (hpType && !canHyperTrain(set, this.curTeam.format)) {
+				if (hpType && !Storage.canHyperTrain(set, this.curTeam.format)) {
 					var hpIVs;
 					switch (hpType) {
 					case 'dark':
@@ -2079,7 +2079,7 @@
 				buf += '</div>';
 			} else {
 				buf += '<div class="col ivcol"><div><strong>DVs</strong></div>';
-				var ivs = set.ivs || getAutoIVs(set, this.curTeam.format);
+				var ivs = set.ivs || Storage.getAutoIVs(set, this.curTeam.format);
 				for (var i in stats) {
 					var val = '' + Math.floor(ivs[i] / 2);
 					buf += '<div><input type="number" name="iv-' + i + '" value="' + BattleLog.escapeHTML(val) + '" class="textbox inputform numform" min="0" max="15" step="1" ' + (set.ivs ? '' : 'disabled') + ' /></div>';
@@ -2214,7 +2214,7 @@
 		},
 		updateIVs: function () {
 			var set = this.curSet;
-			if (!set.moves || canHyperTrain(set, this.curTeam.format)) return;
+			if (!set.moves || Storage.canHyperTrain(set, this.curTeam.format)) return;
 			var hasHiddenPower = false;
 			for (var i = 0; i < set.moves.length; i++) {
 				if (toID(set.moves[i]).slice(0, 11) === 'hiddenpower') {
@@ -2226,7 +2226,7 @@
 			var hpTypes = ['Fighting', 'Flying', 'Poison', 'Ground', 'Rock', 'Bug', 'Ghost', 'Steel', 'Fire', 'Water', 'Grass', 'Electric', 'Psychic', 'Ice', 'Dragon', 'Dark'];
 			var hpType;
 			if (this.curTeam.gen <= 2) {
-				var ivs = set.ivs || getAutoIVs(set, this.curTeam.format);
+				var ivs = set.ivs || Storage.getAutoIVs(set, this.curTeam.format);
 				var atkDV = Math.floor(ivs.atk / 2);
 				var defDV = Math.floor(ivs.def / 2);
 				hpType = hpTypes[4 * (atkDV % 4) + (defDV % 4)];
@@ -2248,7 +2248,7 @@
 			} else {
 				var hpTypeX = 0;
 				var i = 1;
-				var ivs = set.ivs || getAutoIVs(set, this.curTeam.format);
+				var ivs = set.ivs || Storage.getAutoIVs(set, this.curTeam.format);
 				for (var s in ivs) {
 					hpTypeX += i * (ivs[s] % 2);
 					i *= 2;
@@ -2372,7 +2372,7 @@
 			if (newValue) {
 				// Reset the IVs to their defaults
 				set.ivs = null;
-				var autoIVs = getAutoIVs(set, this.curTeam.format);
+				var autoIVs = Storage.getAutoIVs(set, this.curTeam.format);
 				for (var stat in autoIVs) {
 					var val = this.curTeam.gen > 2 ? autoIVs[stat] : Math.floor(autoIVs[stat] / 2);
 					var input = this.$chart.find('input[name=iv-' + stat + ']');
@@ -2386,7 +2386,7 @@
 				// We are still using the same IVs, but this causes them to become "hardcoded" instead
 				// of automatically inferred. For example, if the user adds Gyro Ball to the moveset afterwards,
 				// we will not adjust their speed. Also, we will include any non-31 IVs in the export.
-				if (!set.ivs) set.ivs = getAutoIVs(set, this.curTeam.format);
+				if (!set.ivs) set.ivs = Storage.getAutoIVs(set, this.curTeam.format);
 
 				for (var stat in set.ivs) {
 					var input = this.$chart.find('input[name=iv-' + stat + ']');
@@ -2849,7 +2849,7 @@
 			if (!set.level) set.level = 100;
 
 			var baseStat = (this.getBaseStats(template))[stat];
-			var iv = set.ivs ? set.ivs[stat] : getAutoIV(stat, set, this.curTeam.format);
+			var iv = set.ivs ? set.ivs[stat] : Storage.getAutoIV(stat, set, this.curTeam.format);
 			if (this.curTeam.gen <= 2) iv &= 30;
 			var ev = set.evs[stat];
 			if (evOverride !== undefined) ev = evOverride;

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2864,56 +2864,56 @@
 			if (!set) set = this.curSet;
 			if (set.ivs[stat] !== undefined) return set.ivs[stat];
 
-			var iv = 31;
+			var minValue = 0;
+			var maxValue = 31;
+			var useMaxValue = true;
 
 			var moves = set.moves;
 			var gen = this.curTeam.gen;
 			var hpType = this.getHPTypeFromMoves(moves);
-			if (hpType && !this.canHyperTrain(set)) {
+			var canHyperTrain = this.canHyperTrain(set);
+
+			if (hpType) {
 				if (gen > 2) {
-					iv = exports.BattleTypeChart[hpType].HPivs[stat];
+					minValue = (exports.BattleTypeChart[hpType].HPivs[stat] || 31) % 2;
 				} else {
-					iv = exports.BattleTypeChart[hpType].HPdvs[stat] * 2;
+					// TODO: Old gens
 				}
 			}
 
+			// TODO: Old gens
+			if (hpType && !canHyperTrain) {
+				maxValue = 30 + minValue;
+			}
+
 			if (stat === 'hp') {
-				// TODO: Gen 1/2 stuff
+				// TODO: Old gens
 			} else if (stat === 'atk') {
 				if (gen > 2) {
-					var minAtk = true;
+					useMaxValue = false; // Default to 0 Atk IVs if we don't have a physical attacking move
 					for (var i = 0; i < moves.length; ++i) {
 						if (!moves[i]) continue;
 						var move = Dex.forGen(gen).getMove(moves[i]);
 						if (move.category === 'Physical' &&
 							!move.damage && !move.ohko && move.id !== 'rapidspin' && move.id !== 'foulplay' && move.id !== 'endeavor' && move.id !== 'counter') {
-							minAtk = false;
+							useMaxValue = true;
 							break;
 						} else if (move.id === 'metronome' || move.id === 'assist' || move.id === 'copycat' || move.id === 'mefirst') {
-							minAtk = false;
+							useMaxValue = true;
 							break;
 						}
 					}
-
-					if (minAtk) {
-						iv = (hpType ? iv % 2 : 0);
-					}
 				}
 			} else if (stat === 'spe') {
-				var minSpe = false;
 				for (var i = 0; i < moves.length; ++i) {
 					if (moves[i] === 'Gyro Ball') {
-						minSpe = true;
+						useMaxValue = false;
 						break;
 					}
 				}
-
-				if (minSpe) {
-					iv = (hpType ? iv % 2 : 0);
-				}
 			}
 
-			return iv;
+			return useMaxValue ? maxValue : minValue;
 		},
 
 		getHPTypeFromMoves: function (moves) {

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -1222,7 +1222,7 @@
 					item: '',
 					nature: '',
 					evs: {},
-					ivs: {},
+					ivs: null,
 					moves: []
 				};
 				team.push(newPokemon);

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -19,7 +19,7 @@
 		focus: function () {
 			if (this.curTeam) {
 				this.curTeam.iconCache = '!';
-				this.curTeam.gen = getGen(this.curTeam.format);
+				this.curTeam.gen = this.getGen(this.curTeam.format);
 				Storage.activeSetList = this.curSetList;
 			}
 		},
@@ -665,7 +665,7 @@
 			i = +i;
 			this.curTeam = teams[i];
 			this.curTeam.iconCache = '!';
-			this.curTeam.gen = getGen(this.curTeam.format);
+			this.curTeam.gen = this.getGen(this.curTeam.format);
 			Storage.activeSetList = this.curSetList = Storage.unpackTeam(this.curTeam.team);
 			this.curTeamIndex = i;
 			this.update();
@@ -817,7 +817,7 @@
 				// Chrome is dumb and doesn't support data URLs in HTTPS
 				urlprefix = "https://play.pokemonshowdown.com/action.php?act=dlteam&team=";
 			}
-			var contents = Storage.exportTeam(team.team, team.format).replace(/\n/g, '\r\n');
+			var contents = Storage.exportTeam(team.team).replace(/\n/g, '\r\n');
 			var downloadurl = "text/plain:" + filename + ":" + urlprefix + encodeURIComponent(window.btoa(unescape(encodeURIComponent(contents))));
 			console.log(downloadurl);
 			dataTransfer.setData("DownloadURL", downloadurl);
@@ -1053,7 +1053,7 @@
 			var buf = '';
 			if (this.exportMode) {
 				buf = '<div class="pad"><button name="back"><i class="fa fa-chevron-left"></i> List</button> <input class="textbox teamnameedit" type="text" class="teamnameedit" size="30" value="' + BattleLog.escapeHTML(this.curTeam.name) + '" /> <button name="saveImport"><i class="fa fa-upload"></i> Import/Export</button> <button name="saveImport" class="savebutton"><i class="fa fa-floppy-o"></i> Save</button></div>';
-				buf += '<div class="teamedit"><textarea class="textbox" rows="17">' + BattleLog.escapeHTML(Storage.exportTeam(this.curSetList, this.curTeam.format)) + '</textarea></div>';
+				buf += '<div class="teamedit"><textarea class="textbox" rows="17">' + BattleLog.escapeHTML(Storage.exportTeam(this.curSetList)) + '</textarea></div>';
 			} else {
 				buf = '<div class="pad"><button name="back"><i class="fa fa-chevron-left"></i> List</button> <input class="textbox teamnameedit" type="text" class="teamnameedit" size="30" value="' + BattleLog.escapeHTML(this.curTeam.name) + '" /> <button name="import"><i class="fa fa-upload"></i> Import/Export</button></div>';
 				buf += '<div class="teamchartbox">';
@@ -1293,7 +1293,7 @@
 		},
 		changeFormat: function (format) {
 			this.curTeam.format = format;
-			this.curTeam.gen = getGen(this.curTeam.format);
+			this.curTeam.gen = this.getGen(this.curTeam.format);
 			this.save();
 			if (this.curTeam.gen === 5 && !Dex.loadedSpriteData['bw']) Dex.loadSpriteData('bw');
 			this.update();
@@ -1447,7 +1447,7 @@
 			this.$('.teambuilder-pokemon-import')
 				.show()
 				.find('textarea')
-				.val(Storage.exportTeam([this.curSet], this.curTeam.format).trim())
+				.val(Storage.exportTeam([this.curSet]).trim())
 				.focus()
 				.select();
 		},
@@ -1956,7 +1956,7 @@
 
 			if (this.curTeam.gen > 2) {
 				buf += '<div class="col ivcol"><div><strong>IVs</strong></div>';
-				var ivs = set.ivs || getAutoIVs(set, this.curTeam.format);
+				var ivs = set.ivs || this.getAutoIVs();
 				for (var i in stats) {
 					var val = '' + (ivs[i]);
 					buf += '<div><input type="number" name="iv-' + i + '" value="' + BattleLog.escapeHTML(val) + '" class="textbox inputform numform" min="0" max="31" step="1" ' + (set.ivs ? '' : 'disabled') + ' /></div>';
@@ -1970,7 +1970,7 @@
 						}
 					}
 				}
-				if (hpType && !canHyperTrain(set, this.curTeam.format)) {
+				if (hpType && !this.canHyperTrain(set)) {
 					var hpIVs;
 					switch (hpType) {
 					case 'dark':
@@ -2079,7 +2079,7 @@
 				buf += '</div>';
 			} else {
 				buf += '<div class="col ivcol"><div><strong>DVs</strong></div>';
-				var ivs = set.ivs || getAutoIVs(set, this.curTeam.format);
+				var ivs = set.ivs || this.getAutoIVs();
 				for (var i in stats) {
 					var val = '' + Math.floor(ivs[i] / 2);
 					buf += '<div><input type="number" name="iv-' + i + '" value="' + BattleLog.escapeHTML(val) + '" class="textbox inputform numform" min="0" max="15" step="1" ' + (set.ivs ? '' : 'disabled') + ' /></div>';
@@ -2214,7 +2214,7 @@
 		},
 		updateIVs: function () {
 			var set = this.curSet;
-			if (!set.moves || canHyperTrain(set, this.curTeam.format)) return;
+			if (!set.moves || this.canHyperTrain(set)) return;
 			var hasHiddenPower = false;
 			for (var i = 0; i < set.moves.length; i++) {
 				if (toID(set.moves[i]).slice(0, 11) === 'hiddenpower') {
@@ -2226,7 +2226,7 @@
 			var hpTypes = ['Fighting', 'Flying', 'Poison', 'Ground', 'Rock', 'Bug', 'Ghost', 'Steel', 'Fire', 'Water', 'Grass', 'Electric', 'Psychic', 'Ice', 'Dragon', 'Dark'];
 			var hpType;
 			if (this.curTeam.gen <= 2) {
-				var ivs = set.ivs || getAutoIVs(set, this.curTeam.format);
+				var ivs = set.ivs || this.getAutoIVs();
 				var atkDV = Math.floor(ivs.atk / 2);
 				var defDV = Math.floor(ivs.def / 2);
 				hpType = hpTypes[4 * (atkDV % 4) + (defDV % 4)];
@@ -2248,7 +2248,7 @@
 			} else {
 				var hpTypeX = 0;
 				var i = 1;
-				var ivs = set.ivs || getAutoIVs(set, this.curTeam.format);
+				var ivs = set.ivs || this.getAutoIVs();
 				for (var s in ivs) {
 					hpTypeX += i * (ivs[s] % 2);
 					i *= 2;
@@ -2372,7 +2372,7 @@
 			if (newValue) {
 				// Reset the IVs to their defaults
 				set.ivs = null;
-				var autoIVs = getAutoIVs(set, this.curTeam.format);
+				var autoIVs = this.getAutoIVs();
 				for (var stat in autoIVs) {
 					var val = this.curTeam.gen > 2 ? autoIVs[stat] : Math.floor(autoIVs[stat] / 2);
 					var input = this.$chart.find('input[name=iv-' + stat + ']');
@@ -2386,7 +2386,7 @@
 				// We are still using the same IVs, but this causes them to become "hardcoded" instead
 				// of automatically inferred. For example, if the user adds Gyro Ball to the moveset afterwards,
 				// we will not adjust their speed. Also, we will include any non-31 IVs in the export.
-				if (!set.ivs) set.ivs = getAutoIVs(set, this.curTeam.format);
+				if (!set.ivs) set.ivs = this.getAutoIVs();
 
 				for (var stat in set.ivs) {
 					var input = this.$chart.find('input[name=iv-' + stat + ']');
@@ -2777,6 +2777,16 @@
 			}
 			this.save();
 		},
+		canHyperTrain: function (set) {
+			if (this.curTeam.gen < 7 || this.curTeam.format === 'gen7hiddentype') return false;
+			var format = this.curTeam.format;
+			if (!set.level || set.level === 100) return true;
+			if (format.substr(0, 3) === 'gen') format = format.substr(4);
+			if (format.substr(0, 10) === 'battlespot' || format.substr(0, 3) === 'vgc' || format === 'ultrasinnohclassic') {
+				if (set.level === 50) return true;
+			}
+			return false;
+		},
 		chooseMove: function (moveName) {
 			var set = this.curSet;
 			if (moveName === 'Return') {
@@ -2849,7 +2859,7 @@
 			if (!set.level) set.level = 100;
 
 			var baseStat = (this.getBaseStats(template))[stat];
-			var iv = set.ivs ? set.ivs[stat] : getAutoIV(stat, set, this.curTeam.format);
+			var iv = set.ivs ? set.ivs[stat] : this.getAutoIV(stat, set);
 			if (this.curTeam.gen <= 2) iv &= 30;
 			var ev = set.evs[stat];
 			if (evOverride !== undefined) ev = evOverride;
@@ -2877,6 +2887,88 @@
 			}
 			return Math.floor(val);
 		},
+
+		getAutoIVs: function (set) {
+			return {
+				hp: this.getAutoIV('hp', set),
+				atk: this.getAutoIV('atk', set),
+				def: this.getAutoIV('def', set),
+				spa: this.getAutoIV('spa', set),
+				spd: this.getAutoIV('spd', set),
+				spe: this.getAutoIV('spe', set)
+			};
+		},
+
+		getAutoIV: function (stat, set) {
+			if (!set) set = this.curSet;
+			var minValue = 0;
+			var maxValue = 31;
+			var useMaxValue = true;
+
+			var moves = set.moves;
+			var gen = this.curTeam.gen;
+			var hpType = this.getDesiredHPType(moves);
+			var canHyperTrain = this.canHyperTrain(set);
+
+			if (hpType) {
+				if (gen > 2) {
+					minValue = (exports.BattleTypeChart[hpType].HPivs[stat] || 31) % 2;
+					if (!canHyperTrain) {
+						// Must have matching parity for the correct Hidden Power type
+						maxValue = 30 + minValue;
+					}
+				} else if (stat === 'atk' || stat === 'def') { // Gen 2 only uses atk/def to calc HP type
+					minValue = ((exports.BattleTypeChart[hpType].HPdvs[stat] || 15) % 4) * 2; // Results in 0, 2, 4, or 6
+					maxValue = (minValue === 6 ? 31 : 24 + minValue);
+				}
+			}
+
+			if (stat === 'atk') {
+				if (gen > 2 && set.ability !== 'Battle Bond') { // Ash-Greninja is only available through an event with 31 Atk IVs
+					useMaxValue = false; // Default to 0 Atk IVs if we don't have a physical attacking move
+					for (var i = 0; i < moves.length; ++i) {
+						if (!moves[i]) continue;
+						var move = Dex.forGen(gen).getMove(moves[i]);
+						if (move.category === 'Physical' &&
+							!move.damage && !move.ohko && move.id !== 'rapidspin' && move.id !== 'foulplay' && move.id !== 'endeavor' && move.id !== 'counter') {
+							useMaxValue = true;
+							break;
+						} else if (move.id === 'metronome' || move.id === 'assist' || move.id === 'copycat' || move.id === 'mefirst') {
+							useMaxValue = true;
+							break;
+						}
+					}
+				}
+			} else if (stat === 'spe') {
+				for (var i = 0; i < moves.length; ++i) {
+					if (moves[i] === 'Gyro Ball') {
+						useMaxValue = false;
+						break;
+					}
+				}
+			}
+
+			return useMaxValue ? maxValue : minValue;
+		},
+
+		getDesiredHPType: function (moves) {
+			for (var i = 0; i < moves.length; ++i) {
+				if (moves[i] && moves[i].substr(0, 13) === 'Hidden Power ') {
+					return moves[i].substr(13);
+				}
+			}
+
+			return '';
+		},
+
+		// initialization
+
+		getGen: function (format) {
+			format = '' + format;
+			if (!format) return 7;
+			if (format.substr(0, 3) !== 'gen') return 6;
+			return parseInt(format.substr(3, 1), 10) || 6;
+		}
 	});
 
 	var MoveSetPopup = exports.MoveSetPopup = Popup.extend({

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -1956,10 +1956,11 @@
 
 			if (this.curTeam.gen > 2) {
 				buf += '<div class="col ivcol"><div><strong>IVs</strong></div>';
-				if (!set.ivs) set.ivs = {};
+				var displayIvs = Object.assign({}, set.ivs);
 				for (var i in stats) {
-					if (set.ivs[i] === undefined || isNaN(set.ivs[i])) set.ivs[i] = 31;
-					var val = '' + (set.ivs[i]);
+					// TODO: 31 may not always be the appropriate IV
+					if (displayIvs[i] === undefined || isNaN(displayIvs[i])) displayIvs[i] = 31;
+					var val = '' + (displayIvs[i]);
 					buf += '<div><input type="number" name="iv-' + i + '" value="' + BattleLog.escapeHTML(val) + '" class="textbox inputform numform" min="0" max="31" step="1" /></div>';
 				}
 				var hpType = '';
@@ -2080,10 +2081,11 @@
 				buf += '</div>';
 			} else {
 				buf += '<div class="col ivcol"><div><strong>DVs</strong></div>';
-				if (!set.ivs) set.ivs = {};
+				var displayIvs = Object.assign({}, set.ivs);
 				for (var i in stats) {
-					if (set.ivs[i] === undefined || isNaN(set.ivs[i])) set.ivs[i] = 31;
-					var val = '' + Math.floor(set.ivs[i] / 2);
+					// TODO: 31 may not always be the appropriate IV
+					if (displayIvs[i] === undefined || isNaN(displayIvs[i])) displayIvs[i] = 31;
+					var val = '' + Math.floor(displayIvs[i] / 2);
 					buf += '<div><input type="number" name="iv-' + i + '" value="' + BattleLog.escapeHTML(val) + '" class="textbox inputform numform" min="0" max="15" step="1" /></div>';
 				}
 				buf += '</div>';
@@ -2198,7 +2200,6 @@
 				if (val > 31 || isNaN(val)) val = 31;
 				if (val < 0) val = 0;
 
-				if (!set.ivs) set.ivs = {};
 				if (set.ivs[stat] !== val) {
 					set.ivs[stat] = val;
 					this.updateIVs();
@@ -2221,6 +2222,7 @@
 			var hpTypes = ['Fighting', 'Flying', 'Poison', 'Ground', 'Rock', 'Bug', 'Ghost', 'Steel', 'Fire', 'Water', 'Grass', 'Electric', 'Psychic', 'Ice', 'Dragon', 'Dark'];
 			var hpType;
 			if (this.curTeam.gen <= 2) {
+				// TODO
 				var hpDV = Math.floor(set.ivs.hp / 2);
 				var atkDV = Math.floor(set.ivs.atk / 2);
 				var defDV = Math.floor(set.ivs.def / 2);
@@ -2238,6 +2240,7 @@
 				var i = 1;
 				var stats = {hp: 31, atk: 31, def: 31, spe: 31, spa: 31, spd: 31};
 				for (var s in stats) {
+					// TODO
 					if (set.ivs[s] === undefined) set.ivs[s] = 31;
 					hpTypeX += i * (set.ivs[s] % 2);
 					i *= 2;
@@ -2340,13 +2343,13 @@
 			if (!set) return;
 
 			var spread = e.currentTarget.value.split('/');
-			if (!set.ivs) set.ivs = {};
 			if (spread.length !== 6) return;
 
 			var stats = ['hp', 'atk', 'def', 'spa', 'spd', 'spe'];
 			for (var i = 0; i < 6; i++) {
 				this.$chart.find('input[name=iv-' + stats[i] + ']').val(spread[i]);
-				set.ivs[stats[i]] = parseInt(spread[i], 10);
+				var iv = parseInt(spread[i], 10);
+				if (iv !== 31) set.ivs[stats[i]] = iv;
 			}
 			$(e.currentTarget).val('');
 
@@ -2750,21 +2753,8 @@
 			this.save();
 		},
 		unChooseMove: function (moveName) {
-			var set = this.curSet;
-			if (!moveName || !set || this.curTeam.format === 'gen7hiddentype') return;
-			if (moveName.substr(0, 13) === 'Hidden Power ') {
-				if (set.ivs) {
-					for (var i in set.ivs) {
-						if (set.ivs[i] === 30) set.ivs[i] = 31;
-						if (set.ivs[i] <= 3) set.ivs[i] = 0;
-					}
-				}
-			}
-			var resetSpeed = false;
-			if (moveName === 'Gyro Ball') {
-				resetSpeed = true;
-			}
-			this.chooseMove('', resetSpeed);
+			// Before we were undoing any IV changes we made in the process of choosing Hidden Power / Gyro Ball, however now, we don't make any such changes.
+			// So now, we don't have to do anything here.
 		},
 		canHyperTrain: function (set) {
 			if (this.curTeam.gen < 7 || this.curTeam.format === 'gen7hiddentype') return false;
@@ -2787,6 +2777,7 @@
 				if (!this.canHyperTrain(set)) {
 					var hpType = moveName.substr(13);
 
+					// TODO: IV-changing logic should be decided lazily
 					set.ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
 					if (this.curTeam.gen > 2) {
 						for (var i in exports.BattleTypeChart[hpType].HPivs) {
@@ -2835,6 +2826,7 @@
 				}
 			}
 
+			// TODO: IV-changing logic should be decided lazily
 			if (!set.ivs) {
 				if (minSpe === undefined && (!minAtk || gen < 3)) return;
 				set.ivs = {};
@@ -2912,14 +2904,6 @@
 			if (!set) set = this.curSet;
 			if (!set) return 0;
 
-			if (!set.ivs) set.ivs = {
-				hp: 31,
-				atk: 31,
-				def: 31,
-				spa: 31,
-				spd: 31,
-				spe: 31
-			};
 			if (!set.evs) set.evs = {};
 
 			// do this after setting set.evs because it's assumed to exist
@@ -2928,10 +2912,12 @@
 			if (!template.exists) return 0;
 
 			if (!set.level) set.level = 100;
-			if (typeof set.ivs[stat] === 'undefined') set.ivs[stat] = 31;
+			// TODO
+			if (set.ivs[stat] === undefined) set.ivs[stat] = 31;
 
 			var baseStat = (this.getBaseStats(template))[stat];
-			var iv = (set.ivs[stat] || 0);
+			// TODO
+			var iv = set.ivs[stat];
 			if (this.curTeam.gen <= 2) iv &= 30;
 			var ev = set.evs[stat];
 			if (evOverride !== undefined) ev = evOverride;

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2229,16 +2229,16 @@
 				var defDV = Math.floor(ivs.def / 2);
 				hpType = hpTypes[4 * (atkDV % 4) + (defDV % 4)];
 
-				// If the user opts for manual DVs then verify that the HP DV is correct according to the other DVs
+				// If the user opts for manual DVs, then verify that the HP DV is correct according to the other DVs.
 				// XXX: This behavior should be enabled even when the moveset does not have Hidden Power
-				if (set.ivs) {
-					var speDV = Math.floor(set.ivs.spe / 2);
-					var spcDV = Math.floor(set.ivs.spa / 2);
+				if (ivs === set.ivs) {
+					var speDV = Math.floor(ivs.spe / 2);
+					var spcDV = Math.floor(ivs.spa / 2);
 
 					var expectedHpDV = (atkDV % 2) * 8 + (defDV % 2) * 4 + (speDV % 2) * 2 + (spcDV % 2);
 					if (expectedHpDV !== hpDV) {
-						set.ivs.hp = expectedHpDV * 2;
-						if (set.ivs.hp === 30) set.ivs.hp = 31;
+						ivs.hp = expectedHpDV * 2;
+						if (ivs.hp === 30) ivs.hp = 31;
 						this.$chart.find('input[name=iv-hp]').val(expectedHpDV);
 					}
 				}
@@ -2353,8 +2353,7 @@
 			if (!set.ivs) set.ivs = {};
 			var stats = ['hp', 'atk', 'def', 'spa', 'spd', 'spe'];
 			for (var i = 0; i < 6; i++) {
-				var iv = parseInt(spread[i], 10);
-				set.ivs[stats[i]] = iv;
+				set.ivs[stats[i]] = parseInt(spread[i], 10);
 				this.$chart.find('input[name=iv-' + stats[i] + ']').val(spread[i]);
 			}
 			$(e.currentTarget).val('');

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2232,6 +2232,7 @@
 				// If the user opts for manual DVs, then verify that the HP DV is correct according to the other DVs.
 				// XXX: This behavior should be enabled even when the moveset does not have Hidden Power
 				if (ivs === set.ivs) {
+					var hpDV = Math.floor(ivs.hp / 2);
 					var speDV = Math.floor(ivs.spe / 2);
 					var spcDV = Math.floor(ivs.spa / 2);
 

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2201,7 +2201,7 @@
 
 				var changed = !set.ivs || set.ivs[stat] !== val;
 				if (changed) {
-					if (!set.ivs) set.ivs = {};
+					if (!set.ivs) set.ivs = this.getAutoIVs();
 					set.ivs[stat] = val;
 					this.updateIVs();
 					this.updateStatGraph();
@@ -2246,8 +2246,8 @@
 				var hpTypeX = 0;
 				var i = 1;
 				var ivs = set.ivs || this.getAutoIVs();
-				for (var s in stats) {
-					hpTypeX += i * (set.ivs[s] % 2);
+				for (var s in ivs) {
+					hpTypeX += i * (ivs[s] % 2);
 					i *= 2;
 				}
 				hpType = hpTypes[Math.floor(hpTypeX * 15 / 63)];
@@ -2365,8 +2365,7 @@
 		},
 		useAutoIVsClick: function (e) {
 			var set = this.curSet;
-			var oldValue = e.currentTarget.checked;
-			var newValue = !oldValue;
+			var newValue = e.currentTarget.checked;
 			if (newValue) {
 				// Reset the IVs to their defaults
 				set.ivs = null;
@@ -2716,7 +2715,7 @@
 				set.ability = 'Harvest';
 				set.moves = ['Substitute', 'Horn Leech', 'Earthquake', 'Phantom Force'];
 				set.evs = {hp: 36, atk: 252, def: 0, spa: 0, spd: 0, spe: 220};
-				set.ivs = {};
+				set.ivs = null;
 				set.nature = 'Jolly';
 				this.updateSetTop();
 				this.$(!this.$('input[name=item]').length ? (this.$('input[name=ability]').length ? 'input[name=ability]' : 'input[name=move1]') : 'input[name=item]').select();
@@ -2828,7 +2827,7 @@
 
 			set.moves = [];
 			set.evs = {};
-			set.ivs = {};
+			set.ivs = null;
 			set.nature = '';
 			this.updateSetTop();
 			if (selectNext) this.$(set.item || !this.$('input[name=item]').length ? (this.$('input[name=ability]').length ? 'input[name=ability]' : 'input[name=move1]') : 'input[name=item]').select();

--- a/js/storage.js
+++ b/js/storage.js
@@ -1,3 +1,97 @@
+// TODO: Move these helper fns elsewhere
+
+function getGen(format) {
+	format = '' + format;
+	if (!format) return 7;
+	if (format.substr(0, 3) !== 'gen') return 6;
+	return parseInt(format.substr(3, 1), 10) || 6;
+}
+
+function canHyperTrain(set, format) {
+	var gen = getGen(format);
+	if (gen < 7 || format === 'gen7hiddentype') return false;
+	if (!set.level || set.level === 100) return true;
+	if (format.substr(0, 3) === 'gen') format = format.substr(4);
+	if (format.substr(0, 10) === 'battlespot' || format.substr(0, 3) === 'vgc' || format === 'ultrasinnohclassic') {
+		if (set.level === 50) return true;
+	}
+	return false;
+}
+
+function getDesiredHPType(moves) {
+	for (var i = 0; i < moves.length; ++i) {
+		if (moves[i] && moves[i].substr(0, 13) === 'Hidden Power ') {
+			return moves[i].substr(13);
+		}
+	}
+	return '';
+}
+
+function getAutoIVs(set, format) {
+	return {
+		hp: getAutoIV('hp', set, format),
+		atk: getAutoIV('atk', set, format),
+		def: getAutoIV('def', set, format),
+		spa: getAutoIV('spa', set, format),
+		spd: getAutoIV('spd', set, format),
+		spe: getAutoIV('spe', set, format)
+	};
+}
+
+function getAutoIV(stat, set, format) {
+	if (!format) format = 'gen7';
+	var minValue = 0;
+	var maxValue = 31;
+	var useMaxValue = true;
+
+	var moves = set.moves;
+	var gen = getGen(format);
+	var hpType = getDesiredHPType(moves);
+	var _canHyperTrain = canHyperTrain(set, format);
+
+	if (hpType && window.BattleTypeChart) {
+		if (gen > 2) {
+			minValue = (window.BattleTypeChart[hpType].HPivs[stat] || 31) % 2;
+			if (!_canHyperTrain) {
+				// Must have matching parity for the correct Hidden Power type
+				maxValue = 30 + minValue;
+			}
+		} else if (stat === 'atk' || stat === 'def') { // Gen 2 only uses atk/def to calc HP type
+			minValue = ((window.BattleTypeChart[hpType].HPdvs[stat] || 15) % 4) * 2; // Results in 0, 2, 4, or 6
+			maxValue = (minValue === 6 ? 31 : 24 + minValue);
+		}
+	}
+
+	if (stat === 'atk') {
+		if (gen > 2 && set.ability !== 'Battle Bond') { // Ash-Greninja is only available through an event with 31 Atk IVs
+			useMaxValue = false; // Default to 0 Atk IVs if we don't have a physical attacking move
+			for (var i = 0; i < moves.length; ++i) {
+				if (!moves[i]) continue;
+				var move = Dex.forGen(gen).getMove(moves[i]);
+				if (move.category === 'Physical' &&
+					!move.damage && !move.ohko && move.id !== 'rapidspin' && move.id !== 'foulplay' && move.id !== 'endeavor' && move.id !== 'counter') {
+					useMaxValue = true;
+					break;
+				} else if (move.id === 'metronome' || move.id === 'assist' || move.id === 'copycat' || move.id === 'mefirst') {
+					useMaxValue = true;
+					break;
+				}
+			}
+		}
+	} else if (stat === 'spe') {
+		for (var i = 0; i < moves.length; ++i) {
+			if (moves[i] === 'Gyro Ball') {
+				useMaxValue = false;
+				break;
+			}
+		}
+	}
+
+	return useMaxValue ? maxValue : minValue;
+}
+
+// END TODO
+
 Config.origindomain = 'play.pokemonshowdown.com';
 // `defaultserver` specifies the server to use when the domain name in the
 // address bar is `Config.origindomain`.
@@ -1213,7 +1307,7 @@ Storage.exportAllTeams = function () {
 	for (var i = 0, len = Storage.teams.length; i < len; i++) {
 		var team = Storage.teams[i];
 		buf += '=== ' + (team.format ? '[' + team.format + '] ' : '') + (team.folder ? '' + team.folder + '/' : '') + team.name + ' ===\n\n';
-		buf += Storage.exportTeam(team.team);
+		buf += Storage.exportTeam(team.team, team.format);
 		buf += '\n';
 	}
 	return buf;
@@ -1224,13 +1318,13 @@ Storage.exportFolder = function (folder) {
 		var team = Storage.teams[i];
 		if (team.folder + "/" === folder || team.format === folder) {
 			buf += '=== ' + (team.format ? '[' + team.format + '] ' : '') + (team.folder ? '' + team.folder + '/' : '') + team.name + ' ===\n\n';
-			buf += Storage.exportTeam(team.team);
+			buf += Storage.exportTeam(team.team, team.format);
 			buf += '\n';
 		}
 	}
 	return buf;
 };
-Storage.exportTeam = function (team) {
+Storage.exportTeam = function (team, format) {
 	if (!team) return "";
 	if (typeof team === 'string') {
 		if (team.indexOf('\n') >= 0) return team;
@@ -1302,9 +1396,8 @@ Storage.exportTeam = function (team) {
 				text += '31 all';
 			}
 			text += '  \n';
-		} else if (curSet.autoIVs) { // Automatic IVs
-			ivs = curSet.autoIVs;
-
+		} else { // Automatic IVs
+			ivs = getAutoIVs(curSet, format);
 			for (var j in BattleStatNames) {
 				var val = ivs[j];
 				if (val === 31) continue;
@@ -1589,7 +1682,7 @@ Storage.nwSaveTeam = function (team) {
 		this.nwDeleteTeam(team);
 	}
 	team.filename = filename;
-	fs.writeFile(this.dir + 'Teams/' + filename, Storage.exportTeam(team.team).replace(/\n/g, '\r\n'), function () {});
+	fs.writeFile(this.dir + 'Teams/' + filename, Storage.exportTeam(team.team, team.format).replace(/\n/g, '\r\n'), function () {});
 };
 
 Storage.nwSaveTeams = function () {
@@ -1625,7 +1718,7 @@ Storage.nwDoSaveAllTeams = function () {
 		filename = $.trim(filename).replace(/[\\\/]+/g, '');
 
 		team.filename = filename;
-		fs.writeFile(this.dir + 'Teams/' + filename, Storage.exportTeam(team.team).replace(/\n/g, '\r\n'), function () {});
+		fs.writeFile(this.dir + 'Teams/' + filename, Storage.exportTeam(team.team, team.format).replace(/\n/g, '\r\n'), function () {});
 	}
 };
 

--- a/js/storage.js
+++ b/js/storage.js
@@ -1369,13 +1369,13 @@ Storage.canHyperTrain = function (set, format) {
 	return false;
 };
 
-Storage.getDesiredHPType = function (moves) {
+Storage.inferHPType = function (moves) {
 	for (var i = 0; i < moves.length; ++i) {
 		if (moves[i] && moves[i].substr(0, 13) === 'Hidden Power ') {
 			return moves[i].substr(13);
 		}
 	}
-	return '';
+	return null;
 };
 
 Storage.getAutoIVs = function (set, format) {
@@ -1397,7 +1397,7 @@ Storage.getAutoIV = function (stat, set, format) {
 
 	var moves = set.moves;
 	var gen = Storage.getGen(format);
-	var hpType = Storage.getDesiredHPType(moves);
+	var hpType = set.hpType || Storage.inferHPType(moves);
 	var _canHyperTrain = Storage.canHyperTrain(set, format);
 
 	if (hpType && window.BattleTypeChart) {

--- a/js/storage.js
+++ b/js/storage.js
@@ -850,6 +850,8 @@ Storage.fastUnpackTeam = function (buf) {
 				spd: ivs[4] === '' ? 31 : Number(ivs[4]),
 				spe: ivs[5] === '' ? 31 : Number(ivs[5])
 			};
+		} else {
+			set.ivs = {};
 		}
 		i = j + 1;
 
@@ -1183,8 +1185,8 @@ Storage.importTeam = function (buffer, teams) {
 				var statval = parseInt(ivLine.substr(0, spaceIndex), 10);
 				if (!statid) continue;
 				if (isNaN(statval)) statval = 31;
-				// NOTE: We intentionally do not check for 31 here, so if "31 HP" is explicitly given
-				// that will be reflected if this Pokemon is exported later
+				// We intentionally do not check for 31 here. If "31 HP" is explicitly specified,
+				// that will be reflected if the user tries to export the Pokemon later.
 				curSet.ivs[statid] = statval;
 			}
 		} else if (line.match(/^[A-Za-z]+ (N|n)ature/)) {

--- a/js/storage.js
+++ b/js/storage.js
@@ -840,15 +840,16 @@ Storage.fastUnpackTeam = function (buf) {
 
 		// ivs
 		j = buf.indexOf('|', i);
-		set.ivs = {};
 		if (j !== i) {
 			var ivs = buf.substring(i, j).split(',');
-			if (ivs[0] !== '') set.ivs.hp = Number(ivs[0]);
-			if (ivs[1] !== '') set.ivs.atk = Number(ivs[1]);
-			if (ivs[2] !== '') set.ivs.def = Number(ivs[2]);
-			if (ivs[3] !== '') set.ivs.spa = Number(ivs[3]);
-			if (ivs[4] !== '') set.ivs.spd = Number(ivs[4]);
-			if (ivs[5] !== '') set.ivs.spe = Number(ivs[5]);
+			set.ivs = {
+				hp: ivs[0] === '' ? 31 : Number(ivs[0]),
+				atk: ivs[1] === '' ? 31 : Number(ivs[1]),
+				def: ivs[2] === '' ? 31 : Number(ivs[2]),
+				spa: ivs[3] === '' ? 31 : Number(ivs[3]),
+				spd: ivs[4] === '' ? 31 : Number(ivs[4]),
+				spe: ivs[5] === '' ? 31 : Number(ivs[5])
+			};
 		}
 		i = j + 1;
 
@@ -954,15 +955,16 @@ Storage.unpackTeam = function (buf) {
 
 		// ivs
 		j = buf.indexOf('|', i);
-		set.ivs = {};
 		if (j !== i) {
 			var ivs = buf.substring(i, j).split(',');
-			if (ivs[0] !== '') set.ivs.hp = Number(ivs[0]);
-			if (ivs[1] !== '') set.ivs.atk = Number(ivs[1]);
-			if (ivs[2] !== '') set.ivs.def = Number(ivs[2]);
-			if (ivs[3] !== '') set.ivs.spa = Number(ivs[3]);
-			if (ivs[4] !== '') set.ivs.spd = Number(ivs[4]);
-			if (ivs[5] !== '') set.ivs.spe = Number(ivs[5]);
+			set.ivs = {
+				hp: ivs[0] === '' ? 31 : Number(ivs[0]),
+				atk: ivs[1] === '' ? 31 : Number(ivs[1]),
+				def: ivs[2] === '' ? 31 : Number(ivs[2]),
+				spa: ivs[3] === '' ? 31 : Number(ivs[3]),
+				spd: ivs[4] === '' ? 31 : Number(ivs[4]),
+				spe: ivs[5] === '' ? 31 : Number(ivs[5])
+			};
 		}
 		i = j + 1;
 
@@ -1170,7 +1172,7 @@ Storage.importTeam = function (buffer, teams) {
 		} else if (line.substr(0, 5) === 'IVs: ') {
 			line = line.substr(5);
 			var ivLines = line.split(' / ');
-			curSet.ivs = {};
+			curSet.ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
 			for (var j = 0; j < ivLines.length; j++) {
 				var ivLine = ivLines[j];
 				var spaceIndex = ivLine.indexOf(' ');
@@ -1178,9 +1180,8 @@ Storage.importTeam = function (buffer, teams) {
 				var statid = BattleStatIDs[ivLine.substr(spaceIndex + 1)];
 				var statval = parseInt(ivLine.substr(0, spaceIndex), 10);
 				if (!statid) continue;
-				if (!isNaN(statval) && statval !== 31) {
-					curSet.ivs[statid] = statval;
-				}
+				if (isNaN(statval)) statval = 31;
+				curSet.ivs[statid] = statval;
 			}
 		} else if (line.match(/^[A-Za-z]+ (N|n)ature/)) {
 			var natureIndex = line.indexOf(' Nature');
@@ -1202,7 +1203,6 @@ Storage.importTeam = function (buffer, teams) {
 			curSet.moves.push(line);
 		}
 	}
-	if (curSet && !curSet.ivs) curSet.ivs = {};
 	if (teams && teams.length && typeof teams[teams.length - 1].team !== 'string') {
 		teams[teams.length - 1].team = Storage.packTeam(teams[teams.length - 1].team);
 	}

--- a/js/storage.js
+++ b/js/storage.js
@@ -1283,20 +1283,22 @@ Storage.exportTeam = function (team) {
 			text += '' + curSet.nature + ' Nature' + "  \n";
 		}
 
-		var firstIV = true;
-		for (var j in BattleStatNames) {
-			var val = curSet.ivs[j];
-			if (val === undefined || isNaN(val) || val === 31) continue;
-			if (firstIV) {
-				text += 'IVs: ';
-				firstIV = false;
-			} else {
-				text += ' / ';
+		if (curSet.ivs) {
+			var firstIV = true;
+			for (var j in BattleStatNames) {
+				var val = curSet.ivs[j];
+				if (val === undefined || isNaN(val) || val === 31) continue;
+				if (firstIV) {
+					text += 'IVs: ';
+					firstIV = false;
+				} else {
+					text += ' / ';
+				}
+				text += '' + val + ' ' + BattleStatNames[j];
 			}
-			text += '' + val + ' ' + BattleStatNames[j];
-		}
-		if (!firstIV) {
-			text += "  \n";
+			if (!firstIV) {
+				text += "  \n";
+			}
 		}
 
 		if (curSet.moves) {

--- a/js/storage.js
+++ b/js/storage.js
@@ -731,7 +731,7 @@ Storage.packTeam = function (team) {
 		// ivs
 		var ivs = '|';
 		if (set.ivs) {
-			ivs = '|' + (set.ivs['hp'] === undefined ? '' : set.ivs['hp']) + ',' + (set.ivs['atk'] === undefined ? '' : set.ivs['atk']) + ',' + (set.ivs['def'] === undefined ? '' : set.ivs['def']) + ',' + (set.ivs['spa'] === undefined ? '' : set.ivs['spa']) + ',' + (set.ivs['spd'] === undefined ? '' : set.ivs['spd']) + ',' + (set.ivs['spe'] === undefined ? '' : set.ivs['spe']);
+			ivs = '|' + (set.ivs['hp'] === 31 || set.ivs['hp'] === undefined ? '' : set.ivs['hp']) + ',' + (set.ivs['atk'] === 31 || set.ivs['atk'] === undefined ? '' : set.ivs['atk']) + ',' + (set.ivs['def'] === 31 || set.ivs['def'] === undefined ? '' : set.ivs['def']) + ',' + (set.ivs['spa'] === 31 || set.ivs['spa'] === undefined ? '' : set.ivs['spa']) + ',' + (set.ivs['spd'] === 31 || set.ivs['spd'] === undefined ? '' : set.ivs['spd']) + ',' + (set.ivs['spe'] === 31 || set.ivs['spe'] === undefined ? '' : set.ivs['spe']);
 		}
 		if (ivs === '|,,,,,') {
 			buf += '|';
@@ -1178,9 +1178,7 @@ Storage.importTeam = function (buffer, teams) {
 				var statid = BattleStatIDs[ivLine.substr(spaceIndex + 1)];
 				var statval = parseInt(ivLine.substr(0, spaceIndex), 10);
 				if (!statid) continue;
-				if (!isNaN(statval)) {
-					// We intentionally do not check for 31 here. If "31 HP" is explicitly specified,
-					// that will be reflected if the user tries to export the Pokemon later.
+				if (!isNaN(statval) && statval !== 31) {
 					curSet.ivs[statid] = statval;
 				}
 			}
@@ -1287,14 +1285,15 @@ Storage.exportTeam = function (team) {
 
 		var firstIV = true;
 		for (var j in BattleStatNames) {
-			if (curSet.ivs[j] === undefined) continue;
+			var val = curSet.ivs[j];
+			if (val === undefined || isNaN(val) || val === 31) continue;
 			if (firstIV) {
 				text += 'IVs: ';
 				firstIV = false;
 			} else {
 				text += ' / ';
 			}
-			text += '' + curSet.ivs[j] + ' ' + BattleStatNames[j];
+			text += '' + val + ' ' + BattleStatNames[j];
 		}
 		if (!firstIV) {
 			text += "  \n";

--- a/js/storage.js
+++ b/js/storage.js
@@ -840,18 +840,15 @@ Storage.fastUnpackTeam = function (buf) {
 
 		// ivs
 		j = buf.indexOf('|', i);
+		set.ivs = {};
 		if (j !== i) {
 			var ivs = buf.substring(i, j).split(',');
-			set.ivs = {
-				hp: ivs[0] === '' ? 31 : Number(ivs[0]),
-				atk: ivs[1] === '' ? 31 : Number(ivs[1]),
-				def: ivs[2] === '' ? 31 : Number(ivs[2]),
-				spa: ivs[3] === '' ? 31 : Number(ivs[3]),
-				spd: ivs[4] === '' ? 31 : Number(ivs[4]),
-				spe: ivs[5] === '' ? 31 : Number(ivs[5])
-			};
-		} else {
-			set.ivs = {};
+			if (ivs[0] !== '') set.ivs.hp = Number(ivs[0]);
+			if (ivs[1] !== '') set.ivs.atk = Number(ivs[1]);
+			if (ivs[2] !== '') set.ivs.def = Number(ivs[2]);
+			if (ivs[3] !== '') set.ivs.spa = Number(ivs[3]);
+			if (ivs[4] !== '') set.ivs.spd = Number(ivs[4]);
+			if (ivs[5] !== '') set.ivs.spe = Number(ivs[5]);
 		}
 		i = j + 1;
 
@@ -957,18 +954,15 @@ Storage.unpackTeam = function (buf) {
 
 		// ivs
 		j = buf.indexOf('|', i);
+		set.ivs = {};
 		if (j !== i) {
 			var ivs = buf.substring(i, j).split(',');
-			set.ivs = {
-				hp: ivs[0] === '' ? 31 : Number(ivs[0]),
-				atk: ivs[1] === '' ? 31 : Number(ivs[1]),
-				def: ivs[2] === '' ? 31 : Number(ivs[2]),
-				spa: ivs[3] === '' ? 31 : Number(ivs[3]),
-				spd: ivs[4] === '' ? 31 : Number(ivs[4]),
-				spe: ivs[5] === '' ? 31 : Number(ivs[5])
-			};
-		} else {
-			set.ivs = {};
+			if (ivs[0] !== '') set.ivs.hp = Number(ivs[0]);
+			if (ivs[1] !== '') set.ivs.atk = Number(ivs[1]);
+			if (ivs[2] !== '') set.ivs.def = Number(ivs[2]);
+			if (ivs[3] !== '') set.ivs.spa = Number(ivs[3]);
+			if (ivs[4] !== '') set.ivs.spd = Number(ivs[4]);
+			if (ivs[5] !== '') set.ivs.spe = Number(ivs[5]);
 		}
 		i = j + 1;
 
@@ -1209,7 +1203,7 @@ Storage.importTeam = function (buffer, teams) {
 			curSet.moves.push(line);
 		}
 	}
-	if (!curSet.ivs) curSet.ivs = {};
+	if (curSet && !curSet.ivs) curSet.ivs = {};
 	if (teams && teams.length && typeof teams[teams.length - 1].team !== 'string') {
 		teams[teams.length - 1].team = Storage.packTeam(teams[teams.length - 1].team);
 	}

--- a/js/storage.js
+++ b/js/storage.js
@@ -1379,12 +1379,12 @@ Storage.exportTeam = function (team) {
 		}
 
 		var ivs = curSet.ivs;
-		if (ivs) {
+		var firstIV = true;
+		if (ivs) { // Explicitly specified IVs
 			text += 'IVs: ';
 
-			var firstIV = true;
 			for (var j in BattleStatNames) {
-				var val = curSet.ivs[j];
+				var val = ivs[j];
 				if (val === 31) continue;
 				if (firstIV) {
 					firstIV = false;
@@ -1397,7 +1397,23 @@ Storage.exportTeam = function (team) {
 				text += '31 all';
 			}
 			text += '  \n';
-		} // else if auto IVs aren't all 31, append them and add (auto)
+		} else { // Automatic IVs
+			ivs = getAutoIVs(curSet, team.format);
+			for (var j in BattleStatNames) {
+				var val = ivs[j];
+				if (val === 31) continue;
+				if (firstIV) {
+					text += 'IVs: ';
+					firstIV = false;
+				} else {
+					text += ' / ';
+				}
+				text += '' + val + ' ' + BattleStatNames[j];
+			}
+			if (!firstIV) {
+				text += ' (auto)  \n';
+			}
+		}
 
 		if (curSet.moves) {
 			for (var j = 0; j < curSet.moves.length; j++) {

--- a/js/storage.js
+++ b/js/storage.js
@@ -1296,7 +1296,7 @@ Storage.exportTeam = function (team) {
 				}
 				text += '' + val + ' ' + BattleStatNames[j];
 			}
-			if (!firstIV) {
+			if (firstIV) {
 				text += '31 all';
 			}
 			text += '  \n';

--- a/js/storage.js
+++ b/js/storage.js
@@ -1274,7 +1274,7 @@ Storage.exportTeam = function (team, format) {
 		if (curSet.hpType) {
 			text += 'Hidden Power: ' + curSet.hpType + "  \n";
 		}
-    
+
 		var firstEV = true;
 		if (curSet.evs) {
 			for (var j in BattleStatNames) {

--- a/js/storage.js
+++ b/js/storage.js
@@ -1285,25 +1285,21 @@ Storage.exportTeam = function (team) {
 		if (ivs) {
 			text += 'IVs: ';
 
-			var all31 = (ivs.hp === 31 && ivs.atk === 31 && ivs.def === 31 && ivs.spa === 31 && ivs.spd === 31 && ivs.spe === 31);
-			if (all31) {
-				text += '31 all';
-			} else {
-				var firstIV = true;
-				for (var j in BattleStatNames) {
-					var val = curSet.ivs[j];
-					if (val === 31) continue;
-					if (firstIV) {
-						firstIV = false;
-					} else {
-						text += ' / ';
-					}
-					text += '' + val + ' ' + BattleStatNames[j];
+			var firstIV = true;
+			for (var j in BattleStatNames) {
+				var val = curSet.ivs[j];
+				if (val === 31) continue;
+				if (firstIV) {
+					firstIV = false;
+				} else {
+					text += ' / ';
 				}
+				text += '' + val + ' ' + BattleStatNames[j];
 			}
 			if (!firstIV) {
-				text += "  \n";
+				text += '31 all';
 			}
+			text += '  \n';
 		}
 
 		if (curSet.moves) {

--- a/js/storage.js
+++ b/js/storage.js
@@ -1167,6 +1167,8 @@ Storage.importTeam = function (buffer, teams) {
 			}
 		} else if (line.substr(0, 5) === 'IVs: ') {
 			line = line.substr(5);
+			if (line.trim().endsWith('(auto)')) continue;
+
 			curSet.ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
 			if (line.trim() === '31 all') continue;
 
@@ -1282,12 +1284,12 @@ Storage.exportTeam = function (team) {
 		}
 
 		var ivs = curSet.ivs;
-		if (ivs) {
+		var firstIV = true;
+		if (ivs) { // Explicitly specified IVs
 			text += 'IVs: ';
 
-			var firstIV = true;
 			for (var j in BattleStatNames) {
-				var val = curSet.ivs[j];
+				var val = ivs[j];
 				if (val === 31) continue;
 				if (firstIV) {
 					firstIV = false;
@@ -1300,6 +1302,23 @@ Storage.exportTeam = function (team) {
 				text += '31 all';
 			}
 			text += '  \n';
+		} else if (curSet.autoIVs) { // Automatic IVs
+			ivs = curSet.autoIVs;
+
+			for (var j in BattleStatNames) {
+				var val = ivs[j];
+				if (val === 31) continue;
+				if (firstIV) {
+					text += 'IVs: ';
+					firstIV = false;
+				} else {
+					text += ' / ';
+				}
+				text += '' + val + ' ' + BattleStatNames[j];
+			}
+			if (!firstIV) {
+				text += ' (auto)  \n';
+			}
 		}
 
 		if (curSet.moves) {

--- a/js/storage.js
+++ b/js/storage.js
@@ -1,97 +1,3 @@
-// TODO: Move these helper fns elsewhere
-
-function getGen(format) {
-	format = '' + format;
-	if (!format) return 7;
-	if (format.substr(0, 3) !== 'gen') return 6;
-	return parseInt(format.substr(3, 1), 10) || 6;
-}
-
-function canHyperTrain(set, format) {
-	var gen = getGen(format);
-	if (gen < 7 || format === 'gen7hiddentype') return false;
-	if (!set.level || set.level === 100) return true;
-	if (format.substr(0, 3) === 'gen') format = format.substr(4);
-	if (format.substr(0, 10) === 'battlespot' || format.substr(0, 3) === 'vgc' || format === 'ultrasinnohclassic') {
-		if (set.level === 50) return true;
-	}
-	return false;
-}
-
-function getDesiredHPType(moves) {
-	for (var i = 0; i < moves.length; ++i) {
-		if (moves[i] && moves[i].substr(0, 13) === 'Hidden Power ') {
-			return moves[i].substr(13);
-		}
-	}
-	return '';
-}
-
-function getAutoIVs(set, format) {
-	return {
-		hp: getAutoIV('hp', set, format),
-		atk: getAutoIV('atk', set, format),
-		def: getAutoIV('def', set, format),
-		spa: getAutoIV('spa', set, format),
-		spd: getAutoIV('spd', set, format),
-		spe: getAutoIV('spe', set, format)
-	};
-}
-
-function getAutoIV(stat, set, format) {
-	if (!format) format = 'gen7';
-	var minValue = 0;
-	var maxValue = 31;
-	var useMaxValue = true;
-
-	var moves = set.moves;
-	var gen = getGen(format);
-	var hpType = getDesiredHPType(moves);
-	var _canHyperTrain = canHyperTrain(set, format);
-
-	if (hpType && window.BattleTypeChart) {
-		if (gen > 2) {
-			minValue = (window.BattleTypeChart[hpType].HPivs[stat] || 31) % 2;
-			if (!_canHyperTrain) {
-				// Must have matching parity for the correct Hidden Power type
-				maxValue = 30 + minValue;
-			}
-		} else if (stat === 'atk' || stat === 'def') { // Gen 2 only uses atk/def to calc HP type
-			minValue = ((window.BattleTypeChart[hpType].HPdvs[stat] || 15) % 4) * 2; // Results in 0, 2, 4, or 6
-			maxValue = (minValue === 6 ? 31 : 24 + minValue);
-		}
-	}
-
-	if (stat === 'atk') {
-		if (gen > 2 && set.ability !== 'Battle Bond') { // Ash-Greninja is only available through an event with 31 Atk IVs
-			useMaxValue = false; // Default to 0 Atk IVs if we don't have a physical attacking move
-			for (var i = 0; i < moves.length; ++i) {
-				if (!moves[i]) continue;
-				var move = Dex.forGen(gen).getMove(moves[i]);
-				if (move.category === 'Physical' &&
-					!move.damage && !move.ohko && move.id !== 'rapidspin' && move.id !== 'foulplay' && move.id !== 'endeavor' && move.id !== 'counter') {
-					useMaxValue = true;
-					break;
-				} else if (move.id === 'metronome' || move.id === 'assist' || move.id === 'copycat' || move.id === 'mefirst') {
-					useMaxValue = true;
-					break;
-				}
-			}
-		}
-	} else if (stat === 'spe') {
-		for (var i = 0; i < moves.length; ++i) {
-			if (moves[i] === 'Gyro Ball') {
-				useMaxValue = false;
-				break;
-			}
-		}
-	}
-
-	return useMaxValue ? maxValue : minValue;
-}
-
-// END TODO
-
 Config.origindomain = 'play.pokemonshowdown.com';
 // `defaultserver` specifies the server to use when the domain name in the
 // address bar is `Config.origindomain`.
@@ -1397,7 +1303,7 @@ Storage.exportTeam = function (team, format) {
 			}
 			text += '  \n';
 		} else { // Automatic IVs
-			ivs = getAutoIVs(curSet, format);
+			ivs = Storage.getAutoIVs(curSet, format);
 			for (var j in BattleStatNames) {
 				var val = ivs[j];
 				if (val === 31) continue;
@@ -1430,6 +1336,98 @@ Storage.exportTeam = function (team, format) {
 	}
 	return text;
 };
+
+// helper functions for import/export team
+
+Storage.getGen = function (format) {
+	format = '' + format;
+	if (!format) return 7;
+	if (format.substr(0, 3) !== 'gen') return 6;
+	return parseInt(format.substr(3, 1), 10) || 6;
+}
+
+Storage.canHyperTrain = function (set, format) {
+	var gen = Storage.getGen(format);
+	if (gen < 7 || format === 'gen7hiddentype') return false;
+	if (!set.level || set.level === 100) return true;
+	if (format.substr(0, 3) === 'gen') format = format.substr(4);
+	if (format.substr(0, 10) === 'battlespot' || format.substr(0, 3) === 'vgc' || format === 'ultrasinnohclassic') {
+		if (set.level === 50) return true;
+	}
+	return false;
+}
+
+Storage.getDesiredHPType = function (moves) {
+	for (var i = 0; i < moves.length; ++i) {
+		if (moves[i] && moves[i].substr(0, 13) === 'Hidden Power ') {
+			return moves[i].substr(13);
+		}
+	}
+	return '';
+}
+
+Storage.getAutoIVs = function (set, format) {
+	return {
+		hp: Storage.getAutoIV('hp', set, format),
+		atk: Storage.getAutoIV('atk', set, format),
+		def: Storage.getAutoIV('def', set, format),
+		spa: Storage.getAutoIV('spa', set, format),
+		spd: Storage.getAutoIV('spd', set, format),
+		spe: Storage.getAutoIV('spe', set, format)
+	};
+}
+
+Storage.getAutoIV = function (stat, set, format) {
+	if (!format) format = 'gen7';
+	var minValue = 0;
+	var maxValue = 31;
+	var useMaxValue = true;
+
+	var moves = set.moves;
+	var gen = Storage.getGen(format);
+	var hpType = Storage.getDesiredHPType(moves);
+	var _canHyperTrain = Storage.canHyperTrain(set, format);
+
+	if (hpType && window.BattleTypeChart) {
+		if (gen > 2) {
+			minValue = (window.BattleTypeChart[hpType].HPivs[stat] || 31) % 2;
+			if (!_canHyperTrain) {
+				// Must have matching parity for the correct Hidden Power type
+				maxValue = 30 + minValue;
+			}
+		} else if (stat === 'atk' || stat === 'def') { // Gen 2 only uses atk/def to calc HP type
+			minValue = ((window.BattleTypeChart[hpType].HPdvs[stat] || 15) % 4) * 2; // Results in 0, 2, 4, or 6
+			maxValue = (minValue === 6 ? 31 : 24 + minValue);
+		}
+	}
+
+	if (stat === 'atk') {
+		if (gen > 2 && set.ability !== 'Battle Bond') { // Ash-Greninja is only available through an event with 31 Atk IVs
+			useMaxValue = false; // Default to 0 Atk IVs if we don't have a physical attacking move
+			for (var i = 0; i < moves.length; ++i) {
+				if (!moves[i]) continue;
+				var move = Dex.forGen(gen).getMove(moves[i]);
+				if (move.category === 'Physical' &&
+					!move.damage && !move.ohko && move.id !== 'rapidspin' && move.id !== 'foulplay' && move.id !== 'endeavor' && move.id !== 'counter') {
+					useMaxValue = true;
+					break;
+				} else if (move.id === 'metronome' || move.id === 'assist' || move.id === 'copycat' || move.id === 'mefirst') {
+					useMaxValue = true;
+					break;
+				}
+			}
+		}
+	} else if (stat === 'spe') {
+		for (var i = 0; i < moves.length; ++i) {
+			if (moves[i] === 'Gyro Ball') {
+				useMaxValue = false;
+				break;
+			}
+		}
+	}
+
+	return useMaxValue ? maxValue : minValue;
+}
 
 /*********************************************************
  * Node-webkit

--- a/js/storage.js
+++ b/js/storage.js
@@ -731,7 +731,7 @@ Storage.packTeam = function (team) {
 		// ivs
 		var ivs = '|';
 		if (set.ivs) {
-			ivs = '|' + (set.ivs['hp'] === 31 || set.ivs['hp'] === undefined ? '' : set.ivs['hp']) + ',' + (set.ivs['atk'] === 31 || set.ivs['atk'] === undefined ? '' : set.ivs['atk']) + ',' + (set.ivs['def'] === 31 || set.ivs['def'] === undefined ? '' : set.ivs['def']) + ',' + (set.ivs['spa'] === 31 || set.ivs['spa'] === undefined ? '' : set.ivs['spa']) + ',' + (set.ivs['spd'] === 31 || set.ivs['spd'] === undefined ? '' : set.ivs['spd']) + ',' + (set.ivs['spe'] === 31 || set.ivs['spe'] === undefined ? '' : set.ivs['spe']);
+			ivs = '|' + (set.ivs['hp'] === undefined ? '' : set.ivs['hp']) + ',' + (set.ivs['atk'] === undefined ? '' : set.ivs['atk']) + ',' + (set.ivs['def'] === undefined ? '' : set.ivs['def']) + ',' + (set.ivs['spa'] === undefined ? '' : set.ivs['spa']) + ',' + (set.ivs['spd'] === undefined ? '' : set.ivs['spd']) + ',' + (set.ivs['spe'] === undefined ? '' : set.ivs['spe']);
 		}
 		if (ivs === '|,,,,,') {
 			buf += '|';
@@ -1178,10 +1178,11 @@ Storage.importTeam = function (buffer, teams) {
 				var statid = BattleStatIDs[ivLine.substr(spaceIndex + 1)];
 				var statval = parseInt(ivLine.substr(0, spaceIndex), 10);
 				if (!statid) continue;
-				if (isNaN(statval)) statval = 31;
-				// We intentionally do not check for 31 here. If "31 HP" is explicitly specified,
-				// that will be reflected if the user tries to export the Pokemon later.
-				curSet.ivs[statid] = statval;
+				if (!isNaN(statval)) {
+					// We intentionally do not check for 31 here. If "31 HP" is explicitly specified,
+					// that will be reflected if the user tries to export the Pokemon later.
+					curSet.ivs[statid] = statval;
+				}
 			}
 		} else if (line.match(/^[A-Za-z]+ (N|n)ature/)) {
 			var natureIndex = line.indexOf(' Nature');

--- a/js/storage.js
+++ b/js/storage.js
@@ -965,6 +965,8 @@ Storage.unpackTeam = function (buf) {
 				spd: ivs[4] === '' ? 31 : Number(ivs[4]),
 				spe: ivs[5] === '' ? 31 : Number(ivs[5])
 			};
+		} else {
+			set.ivs = {};
 		}
 		i = j + 1;
 
@@ -1195,6 +1197,10 @@ Storage.importTeam = function (buffer, teams) {
 			line = line.substr(1);
 			if (line.substr(0, 1) === ' ') line = line.substr(1);
 			if (!curSet.moves) curSet.moves = [];
+			if (line.substr(0, 14) === 'Hidden Power [') {
+				var hptype = line.substr(14, line.length - 15);
+				line = 'Hidden Power ' + hptype;
+			}
 			if (line === 'Frustration' && curSet.happiness === undefined) {
 				curSet.happiness = 0;
 			}

--- a/js/storage.js
+++ b/js/storage.js
@@ -1283,16 +1283,17 @@ Storage.exportTeam = function (team) {
 
 		var ivs = curSet.ivs;
 		if (ivs) {
-			var firstIV = true;
+			text += 'IVs: ';
+
 			var all31 = (ivs.hp === 31 && ivs.atk === 31 && ivs.def === 31 && ivs.spa === 31 && ivs.spd === 31 && ivs.spe === 31);
 			if (all31) {
-				text += 'IVs: 31 all';
+				text += '31 all';
 			} else {
+				var firstIV = true;
 				for (var j in BattleStatNames) {
 					var val = curSet.ivs[j];
-					if (val === undefined || isNaN(val) || val === 31) continue;
+					if (val === 31) continue;
 					if (firstIV) {
-						text += 'IVs: ';
 						firstIV = false;
 					} else {
 						text += ' / ';

--- a/js/storage.js
+++ b/js/storage.js
@@ -1356,7 +1356,7 @@ Storage.getGen = function (format) {
 	if (!format) return 7;
 	if (format.substr(0, 3) !== 'gen') return 6;
 	return parseInt(format.substr(3, 1), 10) || 6;
-}
+};
 
 Storage.canHyperTrain = function (set, format) {
 	var gen = Storage.getGen(format);
@@ -1367,7 +1367,7 @@ Storage.canHyperTrain = function (set, format) {
 		if (set.level === 50) return true;
 	}
 	return false;
-}
+};
 
 Storage.getDesiredHPType = function (moves) {
 	for (var i = 0; i < moves.length; ++i) {
@@ -1376,7 +1376,7 @@ Storage.getDesiredHPType = function (moves) {
 		}
 	}
 	return '';
-}
+};
 
 Storage.getAutoIVs = function (set, format) {
 	return {
@@ -1387,7 +1387,7 @@ Storage.getAutoIVs = function (set, format) {
 		spd: Storage.getAutoIV('spd', set, format),
 		spe: Storage.getAutoIV('spe', set, format)
 	};
-}
+};
 
 Storage.getAutoIV = function (stat, set, format) {
 	if (!format) format = 'gen7';
@@ -1439,7 +1439,7 @@ Storage.getAutoIV = function (stat, set, format) {
 	}
 
 	return useMaxValue ? maxValue : minValue;
-}
+};
 
 /*********************************************************
  * Node-webkit

--- a/js/storage.js
+++ b/js/storage.js
@@ -733,11 +733,7 @@ Storage.packTeam = function (team) {
 		if (set.ivs) {
 			ivs = '|' + (set.ivs['hp'] === 31 || set.ivs['hp'] === undefined ? '' : set.ivs['hp']) + ',' + (set.ivs['atk'] === 31 || set.ivs['atk'] === undefined ? '' : set.ivs['atk']) + ',' + (set.ivs['def'] === 31 || set.ivs['def'] === undefined ? '' : set.ivs['def']) + ',' + (set.ivs['spa'] === 31 || set.ivs['spa'] === undefined ? '' : set.ivs['spa']) + ',' + (set.ivs['spd'] === 31 || set.ivs['spd'] === undefined ? '' : set.ivs['spd']) + ',' + (set.ivs['spe'] === 31 || set.ivs['spe'] === undefined ? '' : set.ivs['spe']);
 		}
-		if (ivs === '|,,,,,') {
-			buf += '|';
-		} else {
-			buf += ivs;
-		}
+		buf += ivs;
 
 		// shiny
 		if (set.shiny) {
@@ -1171,8 +1167,10 @@ Storage.importTeam = function (buffer, teams) {
 			}
 		} else if (line.substr(0, 5) === 'IVs: ') {
 			line = line.substr(5);
-			var ivLines = line.split(' / ');
 			curSet.ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
+			if (line.trim() === '31 all') continue;
+
+			var ivLines = line.split(' / ');
 			for (var j = 0; j < ivLines.length; j++) {
 				var ivLine = ivLines[j];
 				var spaceIndex = ivLine.indexOf(' ');
@@ -1283,18 +1281,24 @@ Storage.exportTeam = function (team) {
 			text += '' + curSet.nature + ' Nature' + "  \n";
 		}
 
-		if (curSet.ivs) {
+		var ivs = curSet.ivs;
+		if (ivs) {
 			var firstIV = true;
-			for (var j in BattleStatNames) {
-				var val = curSet.ivs[j];
-				if (val === undefined || isNaN(val) || val === 31) continue;
-				if (firstIV) {
-					text += 'IVs: ';
-					firstIV = false;
-				} else {
-					text += ' / ';
+			var all31 = (ivs.hp === 31 && ivs.atk === 31 && ivs.def === 31 && ivs.spa === 31 && ivs.spd === 31 && ivs.spe === 31);
+			if (all31) {
+				text += 'IVs: 31 all';
+			} else {
+				for (var j in BattleStatNames) {
+					var val = curSet.ivs[j];
+					if (val === undefined || isNaN(val) || val === 31) continue;
+					if (firstIV) {
+						text += 'IVs: ';
+						firstIV = false;
+					} else {
+						text += ' / ';
+					}
+					text += '' + val + ' ' + BattleStatNames[j];
 				}
-				text += '' + val + ' ' + BattleStatNames[j];
 			}
 			if (!firstIV) {
 				text += "  \n";

--- a/js/storage.js
+++ b/js/storage.js
@@ -1167,6 +1167,8 @@ Storage.importTeam = function (buffer, teams) {
 			}
 		} else if (line.substr(0, 5) === 'IVs: ') {
 			line = line.substr(5);
+			if (line.trim().endsWith('(auto)')) continue;
+
 			curSet.ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
 			if (line.trim() === '31 all') continue;
 
@@ -1300,7 +1302,7 @@ Storage.exportTeam = function (team) {
 				text += '31 all';
 			}
 			text += '  \n';
-		}
+		} // else if auto IVs aren't all 31, append them and add (auto)
 
 		if (curSet.moves) {
 			for (var j = 0; j < curSet.moves.length; j++) {


### PR DESCRIPTION
This PR adds a checkbox labeled "Use automatic IVs" to the teambuilder.

- When it is checked, all of the Pokemon's IVs are inferred from context and there will be no `IVs:` line in the export, even if we adjusted it for stuff like Hidden Power.
- When it is unchecked, all non-31 IVs will be reflected in the export via `IVs`. This includes IVs that the user manually specified, as well as Hidden Power IVs, `0 Atk`, and `0 Spe` that we automatically insert. The user can manually uncheck the box, or it will automatically uncheck if the user modifies one of the IVs.
- When we import a set, we will check the box according to whether or not there is an `IVs:` line.
  - We erase IVs that are set to 31 via the textbox GUI, so that `IVs: 31 HP` doesn't randomly show up if the user accidentally adjusts the HP IV and readjusts it back. However, if they import a set with an explicit `IVs: 31 HP` (for example, if they want a Ferrothorn w/ Gyro Ball to have max speed for w/e reason) then we will preserve it and continue to show that when the user exports the set.
- `ivs` now represents only IVs that are explicitly specified by the user; if the box is checked it corresponds to `ivs: {}`. `getAutoIVs()` gets all of the IVs by inferring the missing ones.

/cc @Zarel