### PR TITLE
Make Gen 8 Metronome Battle ignore EV limits

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -128,7 +128,7 @@
 		update: function () {
 			teams = Storage.teams;
 			if (this.curTeam) {
-				this.ignoreEVLimits = (this.curTeam.gen < 3 || this.curTeam.format === 'gen7balancedhackmons' || this.curTeam.format === 'gen7metronomebattle' || this.curTeam.format.endsWith('norestrictions'));
+				this.ignoreEVLimits = (this.curTeam.gen < 3 || this.curTeam.format === 'gen7balancedhackmons' || this.curTeam.format === 'gen8metronomebattle' || this.curTeam.format.endsWith('norestrictions'));
 				if (this.curSet) {
 					return this.updateSetView();
 				}

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -1794,7 +1794,7 @@ class BattleStatGuesser {
 		let needsFourMoves = !['unown', 'ditto'].includes(template.id);
 		let moveids = set.moves.map(toID);
 		if (moveids.includes('lastresort' as ID)) needsFourMoves = false;
-		if (set.moves.length < 4 && needsFourMoves && this.formatid !== 'gen7metronomebattle') {
+		if (set.moves.length < 4 && needsFourMoves && this.formatid !== 'gen8metronomebattle') {
 			return '?';
 		}
 

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -1739,7 +1739,7 @@ class BattleStatGuesser {
 		this.ignoreEVLimits = (
 			this.dex.gen < 3 ||
 			this.formatid.endsWith('hackmons') ||
-			this.formatid === 'gen7metronomebattle' ||
+			this.formatid === 'gen8metronomebattle' ||
 			this.formatid.endsWith('norestrictions')
 		);
 		this.supportsEVs = !this.formatid.startsWith('gen7letsgo');


### PR DESCRIPTION
Changes gen7metronomebattle to gen8metronomebattle in relevant sections, affecting the suggested spreads and auto-adding 252 EVs to every stat features. Gen 7 Balanced Hackmons also has a mention in client-teambuilder.js, but I'm unsure about that so I'm keeping it simple for now.