### PR TITLE
Support /hidetext linecount client-side

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1427,7 +1427,7 @@
 						// but it's now always applied
 						$messages = this.$chat.find('.chatmessage-' + user);
 						if (!$messages.length) break;
-						$messages.hide().addClass('revealed').find('button').parent().remove();
+						$messages.slice(-row[3]).hide().addClass('revealed').find('button').parent().remove();
 						this.$chat.children().last().append(' <button name="toggleMessages" value="' + user + '" class="subtle"><small>(' + $messages.length + ' line' + ($messages.length > 1 ? 's' : '') + ' from ' + user + ' hidden)</small></button>');
 					}
 					break;

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1427,7 +1427,7 @@
 						// but it's now always applied
 						$messages = this.$chat.find('.chatmessage-' + user);
 						if (!$messages.length) break;
-						if (row[3]) $messages = $messages.slice(-parseInt(row[3]);
+						if (row[3]) $messages = $messages.slice(-parseInt(row[3]));
 						$messages.hide().addClass('revealed').find('button').parent().remove();
 						this.$chat.children().last().append(' <button name="toggleMessages" value="' + user + '" class="subtle"><small>(' + $messages.length + ' line' + ($messages.length > 1 ? 's' : '') + ' from ' + user + ' hidden)</small></button>');
 					}

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1428,7 +1428,7 @@
 						$messages = this.$chat.find('.chatmessage-' + user);
 						if (!$messages.length) break;
 						$messages.slice(-row[3]).hide().addClass('revealed').find('button').parent().remove();
-						this.$chat.children().last().append(' <button name="toggleMessages" value="' + user + '" class="subtle"><small>(' + $messages.length + ' line' + ($messages.length > 1 ? 's' : '') + ' from ' + user + ' hidden)</small></button>');
+						this.$chat.children().last().append(' <button name="toggleMessages" value="' + user + '" class="subtle"><small>(' + $messages.slice(-row[3]).length + ' line' + ($messages.slice(-row[3]).length > 1 ? 's' : '') + ' from ' + user + ' hidden)</small></button>');
 					}
 					break;
 

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1427,8 +1427,9 @@
 						// but it's now always applied
 						$messages = this.$chat.find('.chatmessage-' + user);
 						if (!$messages.length) break;
-						$messages.slice(-row[3]).hide().addClass('revealed').find('button').parent().remove();
-						this.$chat.children().last().append(' <button name="toggleMessages" value="' + user + '" class="subtle"><small>(' + $messages.slice(-row[3]).length + ' line' + ($messages.slice(-row[3]).length > 1 ? 's' : '') + ' from ' + user + ' hidden)</small></button>');
+						if (row[3]) $messages = $messages.slice(-parseInt(row[3]);
+						$messages.hide().addClass('revealed').find('button').parent().remove();
+						this.$chat.children().last().append(' <button name="toggleMessages" value="' + user + '" class="subtle"><small>(' + $messages.length + ' line' + ($messages.length > 1 ? 's' : '') + ' from ' + user + ' hidden)</small></button>');
 					}
 					break;
 

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1427,7 +1427,8 @@
 						// but it's now always applied
 						$messages = this.$chat.find('.chatmessage-' + user);
 						if (!$messages.length) break;
-						if (row[3]) $messages = $messages.slice(-parseInt(row[3], 10));
+						var lineCount = parseInt(row[3], 10) || 0;
+						if (lineCount) $messages = $messages.slice(-lineCount);
 						$messages.hide().addClass('revealed').find('button').parent().remove();
 						this.$chat.children().last().append(' <button name="toggleMessages" value="' + user + '" class="subtle"><small>(' + $messages.length + ' line' + ($messages.length > 1 ? 's' : '') + ' from ' + user + ' hidden)</small></button>');
 					}

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1427,7 +1427,7 @@
 						// but it's now always applied
 						$messages = this.$chat.find('.chatmessage-' + user);
 						if (!$messages.length) break;
-						if (row[3]) $messages = $messages.slice(-parseInt(row[3]), 10);
+						if (row[3]) $messages = $messages.slice(-parseInt(row[3], 10));
 						$messages.hide().addClass('revealed').find('button').parent().remove();
 						this.$chat.children().last().append(' <button name="toggleMessages" value="' + user + '" class="subtle"><small>(' + $messages.length + ' line' + ($messages.length > 1 ? 's' : '') + ' from ' + user + ' hidden)</small></button>');
 					}

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1427,7 +1427,7 @@
 						// but it's now always applied
 						$messages = this.$chat.find('.chatmessage-' + user);
 						if (!$messages.length) break;
-						if (row[3]) $messages = $messages.slice(-parseInt(row[3]));
+						if (row[3]) $messages = $messages.slice(-parseInt(row[3]), 10);
 						$messages.hide().addClass('revealed').find('button').parent().remove();
 						this.$chat.children().last().append(' <button name="toggleMessages" value="' + user + '" class="subtle"><small>(' + $messages.length + ' line' + ($messages.length > 1 ? 's' : '') + ' from ' + user + ' hidden)</small></button>');
 					}

--- a/src/battle-log.ts
+++ b/src/battle-log.ts
@@ -141,9 +141,9 @@ class BattleLog {
 
 		case 'unlink': {
 			const user = toID(args[2]) || toID(args[1]);
-			this.unlinkChatFrom(user);
+			this.unlinkChatFrom(user, args[args.length]);
 			if (args[2]) {
-				this.hideChatFrom(user);
+				this.hideChatFrom(user, args[args.length]);
 			}
 			return;
 		}
@@ -306,7 +306,7 @@ class BattleLog {
 			this.prependDiv('notice uhtml-' + id, BattleLog.sanitizeHTML(html));
 		}
 	}
-	hideChatFrom(userid: ID, showRevealButton = true) {
+	hideChatFrom(userid: ID, showRevealButton = true, lineCount = 0) {
 		const classStart = 'chat chatmessage-' + userid + ' ';
 		let lastNode;
 		let count = 0;
@@ -315,6 +315,7 @@ class BattleLog {
 				node.style.display = 'none';
 				node.className = 'revealed ' + node.className;
 				count++;
+				if (count >= lineCount && lineCount !== 0) break;
 			}
 			lastNode = node;
 		}

--- a/src/battle-log.ts
+++ b/src/battle-log.ts
@@ -309,36 +309,38 @@ class BattleLog {
 	}
 	hideChatFrom(userid: ID, showRevealButton = true, lineCount = 0) {
 		const classStart = 'chat chatmessage-' + userid + ' ';
-		let lastNode;
-		let count = 0;
-		for (const node of this.innerElem.childNodes as any) {
+		let nodes: HTMLElement[] = [];
+		for (const node of this.innerElem.childNodes as any as HTMLElement[]) {
+			if (node.className && (node.className + ' ').startsWith(classStart)) {
+				nodes.push(node);
+			}
+		}
+		if (this.preemptElem) {
+			for (const node of this.preemptElem.childNodes as any as HTMLElement[]) {
+				if (node.className && (node.className + ' ').startsWith(classStart)) {
+					nodes.push(node);
+				}
+			}
+		}
+		if (lineCount) nodes = nodes.slice(-lineCount);
+
+		for (const node of nodes) {
 			if (node.className && (node.className + ' ').startsWith(classStart)) {
 				node.style.display = 'none';
 				node.className = 'revealed ' + node.className;
-				count++;
-				if (count >= lineCount && lineCount !== 0) break;
-			}
-			lastNode = node;
-		}
-		if (this.preemptElem) {
-			for (const node of this.preemptElem.childNodes as any) {
-				if (node.className && (node.className + ' ').startsWith(classStart)) {
-					node.style.display = 'none';
-					node.className = 'revealed ' + node.className;
-					count++;
-				}
-				lastNode = node;
 			}
 		}
-		if (!count || !showRevealButton) return;
+		if (!nodes.length || !showRevealButton) return;
 		const button = document.createElement('button');
 		button.name = 'toggleMessages';
 		button.value = userid;
 		button.className = 'subtle';
-		button.innerHTML = '<small>(' + count + ' line' + (count > 1 ? 's' : '') + ' from ' + userid + ' hidden)</small>';
+		button.innerHTML = `<small>(${nodes.length} line${nodes.length > 1 ? 's' : ''} from ${userid} hidden)</small>`;
+		const lastNode = nodes[nodes.length - 1];
 		lastNode.appendChild(document.createTextNode(' '));
 		lastNode.appendChild(button);
 	}
+
 	static unlinkNodeList(nodeList: ArrayLike<HTMLElement>, classStart: string) {
 		for (const node of nodeList as HTMLElement[]) {
 			if (node.className && (node.className + ' ').startsWith(classStart)) {
@@ -356,6 +358,7 @@ class BattleLog {
 			}
 		}
 	}
+
 	unlinkChatFrom(userid: ID) {
 		const classStart = 'chat chatmessage-' + userid + ' ';
 		const innerNodeList = this.innerElem.childNodes;

--- a/src/battle-log.ts
+++ b/src/battle-log.ts
@@ -143,7 +143,8 @@ class BattleLog {
 			const user = toID(args[2]) || toID(args[1]);
 			this.unlinkChatFrom(user, parseInt(args[args.length], 10));
 			if (args[2]) {
-				this.hideChatFrom(user, parseInt(args[args.length], 10));
+				const lineCount = parseInt(args[3], 10);
+				this.hideChatFrom(user, true, lineCount);
 			}
 			return;
 		}

--- a/src/battle-log.ts
+++ b/src/battle-log.ts
@@ -325,10 +325,8 @@ class BattleLog {
 		if (lineCount) nodes = nodes.slice(-lineCount);
 
 		for (const node of nodes) {
-			if (node.className && (node.className + ' ').startsWith(classStart)) {
-				node.style.display = 'none';
-				node.className = 'revealed ' + node.className;
-			}
+			node.style.display = 'none';
+			node.className = 'revealed ' + node.className;
 		}
 		if (!nodes.length || !showRevealButton) return;
 		const button = document.createElement('button');

--- a/src/battle-log.ts
+++ b/src/battle-log.ts
@@ -141,9 +141,9 @@ class BattleLog {
 
 		case 'unlink': {
 			const user = toID(args[2]) || toID(args[1]);
-			this.unlinkChatFrom(user, parseInt(args[args.length]));
+			this.unlinkChatFrom(user, parseInt(args[args.length], 10));
 			if (args[2]) {
-				this.hideChatFrom(user, parseInt(args[args.length]));
+				this.hideChatFrom(user, parseInt(args[args.length], 10));
 			}
 			return;
 		}

--- a/src/battle-log.ts
+++ b/src/battle-log.ts
@@ -141,7 +141,7 @@ class BattleLog {
 
 		case 'unlink': {
 			const user = toID(args[2]) || toID(args[1]);
-			this.unlinkChatFrom(user, parseInt(args[args.length], 10));
+			this.unlinkChatFrom(user);
 			if (args[2]) {
 				const lineCount = parseInt(args[3], 10);
 				this.hideChatFrom(user, true, lineCount);

--- a/src/battle-log.ts
+++ b/src/battle-log.ts
@@ -141,9 +141,9 @@ class BattleLog {
 
 		case 'unlink': {
 			const user = toID(args[2]) || toID(args[1]);
-			this.unlinkChatFrom(user, args[args.length]);
+			this.unlinkChatFrom(user, parseInt(args[args.length], 10));
 			if (args[2]) {
-				this.hideChatFrom(user, args[args.length]);
+				this.hideChatFrom(user, parseInt(args[args.length], 10));
 			}
 			return;
 		}

--- a/src/battle-log.ts
+++ b/src/battle-log.ts
@@ -141,9 +141,9 @@ class BattleLog {
 
 		case 'unlink': {
 			const user = toID(args[2]) || toID(args[1]);
-			this.unlinkChatFrom(user, parseInt(args[args.length], 10));
+			this.unlinkChatFrom(user, parseInt(args[args.length]));
 			if (args[2]) {
-				this.hideChatFrom(user, parseInt(args[args.length], 10));
+				this.hideChatFrom(user, parseInt(args[args.length]));
 			}
 			return;
 		}


### PR DESCRIPTION
Reference: https://github.com/smogon/pokemon-showdown/pull/6471

This is a client-side patch that modifies hidetext messages to support an integer parameter of lines to hide. Default is still all lines, but now a supplied number of lines can be hidden as well.