### PR TITLE
Add Heavy Duty Boots, Expert Belt, and Room Service to Popular items

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -596,6 +596,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 			case 'powerherb':
 			case 'mentalherb':
 			case 'rockyhelmet':
+			case 'heavydutyboots':
 				greatItems.push(id);
 				break;
 			case 'lumberry':

--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -597,6 +597,8 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 			case 'mentalherb':
 			case 'rockyhelmet':
 			case 'heavydutyboots':
+			case 'expertbelt':
+			case 'roomservice':
 				greatItems.push(id);
 				break;
 			case 'lumberry':


### PR DESCRIPTION
Heavy Duty Boots should go in the Popular items section. I discussed this briefly on the Discord and the reception was unanimously positive.

I would like Expert Belt and Room Service to be added to the Popular items section as well.