### PR TITLE
Fix teambuilder tiers for previous generations

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -34,8 +34,7 @@
 		this.cur = {};
 		this.$inputEl = null;
 		this.gen = 8;
-		this.isDoubles = false;
-		this.isNatDex = false;
+		this.mod = null;
 
 		var self = this;
 		this.$el.on('click', '.more button', function (e) {
@@ -796,13 +795,16 @@
 		} else if (!format) {
 			this.gen = 8;
 		}
-		if (format.includes('doubles')) this.isDoubles = true;
+		if (format.includes('doubles')) this.mod = 'doubles';
 		var isLetsGo = format.startsWith('letsgo');
-		if (isLetsGo) format = format.slice(6);
+		if (isLetsGo) {
+			format = format.slice(6);
+			this.mod = 'letsgo';
+		}
 		var isNatDex = format.startsWith('nationaldex');
 		if (isNatDex) {
 			format = format.slice(11);
-			this.isNatDex = true;
+			this.mod = 'natdex';
 			if (!format) format = 'ou';
 		}
 		var requirePentagon = (format === 'battlespotsingles' || format === 'battledoubles' || format.slice(0, 3) === 'vgc');
@@ -1344,13 +1346,13 @@
 		// buf += '<span class="col numcol">' + (pokemon.num >= 0 ? pokemon.num : 'CAP') + '</span> ';
 		var tier;
 		if (pokemon.tier) {
-			tier = Dex.getTier(Dex.forGen(this.gen).getTemplate(id), this.gen, this.isDoubles);
+			tier = Dex.getTier(pokemon.species, this.gen, this.mod);
 		} else if (pokemon.forme && pokemon.forme.endsWith('Totem')) {
-			tier = Dex.getTier(Dex.forGen(this.gen).getTemplate(pokemon.species.slice(0, (pokemon.forme.startsWith('Alola') ? -6 : pokemon.baseSpecies.length + 1))), this.gen, this.isDoubles);
+			tier = Dex.getTier(pokemon.species.slice(0, (pokemon.forme.startsWith('Alola') ? -6 : pokemon.baseSpecies.length + 1)), this.gen, this.mod);
 		} else {
-			tier = Dex.getTier(Dex.forGen(this.gen).getTemplate(pokemon.baseSpecies), this.gen, this.isDoubles);
+			tier = Dex.getTier(pokemon.baseSpecies, this.gen, this.mod);
 		}
-		if (this.isNatDex) tier = (pokemon.num >= 0 ? pokemon.num : 'CAP');
+		if (this.mod === 'natdex') tier = (pokemon.num >= 0 ? pokemon.num : 'CAP');
 		buf += '<span class="col numcol">' + tier + '</span> ';
 
 		// icon

--- a/src/battle-dex.ts
+++ b/src/battle-dex.ts
@@ -443,29 +443,27 @@ const Dex = new class implements ModdedDex {
 		return template;
 	}
 
-	/** @deprecated */
-	getTier(pokemon: Template, gen = 7, isDoubles = false): string {
-		if (gen < 8) pokemon = this.forGen(gen).getTemplate(pokemon.id);
-		if (!isDoubles) return pokemon.tier;
+	getTier(pokemon: string, genNum = 8, mod?: string): string {
+		let template = this.getTemplate(pokemon);
+		if (genNum < 8) template = this.forGen(genNum).getTemplate(pokemon);
 		let table = window.BattleTeambuilderTable;
-		if (table && table[`gen${this.gen}doubles`]) {
-			table = table[`gen${this.gen}doubles`];
+		if (!table) return template.tier;
+		if (mod === 'doubles') {
+			table = table[`gen${genNum}doubles`];
+		} else if (genNum < 8) {
+			table = table[`gen${genNum}`];
+		} else if (mod && table[toID(mod)]) {
+			table = table[toID(mod)];
 		}
-		if (!table) return pokemon.tier;
 
-		let id = pokemon.id;
+		if (!table.overrideTier) return template.tier;
+
+		let id = template.id;
 		if (id in table.overrideTier) {
 			return table.overrideTier[id];
 		}
-		if (id.slice(-5) === 'totem' && id.slice(0, -5) in table.overrideTier) {
-			return table.overrideTier[id.slice(0, -5)];
-		}
-		id = toID(pokemon.baseSpecies);
-		if (id in table.overrideTier) {
-			return table.overrideTier[id];
-		}
 
-		return pokemon.tier;
+		return template.tier;
 	}
 
 	getType(type: any): Effect {

--- a/src/battle-dex.ts
+++ b/src/battle-dex.ts
@@ -443,6 +443,7 @@ const Dex = new class implements ModdedDex {
 		return template;
 	}
 
+	/** @deprecated */
 	getTier(pokemon: string, genNum = 8, mod?: string): string {
 		let template = this.getTemplate(pokemon);
 		if (genNum < 8) template = this.forGen(genNum).getTemplate(pokemon);


### PR DESCRIPTION
This fixes the issue where Pokemon in past-gens doubles formats would have their tiers display as their gen 8 singles tiers (corsola in gen 4 doubles would display as unreleased) and also where Mega Pokemon in past gens would have their tiers appear as their base forme's