### PR TITLE
(Really) maximize Attack IVs if Transform is the sole move

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2963,7 +2963,15 @@
 				var move = Dex.forGen(this.curTeam.gen).getMove(moves[i]);
 				if (move.id === 'transform') {
 					hasHiddenPower = true; // A Pokemon with Transform can copy another Pokemon that knows Hidden Power
-					if (moves.length === 1) minAtk = false;
+
+					var hasMoveBesidesTransform = false;
+					for (var j = 0; j < moves.length; ++j) {
+						if (j !== i && moves[j]) {
+							hasMoveBesidesTransform = true;
+							break;
+						}
+					}
+					if (!hasMoveBesidesTransform) minAtk = false;
 				} else if (move.category === 'Physical' &&
 						!move.damage && !move.ohko && move.id !== 'rapidspin' && move.id !== 'foulplay' && move.id !== 'endeavor' && move.id !== 'counter') {
 					minAtk = false;


### PR DESCRIPTION
I noticed that #1442 did not seem to be working properly. This is because `moves` is always a length 4 array, ie. it's represented as `["Transform", "", "", ""]` rather than `["Transform"]`.