### PR TITLE
Switch Aura Wheel display type when Morpeko-Hangry

### DIFF
--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -1172,14 +1172,14 @@ class BattleTooltips {
 		}
 
 		// Aura Wheel as Morpeko-Hangry changes the type to Dark
-		if(move.id === 'aurawheel') {
-			if(value.pokemon.getTemplate().species === 'Morpeko-Hangry') {
+		if (move.id === 'aurawheel') {
+			if (value.pokemon.getTemplate().species === 'Morpeko-Hangry') {
 				moveType = 'Dark';
 			} else {
 				moveType = 'Electric';
 			}
 		}
-		
+
 		// Other abilities that change the move type.
 		const noTypeOverride = [
 			'judgment', 'multiattack', 'naturalgift', 'revelationdance', 'struggle', 'technoblast', 'weatherball',

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -1170,6 +1170,16 @@ class BattleTooltips {
 				break;
 			}
 		}
+
+		// Aura Wheel as Morpeko-Hangry changes the type to Dark
+		if(move.id === 'aurawheel') {
+			if(value.pokemon.getTemplate().species === 'Morpeko-Hangry') {
+				moveType = 'Dark';
+			} else {
+				moveType = 'Electric';
+			}
+		}
+		
 		// Other abilities that change the move type.
 		const noTypeOverride = [
 			'judgment', 'multiattack', 'naturalgift', 'revelationdance', 'struggle', 'technoblast', 'weatherball',


### PR DESCRIPTION
Just a quick change to display Aura Wheel as Dark type when in Morpeko-Hangry form. It already calcs the move as Dark type, but in the move selection it showed as Electric type and that could confuse some players. 
If there's anything that needs to change or if this is not a valid feature let me know, this is my first time contributing to the repo =D