### PR TITLE
Fix import of smogon sets

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -1528,6 +1528,9 @@
 				this.importSetButtons();
 				return;
 			}
+			// We fetch this as 'text' and JSON.parse it ourserves in order to have consistent behavior
+			// between the localdev CORS helper and the real jQuery.get function, which would already parse
+			// this into an object based on the content-type header.
 			$.get('https://play.pokemonshowdown.com/data/sets/' + format + '.json', {}, function (data) {
 				try {
 					self.smogonSets[format] = JSON.parse(data);
@@ -1537,7 +1540,7 @@
 					self.smogonSets[format] = false;
 				}
 				self.importSetButtons();
-			});
+			}, 'text');
 		},
 		importSetButtons: function () {
 			var formatSets = this.smogonSets[this.curTeam.format];


### PR DESCRIPTION
The code comment should explain what went wrong and how it's fixed.

Basically, I forgot that jQuery - trying to be helpful - would parse the response into an object unless asked not to.  Inconsistency between the CORs helper and the actual implementation.