### PR TITLE
Remove getTemplate call from Pokemon constructor

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -106,9 +106,6 @@ class Pokemon implements PokemonDetails, PokemonHealth {
 		this.side = side;
 		this.species = data.species;
 
-		// TODO: stop doing this
-		Object.assign(this, Dex.getTemplate(data.species));
-
 		this.details = data.details;
 		this.name = data.name;
 		this.level = data.level;


### PR DESCRIPTION
- `tsc` presumably covers us within `src`
- per `#sim-dev` I checked `replay.js`, `replay-embed.js` and `client-battle.js`
	- the two replay files are short and I have high confidence that they are not relying on fields from `Template`
  - I searched for `'okemon'` and looked at the 142 usages in `client-battle.js` and none appear to be using `Template` fields. no strong guarantee here given nothing is typed, but this is an easy enough change to rollback