### PR TITLE
Teambuilder: Import teams from pokepast.es or gist urls

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -1092,7 +1092,7 @@
 					buf += '<li><button name="undeleteSet"><i class="fa fa-undo"></i> Undo Delete</button></li>';
 				}
 				if (i === 0) {
-					buf += '<li><button name="import" class="button big"><i class="fa fa-upload"></i> Import from text</button></li>';
+					buf += '<li><button name="import" class="button big"><i class="fa fa-upload"></i> Import from text or URL</button></li>';
 				}
 				if (i < 6) {
 					buf += '<li><button name="addPokemon" class="button big"><i class="fa fa-plus"></i> Add Pok&eacute;mon</button></li>';
@@ -1228,6 +1228,7 @@
 						self.back();
 					},
 					error: function () {
+						app.addPopupMessage("Could not fetch a team from this URL. Make sure you copied the full link, or paste the team in by hand.");
 						self.$('.teamedit textarea, .teamedit .savebutton').attr('disabled', null);
 					}
 				});

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -1213,8 +1213,43 @@
 		},
 
 		saveImport: function () {
-			Storage.activeSetList = this.curSetList = Storage.importTeam(this.$('.teamedit textarea').val());
-			this.back();
+			var text = this.$('.teamedit textarea').val();
+			var url = this.importableUrl(text);
+
+			if (url) {
+				this.$('.teamedit textarea, .teamedit .savebutton').attr('disabled', true);
+				var self = this;
+				$.ajax({
+					type: 'GET',
+					url: url,
+					success: function (data) {
+						Storage.activeSetList = self.curSetList = Storage.importTeam(data);
+						self.$('.teamedit textarea, .teamedit .savebutton').attr('disabled', null);
+						self.back();
+					},
+					error: function () {
+						self.$('.teamedit textarea, .teamedit .savebutton').attr('disabled', null);
+					}
+				});
+			} else {
+				Storage.activeSetList = this.curSetList = Storage.importTeam(text);
+				this.back();
+			}
+		},
+		importableUrl: function (value) {
+			var match = value.match(/^https?:\/\/(pokepast\.es|gist\.github(?:usercontent)?\.com)\/(.*)\s*$/);
+			if (!match) return;
+
+			var host = match[1];
+			var path = match[2];
+
+			switch (host) {
+			case 'pokepast.es':
+				return 'https://pokepast.es/' + path.replace(/\/.*/, '') + '/raw';
+			default: // gist
+				var split = path.split('/');
+				return split.length < 2 ? undefined : 'https://gist.githubusercontent.com/' + split[0] + '/' + split[1] + '/raw';
+			}
 		},
 		addPokemon: function () {
 			if (!this.curTeam) return;


### PR DESCRIPTION
This PR is based on https://github.com/smogon/pokemon-showdown-client/issues/1349, which is a feature I've wanted for some time myself. It only attempts to import if a valid-looking URL is the *only* thing in the team textbox, and it only looks for a single URL. I figure this meets 95% of actual use, and so is a good place to start.

I've attempted to match the style of the surrounding code, but please let me know if there's a different preferred style for anything.

I used $.ajax rather than $.get in order to bypass the testclient CORS helper - it doesn't play nicely with multiline return values. Due to the fact that pokepast.es insists on https, you'll also have to either host testclient.html on https localhost, or temporarily disable your browser's content security policy. This of shouldn't be an issue when it's on a real server, but it does unfortunately make it a pain to work with locally.