### PR TITLE
Do not change attack IVs for Pokemon with Transform

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2844,9 +2844,11 @@
 			var moves = set.moves;
 			for (var i = 0; i < moves.length; ++i) {
 				if (!moves[i]) continue;
-				if (moves[i].substr(0, 13) === 'Hidden Power ' || move.id === 'transform') hasHiddenPower = true;
+				if (moves[i].substr(0, 13) === 'Hidden Power ') hasHiddenPower = true;
 				var move = Dex.forGen(this.curTeam.gen).getMove(moves[i]);
-				if (move.category === 'Physical' &&
+				if (move.id === 'transform') {
+					hasHiddenPower = true;
+				} else if (move.category === 'Physical' &&
 						!move.damage && !move.ohko && move.id !== 'rapidspin' && move.id !== 'foulplay' && move.id !== 'endeavor' && move.id !== 'counter') {
 					minAtk = false;
 				} else if (move.id === 'metronome' || move.id === 'assist' || move.id === 'copycat' || move.id === 'mefirst') {

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2844,12 +2844,12 @@
 			var moves = set.moves;
 			for (var i = 0; i < moves.length; ++i) {
 				if (!moves[i]) continue;
-				if (moves[i].substr(0, 13) === 'Hidden Power ') hasHiddenPower = true;
+				if (moves[i].substr(0, 13) === 'Hidden Power ' || move.id === 'transform') hasHiddenPower = true;
 				var move = Dex.forGen(this.curTeam.gen).getMove(moves[i]);
 				if (move.category === 'Physical' &&
 						!move.damage && !move.ohko && move.id !== 'rapidspin' && move.id !== 'foulplay' && move.id !== 'endeavor' && move.id !== 'counter') {
 					minAtk = false;
-				} else if (move.id === 'metronome' || move.id === 'assist' || move.id === 'copycat' || move.id === 'mefirst' || move.id === 'transform') {
+				} else if (move.id === 'metronome' || move.id === 'assist' || move.id === 'copycat' || move.id === 'mefirst') {
 					minAtk = false;
 				}
 				if (minSpe === false && moveName === 'Gyro Ball') {

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2849,7 +2849,7 @@
 				if (move.category === 'Physical' &&
 						!move.damage && !move.ohko && move.id !== 'rapidspin' && move.id !== 'foulplay' && move.id !== 'endeavor' && move.id !== 'counter') {
 					minAtk = false;
-				} else if (move.id === 'metronome' || move.id === 'assist' || move.id === 'copycat' || move.id === 'mefirst') {
+				} else if (move.id === 'metronome' || move.id === 'assist' || move.id === 'copycat' || move.id === 'mefirst' || move.id === 'transform') {
 					minAtk = false;
 				}
 				if (minSpe === false && moveName === 'Gyro Ball') {

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2847,7 +2847,7 @@
 				if (moves[i].substr(0, 13) === 'Hidden Power ') hasHiddenPower = true;
 				var move = Dex.forGen(this.curTeam.gen).getMove(moves[i]);
 				if (move.id === 'transform') {
-					hasHiddenPower = true;
+					hasHiddenPower = true; // A Pokemon with Transform can copy another Pokemon that knows Hidden Power
 				} else if (move.category === 'Physical' &&
 						!move.damage && !move.ohko && move.id !== 'rapidspin' && move.id !== 'foulplay' && move.id !== 'endeavor' && move.id !== 'counter') {
 					minAtk = false;


### PR DESCRIPTION
This is an easy fix for https://github.com/Zarel/Pokemon-Showdown-Client/issues/1331. Note that it will still auto adjust the Speed IV, ie. if you have both Transform and Gyro Ball on Mew for example, so the behavior is not completely fixed. That should be easier to deal with once https://github.com/Zarel/Pokemon-Showdown-Client/pull/1333 is merged.