### PR TITLE
Added favoriting system

### DIFF
--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -52,7 +52,7 @@
 
 			buf += '<div class="menugroup"><p><button class="button mainmenu4 onlineonly disabled" name="joinRoom" value="battles">Watch a battle</button></p>';
 			buf += '<p><button class="button mainmenu5 onlineonly disabled" name="finduser">Find a user</button></p>';
-			buf += '<p><button class="button mainmenu7 onlineonly disabled" name="favoritedUsers">Favorited users</button></p></div>'
+			buf += '<p><button class="button mainmenu7 onlineonly disabled" name="favoritedUsers">Favorited users</button></p></div>';
 
 			this.$('.mainmenu').html(buf);
 
@@ -982,10 +982,9 @@
 			var $usernames = $favUserWindow.find('.pm-log');
 
 			var buf = "";
-			for (var i = 0 ; i < Storage.favedUsers.length; i++)
-			{
+			for (var i = 0; i < Storage.favedUsers.length; i++) {
 				var color = BattleLog.hashColor(toID(Storage.favedUsers[i]));
-				buf += '<div class="favUser"><strong style="' + color + '"><span class="username" data-roomgroup=" " data-name="' + Storage.favedUsers[i] + '">'  + Storage.favedUsers[i] + '</span></strong></div>';
+				buf += '<div class="favUser"><strong style="' + color + '"><span class="username" data-roomgroup=" " data-name="' + Storage.favedUsers[i] + '">' + Storage.favedUsers[i] + '</span></strong></div>';
 			}
 			$usernames.empty();
 			$usernames.append(buf);

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -964,7 +964,7 @@
 				var buf = '<div class="pm-window fav-user-window">';
 				buf += '<h3><button class="closebutton" tabindex="-1" aria-label="Close"><i class="fa fa-times-circle"></i></button>';
 				buf += '<button class="minimizebutton tabindex="-1" aria-label="Minimize"><i class="fa fa-minus-circle"></i></button>';
-				buf += 'Favourited Users</h3>';
+				buf += 'Favorited Users</h3>';
 				buf += '<div id="favorited-users" class="pm-log">';
 				buf += '</div></div>';
 				$favUserWindow = $(buf).appendTo(this.$pmBox);

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -2,6 +2,7 @@
 
 	this.MainMenuRoom = this.Room.extend({
 		type: 'mainmenu',
+		title: 'mainmenu',
 		tinyWidth: 340,
 		bestWidth: 628,
 		events: {
@@ -50,7 +51,8 @@
 			buf += '<p><button class="button mainmenu3" name="joinRoom" value="ladder">Ladder</button></p></div>';
 
 			buf += '<div class="menugroup"><p><button class="button mainmenu4 onlineonly disabled" name="joinRoom" value="battles">Watch a battle</button></p>';
-			buf += '<p><button class="button mainmenu5 onlineonly disabled" name="finduser">Find a user</button></p></div>';
+			buf += '<p><button class="button mainmenu5 onlineonly disabled" name="finduser">Find a user</button></p>';
+			buf += '<p><button class="button mainmenu7 onlineonly disabled" name="favoritedUsers">Favorited users</button></p></div>'
 
 			this.$('.mainmenu').html(buf);
 
@@ -953,8 +955,43 @@
 				}
 				app.addPopup(UserPopup, {name: target});
 			});
-		}
+		},
+
+		favoritedUsers: function () {
+			Storage.getUsers();
+			var $favUserWindow = this.$pmBox.find('.fav-user-window');
+			if (!$favUserWindow.length) {
+				var buf = '<div class="pm-window fav-user-window">';
+				buf += '<h3><button class="closebutton" tabindex="-1" aria-label="Close"><i class="fa fa-times-circle"></i></button>';
+				buf += '<button class="minimizebutton tabindex="-1" aria-label="Minimize"><i class="fa fa-minus-circle"></i></button>';
+				buf += 'Favourited Users</h3>';
+				buf += '<div id="favorited-users" class="pm-log">';
+				buf += '</div></div>';
+				$favUserWindow = $(buf).appendTo(this.$pmBox);
+				MainMenuRoom.refreshFavUsers();
+			} else {
+				$favUserWindow.show();
+			}
+		},
+
 	}, {
+		refreshFavUsers: function () {
+			var $activityMenu = $('.activitymenu');
+			var $pmBox = $activityMenu.find('.pmbox');
+			var $favUserWindow = $pmBox.find('.fav-user-window');
+			var $usernames = $favUserWindow.find('.pm-log');
+
+			var buf = "";
+			for (var i = 0 ; i < Storage.favedUsers.length; i++)
+			{
+				var color = BattleLog.hashColor(toID(Storage.favedUsers[i]));
+				buf += '<div class="favUser"><strong style="' + color + '"><span class="username" data-roomgroup=" " data-name="' + Storage.favedUsers[i] + '">'  + Storage.favedUsers[i] + '</span></strong></div>';
+			}
+			$usernames.empty();
+			$usernames.append(buf);
+
+		},
+
 		parseChatMessage: function (message, name, timestamp, isHighlighted, $chatElem) {
 			var showMe = !((Dex.prefs('chatformatting') || {}).hideme);
 			var group = ' ';

--- a/js/client.js
+++ b/js/client.js
@@ -2584,16 +2584,15 @@ function toId() {
 			app.addPopup(AvatarsPopup);
 		},
 
-		toggleFavorite: function() {
-			if(!Storage.favedUsers.includes(this.data.name)) {
+		toggleFavorite: function () {
+			if (!Storage.favedUsers.includes(this.data.name)) {
 				console.log("ADD " + this.data.name);
-				
+
 				Storage.addUser(this.data.name);
 				Storage.getUsers();
 				this.update();
 				console.log(Storage.favedUsers);
-			}
-			else {
+			} else {
 				console.log("REMOVE " + this.data.name);
 				Storage.removeUser(this.data.name);
 				Storage.getUsers();

--- a/js/client.js
+++ b/js/client.js
@@ -2559,13 +2559,14 @@ function toId() {
 
 			buf += '<p class="buttonbar">';
 			if (userid === app.user.get('userid') || !app.user.get('named')) {
-				buf += '<button disabled>Challenge</button> <button disabled>Chat</button>';
+				buf += '<button disabled>Favorite</button> <button disabled>Challenge</button> <button disabled>Chat</button>';
 				if (userid === app.user.get('userid')) {
 					buf += '</p><hr /><p class="buttonbar" style="text-align: right">';
 					buf += '<button name="login"><i class="fa fa-pencil"></i> Change name</button> <button name="logout"><i class="fa fa-power-off"></i> Log out</button>';
 				}
 			} else {
-				buf += '<button name="challenge">Challenge</button> <button name="pm">Chat</button> <button name="userOptions">\u2026</button>';
+				Storage.getUsers();
+				buf += '<button name="toggleFavorite">' + (Storage.favedUsers.includes(this.data.name) ? 'Unfavorite' : 'Favorite') + '</button> <button name="challenge">Challenge</button> <button name="pm">Chat</button> <button name="userOptions">\u2026</button>';
 			}
 			buf += '</p>';
 
@@ -2582,6 +2583,26 @@ function toId() {
 		avatars: function () {
 			app.addPopup(AvatarsPopup);
 		},
+
+		toggleFavorite: function() {
+			if(!Storage.favedUsers.includes(this.data.name)) {
+				console.log("ADD " + this.data.name);
+				
+				Storage.addUser(this.data.name);
+				Storage.getUsers();
+				this.update();
+				console.log(Storage.favedUsers);
+			}
+			else {
+				console.log("REMOVE " + this.data.name);
+				Storage.removeUser(this.data.name);
+				Storage.getUsers();
+				this.update();
+				console.log(Storage.favedUsers);
+			}
+			MainMenuRoom.refreshFavUsers();
+		},
+
 		challenge: function () {
 			app.rooms[''].requestNotifications();
 			this.close();

--- a/js/storage.js
+++ b/js/storage.js
@@ -539,6 +539,64 @@ Storage.initTestClient = function () {
 	});
 };
 
+//Saved users
+Storage.favedUsers = [];
+Storage.addUser = function(user){
+	if (localStorage.getItem('saved_users') != null)
+	{
+		Storage.favedUsers = JSON.parse(localStorage.getItem('saved_users'));
+	}
+	Storage.favedUsers.push(user);
+	console.log(localStorage.getItem('saved_users'));
+	try {
+		if (window.localStorage) {
+			console.log("SAVED");
+			localStorage.setItem('saved_users', JSON.stringify(Storage.favedUsers));
+			Storage.cantSave = false;
+		}
+	} catch (e) {
+		console.log("NOT SAVED");
+		if (e.code === DOMException.QUOTA_EXCEEDED_ERR) {
+			Storage.cantSave = true;
+		} else {
+			throw e;
+		}
+	}
+};
+Storage.removeUser = function(user){
+	if (localStorage.getItem('saved_users') != null)
+	{
+		Storage.favedUsers = JSON.parse(localStorage.getItem('saved_users'));
+	}
+	var index = Storage.favedUsers.indexOf(user);
+	if (index > -1)
+	{
+		Storage.favedUsers.splice(index, 1);
+	}
+	try {
+		if (window.localStorage) {
+			console.log("REMOVED");
+			localStorage.setItem('saved_users', JSON.stringify(Storage.favedUsers));
+			Storage.cantSave = false;
+		}
+	} catch (e) {
+		console.log("NOT REMOVED");
+		if (e.code === DOMException.QUOTA_EXCEEDED_ERR) {
+			Storage.cantSave = true;
+		} else {
+			throw e;
+		}
+	}
+};
+
+Storage.getUsers = function() {
+	Storage.favedUsers = JSON.parse(localStorage.getItem('saved_users'));
+	if (Storage.favedUsers == null)
+	{
+		Storage.favedUsers = [];
+	}
+}
+
 /*********************************************************
  * Teams
  *********************************************************/

--- a/js/storage.js
+++ b/js/storage.js
@@ -541,9 +541,8 @@ Storage.initTestClient = function () {
 
 //Saved users
 Storage.favedUsers = [];
-Storage.addUser = function(user){
-	if (localStorage.getItem('saved_users') != null)
-	{
+Storage.addUser = function (user) {
+	if (localStorage.getItem('saved_users') != null) {
 		Storage.favedUsers = JSON.parse(localStorage.getItem('saved_users'));
 	}
 	Storage.favedUsers.push(user);
@@ -563,14 +562,12 @@ Storage.addUser = function(user){
 		}
 	}
 };
-Storage.removeUser = function(user){
-	if (localStorage.getItem('saved_users') != null)
-	{
+Storage.removeUser = function (user) {
+	if (localStorage.getItem('saved_users') != null) {
 		Storage.favedUsers = JSON.parse(localStorage.getItem('saved_users'));
 	}
 	var index = Storage.favedUsers.indexOf(user);
-	if (index > -1)
-	{
+	if (index > -1) {
 		Storage.favedUsers.splice(index, 1);
 	}
 	try {
@@ -589,13 +586,12 @@ Storage.removeUser = function(user){
 	}
 };
 
-Storage.getUsers = function() {
+Storage.getUsers = function () {
 	Storage.favedUsers = JSON.parse(localStorage.getItem('saved_users'));
-	if (Storage.favedUsers == null)
-	{
+	if (Storage.favedUsers == null) {
 		Storage.favedUsers = [];
 	}
-}
+};
 
 /*********************************************************
  * Teams

--- a/style/client.css
+++ b/style/client.css
@@ -1048,6 +1048,12 @@ p.or:after {
 	background: #f8f8f8;
 	color: #222222;
 }
+
+.favUser {
+	margin: 2px;
+	padding-left: 5px;
+}
+
 .challenge {
 	margin-top: -1px;
 	background: #fcd2b3;
@@ -1182,6 +1188,10 @@ p.or:after {
 .button.mainmenu6 { background: linear-gradient(to bottom,  hsl(270,40%,72%),  hsl(270,40%,52%)); border-color: hsl(270,40%,40%); }
 .button.mainmenu6:hover { background: linear-gradient(to bottom,  hsl(270,40%,62%),  hsl(270,40%,42%)); }
 .button.mainmenu6:active { background: linear-gradient(to bottom,  hsl(270,40%,42%),  hsl(300,40%,58%)); }
+
+.button.mainmenu7 { background: linear-gradient(to bottom,  hsl(270,40%,72%),  hsl(270,40%,52%)); border-color: hsl(270,40%,40%); }
+.button.mainmenu7:hover { background: linear-gradient(to bottom,  hsl(270,40%,62%),  hsl(270,40%,42%)); }
+.button.mainmenu7:active { background: linear-gradient(to bottom,  hsl(270,40%,42%),  hsl(300,40%,58%)); }
 
 .rightmenu {
 	width: 294px;


### PR DESCRIPTION
Pull request for issue #6158

I created a feature where users can 'favorite' other users which allows them to be quickly found later, without having to search up their username.
The favorited users are stored in local storage and parsed into an array when needed.

![favebuttonadded](https://user-images.githubusercontent.com/54869235/70367681-39011f00-1870-11ea-8697-14f97d38666e.JPG)
![favebuttontoggles](https://user-images.githubusercontent.com/54869235/70367682-43bbb400-1870-11ea-82c1-53cd8bb56c0c.JPG)
I added a favorite/unfavorite button to the user popup which toggles depending on if the selected user is already favorited.

![viewallfave](https://user-images.githubusercontent.com/54869235/70367698-72398f00-1870-11ea-9770-d258f708d52b.JPG)
I also added a button under "Find a user" to display all your favorited users. I copied the css properties of button6 to this button and named it button7 since I noticed that 6 wasn't being used but I wasn't sure if i should attach my own feature to it.

![viewallfavewindow](https://user-images.githubusercontent.com/54869235/70367816-d90b7800-1871-11ea-943e-a2480910f15a.JPG)
![viewallfavpopup](https://user-images.githubusercontent.com/54869235/70367817-dc066880-1871-11ea-9896-ba0f64ffc6e4.JPG)
Clicking the button opens a pm style window under the news window which shows all the saved usernames. Clicking them opens the user popup like the other instances of username.
The list also updates itself when a user is added or removed.
