### PR TITLE
UserPopup: Don't show IDs for expired users

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -178,7 +178,7 @@
 			var name = $(e.currentTarget).data('name') || $(e.currentTarget).text();
 			var away = $(e.currentTarget).data('away') || false;
 			var status = $(e.currentTarget).data('status');
-			app.addPopup(UserPopup, {roomGroup: roomGroup, name: name, away: away, status: status, sourceEl: e.currentTarget, position: position});
+			app.addPopup(UserPopup, {roomGroup: roomGroup, username: name, away: away, status: status, sourceEl: e.currentTarget, position: position});
 		},
 		openPM: function (e) {
 			e.preventDefault();
@@ -486,7 +486,7 @@
 			case 'user':
 			case 'open':
 				var openUser = function (target) {
-					app.addPopup(UserPopup, {name: target});
+					app.addPopup(UserPopup, {username: target});
 				};
 				target = toName(target);
 				if (!target) {

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -458,7 +458,7 @@
 		clickUsername: function (e) {
 			e.stopPropagation();
 			var name = $(e.currentTarget).data('name') || $(e.currentTarget).text();
-			app.addPopup(UserPopup, {name: name, sourceEl: e.currentTarget});
+			app.addPopup(UserPopup, {username: name, sourceEl: e.currentTarget});
 		},
 		clickPMBackground: function (e) {
 			if (!e.shiftKey && !e.cmdKey && !e.ctrlKey) {
@@ -931,7 +931,7 @@
 					app.addPopup(Popup, {htmlMessage: "Zarel is very busy; please don't contact him this way. If you're looking for help, try <a href=\"/help\">joining the Help room</a>?"});
 					return;
 				}
-				app.addPopup(UserPopup, {name: target});
+				app.addPopup(UserPopup, {username: target});
 			});
 		}
 	}, {

--- a/js/client-rooms.js
+++ b/js/client-rooms.js
@@ -106,7 +106,7 @@
 					app.addPopup(Popup, {htmlMessage: "Zarel is very busy; please don't contact him this way. If you're looking for help, try <a href=\"/help\">joining the Help room</a>?"});
 					return;
 				}
-				app.addPopup(UserPopup, {name: target});
+				app.addPopup(UserPopup, {username: target});
 			});
 		}
 	});

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -56,7 +56,7 @@
 			e.preventDefault();
 			e.stopPropagation();
 			var name = $(e.currentTarget).data('name');
-			app.addPopup(UserPopup, {name: name, sourceEl: e.currentTarget});
+			app.addPopup(UserPopup, {username: name, sourceEl: e.currentTarget});
 		},
 		toggleMute: function () {
 			var muted = !Dex.prefs('mute');

--- a/js/client.js
+++ b/js/client.js
@@ -2467,7 +2467,7 @@ function toId() {
 			this.data = data = _.extend(data, UserPopup.dataCache[data.userid]);
 			data.name = name;
 			app.on('response:userdetails', this.update, this);
-			app.send('/cmd userdetails ' + data.userid);
+			app.send('/cmd userdetails ' + data.name);
 			this.update();
 		},
 		events: {

--- a/js/client.js
+++ b/js/client.js
@@ -2462,12 +2462,12 @@ function toId() {
 
 	var UserPopup = this.UserPopup = Popup.extend({
 		initialize: function (data) {
-			data.userid = toID(data.name);
-			var name = data.name;
+			data.userid = toID(data.username);
+			var username = data.username;
 			this.data = data = _.extend(data, UserPopup.dataCache[data.userid]);
-			data.name = name;
+			data.username = username;
 			app.on('response:userdetails', this.update, this);
-			app.send('/cmd userdetails ' + data.name);
+			app.send('/cmd userdetails ' + data.userid);
 			this.update();
 		},
 		events: {
@@ -2484,7 +2484,7 @@ function toId() {
 				data = this.data;
 			}
 			var userid = data.userid;
-			var name = data.name;
+			var username = data.username;
 			var avatar = data.avatar || '';
 			var group = ((Config.groups[data.roomGroup] || {}).name || '');
 			var globalgroup = ((Config.groups[(data.group || Config.defaultGroup || ' ')] || {}).name || '');
@@ -2500,7 +2500,7 @@ function toId() {
 
 			var buf = '<div class="userdetails">';
 			if (avatar) buf += '<img class="trainersprite' + (userid === ownUserid ? ' yours' : '') + '" src="' + Dex.resolveAvatar(avatar) + '" />';
-			buf += '<strong><a href="//pokemonshowdown.com/users/' + userid + '" target="_blank">' + BattleLog.escapeHTML(name) + '</a></strong><br />';
+			buf += '<strong><a href="//pokemonshowdown.com/users/' + userid + '" target="_blank">' + BattleLog.escapeHTML(username) + '</a></strong><br />';
 			var offline = data.rooms === false;
 			if (data.status || offline) {
 				var status = offline ? '(Offline)' : data.status.startsWith('!') ? data.status.slice(1) : data.status;


### PR DESCRIPTION
Previously, clicking a username whose user object has been destroyed would lead to the name field showing the userid instead of the username because the server can't find the username.

~This is the simplest solution, although I guess it's more load on the server since it's not receiving pure IDs, but I seriously doubt that matters.~

~I'm not too sure of how it ever was showing the real username, or if it ever even was doing that.~

This is because `data.name` would get shadowed by the server's `name` field.