### PR TITLE
Add team storage to login server (See #1417)

### DIFF
--- a/action.php
+++ b/action.php
@@ -32,6 +32,7 @@ include_once 'lib/dispatcher.lib.php';
 
 $dispatcher = new ActionDispatcher(array(
 	new DefaultActionHandler(),
-	new LadderActionHandler()
+	new LadderActionHandler(),
+	new TeamsActionHandler()
 ));
 $dispatcher->executeActions();

--- a/lib/dispatcher.lib.php
+++ b/lib/dispatcher.lib.php
@@ -496,7 +496,7 @@ class DefaultActionHandler {
 		// The ] denotes that it was successful
 		die(']A friend request has been sent to ' . $player['username'] . '!');
 	}
-	
+
 	/**
 	 * This function simply removes the friend given in the query string.
 	 */
@@ -598,4 +598,34 @@ class LadderActionHandler {
 			}
 		}
 	}
+}
+
+class TeamsActionHandler {
+	var $PAGESIZE = 50;
+
+	/**
+	 * This function fetches all published teams uploaded by the user.
+	 */
+	public function getuploadedteams($dispatcher, &$reqData, &$out) {
+		global $psdb, $teams, $curuser;
+		// A valid curuser array is needed
+		if (!@$curuser['loggedin'] || !@$curuser['userid']) {
+		   die('Not using a valid nick; you should be registered and logged in in order to view your published teams.');
+		}
+		$userid = $psdb->escape($curuser['userid']);
+		$res = $psdb.query(
+			"SELECT `teamname`, `format`, `packedteam`, `public` FROM `ntbb_teams` WHERE (`ownerid` = '" . $userid . "')" .
+			" ORDER BY `teamid` DESC"
+		);
+		$out = array();
+		$i = 0;
+		while($i < $PAGESIZE && $team = $psdb->fetch_assoc($res)) {
+			$i += 1;
+			$out[] = $team;
+		}
+	}
+
+	/**
+	 * This function
+	 */
 }

--- a/lib/dispatcher.lib.php
+++ b/lib/dispatcher.lib.php
@@ -601,7 +601,7 @@ class LadderActionHandler {
 }
 
 class TeamsActionHandler {
-	$MAXPAGESIZE = 50;
+	const MAXPAGESIZE = 50;
 	/**
 	 * Fetches all published teams uploaded by the user.
 	 * Mandatory request args: userid: user id; page, pagesize: control the range of data that is returned.
@@ -618,8 +618,8 @@ class TeamsActionHandler {
 		}
 
 		$userid = $psdb->escape($curuser['userid']);
-		$pagesize = min($MAXPAGESIZE, intval(@$reqData['pagesize']));
-		$pagesize = $pagesize == 0 ? $MAXPAGESIZE : $pagesize;
+		$pagesize = min(self::MAXPAGESIZE, intval(@$reqData['pagesize']));
+		$pagesize = $pagesize == 0 ? self::MAXPAGESIZE : $pagesize;
 		$page = intval(@$reqData['page']);
 		if($pagesize <= 0 || $page < 0) {
 			$out = 0;
@@ -658,10 +658,10 @@ class TeamsActionHandler {
 		}
 
 		$userid = $psdb->escape($curuser['userid']);
-		$pagesize = min($MAXPAGESIZE, intval(@$reqData['pagesize']));
-		$pagesize = $pagesize == 0 ? $MAXPAGESIZE : $pagesize;
+		$pagesize = min(self::MAXPAGESIZE, intval(@$reqData['pagesize']));
+		$pagesize = $pagesize == 0 ? self::MAXPAGESIZE : $pagesize;
 		$page = intval(@$reqData['page']);
-		if($pagesize <= 0 || $page < 0) {
+		if($pagesize <= 0 || $page < 0 || !$userid) {
 			$out = 0;
 			return;
 		}
@@ -701,8 +701,8 @@ class TeamsActionHandler {
 	public function getpublicteams($dispatcher, &$reqData, &$out) {
 	 	global $psdb, $teams;
 
-		$pagesize = min($MAXPAGESIZE, intval(@$reqData['pagesize']));
-		$pagesize = $pagesize == 0 ? $MAXPAGESIZE : $pagesize;
+		$pagesize = min(self::MAXPAGESIZE, intval(@$reqData['pagesize']));
+		$pagesize = $pagesize == 0 ? self::MAXPAGESIZE : $pagesize;
 		$page = intval(@$reqData['page']);
 		if($pagesize <= 0 || $page < 0) {
 			$out = 0;

--- a/lib/dispatcher.lib.php
+++ b/lib/dispatcher.lib.php
@@ -681,7 +681,7 @@ class TeamsActionHandler {
 
 	/**
 	 * Uploads a new team. out is 0 for args error, 1 for duplicate, 2 for success.
-	 * Mandatory request args: teamname, format, packedteam, public (int either 0 or 1)
+	 * Mandatory request args: userid, teamname, format, packedteam, public (int either 0 or 1)
 	 * Server only.
 	 */
 	public function uploadteam($dispatcher, &$reqData, &$out) {

--- a/lib/dispatcher.lib.php
+++ b/lib/dispatcher.lib.php
@@ -603,9 +603,8 @@ class LadderActionHandler {
 class TeamsActionHandler {
 	const MAXPAGESIZE = 50;
 	/**
-	 * Fetches all published teams uploaded by the user.
-	 * Mandatory request args: userid: user id; page, pagesize: control the range of data that is returned.
-	 * Server only.
+	 * Fetches all published teams uploaded by the user (must be logged in).
+	 * Mandatory request args: page, pagesize: control the range of data that is returned.
 	 */
 	public function getuploadedteams($dispatcher, &$reqData, &$out) {
 		global $psdb, $teams, $curuser;
@@ -631,9 +630,8 @@ class TeamsActionHandler {
 	}
 
 	/**
-	 * Fetches all teams shared with the user.
-	 * Mandatory request args: userid: user id; page, pagesize: control the range of data that is returned.
-	 * Server only.
+	 * Fetches all teams shared with the user (must be logged in).
+	 * Mandatory request args: page, pagesize: control the range of data that is returned.
 	 */
 	public function getsharedteams($dispatcher, &$reqData, &$out) {
 	 	global $psdb, $teams, $curuser;
@@ -662,7 +660,6 @@ class TeamsActionHandler {
 	/**
 	 * Fetches all public teams.
 	 * Mandatory request args: page, pagesize: control the range of data that is returned.
-	 * Server only.
 	 */
 
 	public function getpublicteams($dispatcher, &$reqData, &$out) {
@@ -726,7 +723,7 @@ class TeamsActionHandler {
 	/**
 	 * Shares a team with a player. 1 = user doesn't own the team. 2 = success.
 	 * Mandatory request args: ownerid: owner's id; teamid: team id; userid: user to share with
-	 * Server only
+	 * Server only.
 	 */
 	public function shareteam($dispatcher, &$reqData, &$out) {
 	 	global $psdb, $teams;

--- a/lib/ntbb-sharelist.sql
+++ b/lib/ntbb-sharelist.sql
@@ -1,0 +1,10 @@
+-- Database: showdown
+
+--
+-- Table structure for table `ntbb_sharelist`
+--
+
+CREATE TABLE IF NOT EXISTS `ntbb_sharelist` (
+    `teamid` bigint NOT NULL,
+    `userid` varbinary(255) NOT NULL
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/lib/ntbb-teams.sql
+++ b/lib/ntbb-teams.sql
@@ -1,0 +1,16 @@
+-- Database: showdown
+
+--
+-- Table structure for table `ntbb_teams`
+--
+
+CREATE TABLE IF NOT EXISTS `ntbb_teams` (
+    `teamid` bigint NOT NULL AUTO_INCREMENT,
+    `ownerid` varbinary(255) NOT NULL,
+    `teamname` varbinary(255) NOT NULL,
+    `format` varbinary(255) NOT NULL,
+    `packedteam` text NOT NULL,
+    `public` boolean NOT NULL,
+    PRIMARY KEY (`teamid`),
+    KEY `ownerid` (`ownerid`)
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Database/backend part of #1417. See also the PR on the game server side that uses the `uploadteam` and `shareteam` actions: smogon/pokemon-showdown#6140.

This PR adds five new actions for the login server, which all relate to storing teams in a database. It also includes schemas for new tables that would store teams and team-related information. The actions are:

- `getuploadedteams`: Gets the user's uploaded teams. User must be logged in.
- `getsharedteams`: Gets teams shared directly with the user. User must be logged in.
- `getpublicteams`: Gets teams public to everyone.

The above three actions are all available directly to the client, and they are all paged -- the server enforces a maximum page size of 50, so the user can only fetch 50 teams per request. This is to prevent against the user downloading a ton of teams from the server all at once. 

- `uploadteam`: Upload a new team to the team database.
- `shareteam`: Share one user's team with a different user.

The above two actions are server-only; if the client attempts them they will immediately fail. This is to prevent against the user being able to add arbitrary stuff to the DB tables. The game server will prevent against invalid teams for given format being uploaded and other forms of invalid input.

`ntbb_teams` and `ntbb_sharelist` are the two tables that should be added to the PS database in order for these actions to work.

This is a first crack, future improvements would probably relate to filtering options for the `getXXXteams` actions (i.e. filter by username, teamname, pokemon, ...).