### PR TITLE
Fix learnsets for Gmax formes

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -649,7 +649,8 @@
 		if (!template) return '';
 		if (template.prevo) return template.prevo;
 		var baseSpecies = template.baseSpecies;
-		if (baseSpecies !== template.species && (baseSpecies === 'Rotom' || baseSpecies === 'Pumpkaboo' || baseSpecies === 'Necrozma')) {
+		if ((template.forme && template.forme.indexOf('Gmax') >= 0) ||
+			(baseSpecies !== template.species && (baseSpecies === 'Rotom' || baseSpecies === 'Pumpkaboo' || baseSpecies === 'Necrozma'))) {
 			return toID(template.baseSpecies);
 		}
 		return '';


### PR DESCRIPTION
The event-only Gmax Pokemon (Eevee, Pikachu, Meowth) currently only have four moves in their movesets; this fixes that issue and also any potential future encounters with event-only Gmax Pokemon.