### PR TITLE
Allow /ignore to block voices in PMs

### DIFF
--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -134,7 +134,7 @@
 
 		addPM: function (name, message, target) {
 			var userid = toUserid(name);
-			if (app.ignore[userid] && name.substr(0, 1) in {' ': 1, '!': 1, '✖': 1, '‽': 1}) return;
+			if (app.ignore[userid] && name.substr(0, 1) in {' ': 1, '+': 1, '!': 1, '✖': 1, '‽': 1}) return;
 
 			var isSelf = (toID(name) === app.user.get('userid'));
 			var oName = isSelf ? target : name;


### PR DESCRIPTION
I see no reason for gvoices to be immune to /ignore, and someone brought it up to me as a weird thing they noticed, so might as well.
We could probably also turn it around and have a list of staff symbols that can't be blocked by ignore.