### PR TITLE
Fix unreleased hidden abilities in past gens

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -767,15 +767,6 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 		BattleTeambuilderTable[gen].overrideHiddenAbility = overrideHiddenAbility;
 		const removeSecondAbility = {};
 		BattleTeambuilderTable[gen].removeSecondAbility = removeSecondAbility;
-		const unreleasedHiddenAbility = {};
-		BattleTeambuilderTable[gen].unreleasedHiddenAbility = unreleasedHiddenAbility;
-		for (const id in genData.FormatsData) {
-			const pastEntry = genData.FormatsData[id];
-			unreleasedHiddenAbility[id] = true;
-			if (!pastEntry.unreleasedHidden) {
-				unreleasedHiddenAbility[id] = false;
-			}
-		}
 		for (const id in genData.Pokedex) {
 			const pastEntry = genData.Pokedex[id];
 			const nowEntry = Dex.data.Pokedex[id];

--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -771,9 +771,9 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 		BattleTeambuilderTable[gen].unreleasedHiddenAbility = unreleasedHiddenAbility;
 		for (const id in genData.FormatsData) {
 			const pastEntry = genData.FormatsData[id];
-			unreleasedHiddenAbility[id] = true; 
+			unreleasedHiddenAbility[id] = true;
 			if (!pastEntry.unreleasedHidden) {
-				unreleasedHiddenAbility[id] = false; 
+				unreleasedHiddenAbility[id] = false;
 			}
 		}
 		for (const id in genData.Pokedex) {

--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -767,6 +767,15 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 		BattleTeambuilderTable[gen].overrideHiddenAbility = overrideHiddenAbility;
 		const removeSecondAbility = {};
 		BattleTeambuilderTable[gen].removeSecondAbility = removeSecondAbility;
+		const unreleasedHiddenAbility = {};
+		BattleTeambuilderTable[gen].unreleasedHiddenAbility = unreleasedHiddenAbility;
+		for (const id in genData.FormatsData) {
+			const pastEntry = genData.FormatsData[id];
+			unreleasedHiddenAbility[id] = true; 
+			if (!pastEntry.unreleasedHidden) {
+				unreleasedHiddenAbility[id] = false; 
+			}
+		}
 		for (const id in genData.Pokedex) {
 			const pastEntry = genData.Pokedex[id];
 			const nowEntry = Dex.data.Pokedex[id];

--- a/js/search.js
+++ b/js/search.js
@@ -1386,7 +1386,7 @@
 
 		var gen = this.gen;
 		var table = (gen < 8 ? BattleTeambuilderTable['gen' + gen] : null);
-
+		
 		// type
 		buf += '<span class="col typecol">';
 		var types = pokemon.types;
@@ -1406,10 +1406,17 @@
 				buf += '<span class="col abilitycol">' + abilities['0'] + '</span>';
 			}
 			if (gen >= 5) {
+				var unreleasedHidden = pokemon.unreleasedHidden;
+				if (table && id in table.unreleasedHiddenAbility) {
+					unreleasedHidden = table.unreleasedHiddenAbility[id];
+				}
+				if (this.isNatDex && pokemon.unreleasedHidden === "Past") {
+					unreleasedHidden = false;
+				}
 				if (abilities['S']) {
-					buf += '<span class="col twoabilitycol' + (pokemon.unreleasedHidden ? ' unreleasedhacol' : '') + '">' + (abilities['H'] || '') + '<br />' + abilities['S'] + '</span>';
+					buf += '<span class="col twoabilitycol' + (unreleasedHidden ? ' unreleasedhacol' : '') + '">' + (abilities['H'] || '') + '<br />' + abilities['S'] + '</span>';
 				} else if (abilities['H']) {
-					buf += '<span class="col abilitycol' + (pokemon.unreleasedHidden ? ' unreleasedhacol' : '') + '">' + abilities['H'] + '</span>';
+					buf += '<span class="col abilitycol' + (unreleasedHidden ? ' unreleasedhacol' : '') + '">' + abilities['H'] + '</span>';
 				} else {
 					buf += '<span class="col abilitycol"></span>';
 				}

--- a/js/search.js
+++ b/js/search.js
@@ -1407,12 +1407,7 @@
 			}
 			if (gen >= 5) {
 				var unreleasedHidden = pokemon.unreleasedHidden;
-				if (table && id in table.unreleasedHiddenAbility) {
-					unreleasedHidden = table.unreleasedHiddenAbility[id];
-				}
-				if (this.isNatDex && pokemon.unreleasedHidden === "Past") {
-					unreleasedHidden = false;
-				}
+				if (unreleasedHidden === 'Past' && (this.isNatDex || gen < 8)) unreleasedHidden = false;
 				if (abilities['S']) {
 					buf += '<span class="col twoabilitycol' + (unreleasedHidden ? ' unreleasedhacol' : '') + '">' + (abilities['H'] || '') + '<br />' + abilities['S'] + '</span>';
 				} else if (abilities['H']) {

--- a/js/search.js
+++ b/js/search.js
@@ -1386,7 +1386,7 @@
 
 		var gen = this.gen;
 		var table = (gen < 8 ? BattleTeambuilderTable['gen' + gen] : null);
-		
+
 		// type
 		buf += '<span class="col typecol">';
 		var types = pokemon.types;

--- a/src/battle-dex-data.ts
+++ b/src/battle-dex-data.ts
@@ -1338,8 +1338,12 @@ class Template implements Effect {
 	readonly isPrimal: boolean;
 	readonly battleOnly: boolean;
 	readonly isNonstandard: string | null;
+<<<<<<< HEAD
 	readonly unreleasedHidden: boolean;
 	readonly inheritsFrom: string | null;
+=======
+	readonly unreleasedHidden: boolean | 'Past';
+>>>>>>> Fix unreleased hidden abilities in past gens
 
 	constructor(id: ID, name: string, data: any) {
 		if (!data || typeof data !== 'object') data = {};
@@ -1419,8 +1423,12 @@ class Template implements Effect {
 		this.isPrimal = false;
 		this.battleOnly = !!data.battleOnly;
 		this.isNonstandard = data.isNonstandard || null;
+<<<<<<< HEAD
 		this.unreleasedHidden = !!data.unreleasedHidden;
 		this.inheritsFrom = (Array.isArray(data.inheritsFrom) ? this.baseSpecies : data.inheritsFrom) || null;
+=======
+		this.unreleasedHidden = data.unreleasedHidden || false;
+>>>>>>> Fix unreleased hidden abilities in past gens
 		if (!this.gen) {
 			if (this.num >= 810 || this.forme === 'Galar' || this.isGigantamax) {
 				this.gen = 8;

--- a/src/battle-dex-data.ts
+++ b/src/battle-dex-data.ts
@@ -1338,12 +1338,8 @@ class Template implements Effect {
 	readonly isPrimal: boolean;
 	readonly battleOnly: boolean;
 	readonly isNonstandard: string | null;
-<<<<<<< HEAD
-	readonly unreleasedHidden: boolean;
-	readonly inheritsFrom: string | null;
-=======
 	readonly unreleasedHidden: boolean | 'Past';
->>>>>>> Fix unreleased hidden abilities in past gens
+	readonly inheritsFrom: string | null;
 
 	constructor(id: ID, name: string, data: any) {
 		if (!data || typeof data !== 'object') data = {};
@@ -1423,12 +1419,8 @@ class Template implements Effect {
 		this.isPrimal = false;
 		this.battleOnly = !!data.battleOnly;
 		this.isNonstandard = data.isNonstandard || null;
-<<<<<<< HEAD
-		this.unreleasedHidden = !!data.unreleasedHidden;
-		this.inheritsFrom = (Array.isArray(data.inheritsFrom) ? this.baseSpecies : data.inheritsFrom) || null;
-=======
 		this.unreleasedHidden = data.unreleasedHidden || false;
->>>>>>> Fix unreleased hidden abilities in past gens
+		this.inheritsFrom = (Array.isArray(data.inheritsFrom) ? this.baseSpecies : data.inheritsFrom) || null;
 		if (!this.gen) {
 			if (this.num >= 810 || this.forme === 'Galar' || this.isGigantamax) {
 				this.gen = 8;


### PR DESCRIPTION
Currently, Pokemon with no access to their hidden ability in gen 8 (such as clefable) can still use them in gen 7, etc; however, the teambuilder still crosses them out.