### PR TITLE
Properly set the encoding to UTF-8 on all HTML pages

### DIFF
--- a/action.php
+++ b/action.php
@@ -10,7 +10,7 @@ License: GPLv2 or later
 error_reporting(E_ALL);
 
 if (@$_GET['act'] === 'dlteam') {
-	header("Content-Type: text/plain");
+	header("Content-Type: text/plain; charset=utf-8");
 	if (substr(@$_SERVER['HTTP_REFERER'], 0, 32) !== 'https://play.pokemonshowdown.com') {
 		// since this is only to support Chrome on HTTPS, we can get away with a very specific referer check
 		die("access denied");

--- a/crossprotocol.html
+++ b/crossprotocol.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html>
-<meta charset="utf-8" />
+﻿<!DOCTYPE html>
+<meta charset="UTF-8" />
 <script src="/js/lib/jquery-2.1.4.min.js"></script>
 <script>
 

--- a/desktop/index.html
+++ b/desktop/index.html
@@ -1,4 +1,5 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
+<meta charset="UTF-8" />
 <script>
 var gui = require('nw.gui');
 var win = gui.Window.get();

--- a/index.template.html
+++ b/index.template.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <!--
            .............
        ,...................
@@ -24,7 +24,7 @@ Also visit us in the Dev chatroom:
 https://psim.us/dev
 
 -->
-<meta charset="utf-8" />
+<meta charset="UTF-8" />
 <meta id="viewport" name="viewport" content="width=device-width" />
 <title>Showdown!</title>
 <meta http-equiv="X-UA-Compatible" content="IE=Edge" />

--- a/preactalpha.template.html
+++ b/preactalpha.template.html
@@ -1,6 +1,6 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html><head>
-	<meta charset="utf-8" />
+	<meta charset="UTF-8" />
 	<meta name="viewport" content="width=device-width" />
 	<title>Showdown!</title>
 	<link rel="shortcut icon" href="favicon.ico" id="dynamic-favicon" />

--- a/recoverteams.html
+++ b/recoverteams.html
@@ -1,4 +1,5 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
+<meta charset="UTF-8" />
 <script>
 	Config = {};
 	exports = window;

--- a/style/hpbartest.html
+++ b/style/hpbartest.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html>
-<meta charset="utf-8" />
+﻿<!DOCTYPE html>
+<meta charset="UTF-8" />
 
 <link rel="stylesheet" href="battle.css" />
 

--- a/testclient-beta.html
+++ b/testclient-beta.html
@@ -1,6 +1,6 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html><head>
-	<meta charset="utf-8" />
+	<meta charset="UTF-8" />
 	<meta name="viewport" content="width=device-width" />
 	<title>Showdown!</title>
 	<link rel="shortcut icon" href="favicon.ico" id="dynamic-favicon" />

--- a/testclient.html
+++ b/testclient.html
@@ -1,7 +1,7 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 	<head>
-		<meta charset="utf-8" />
+		<meta charset="UTF-8" />
 		<meta id="viewport" name="viewport" content="width=device-width" />
 		<title>Showdown!</title>
 		<link rel="shortcut icon" href="favicon.ico" id="dynamic-favicon" />


### PR DESCRIPTION
This adds the BOM to all HTTP pages as per the HTML5 spec and ensures
all pages use UTF-8 as their meta charset (which is still kept for
compatibility with older browsers).

If this PR is alright, main's client sets the encoding to ISO-8859-1 in the `Content-Type` header. This can mess with older browsers when combined with this, so it'd need to be changed as well.