### PR TITLE
Disable battle chat upon disconnection

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -518,6 +518,7 @@ function toId() {
 				self.rooms[''].updateFormats();
 				$('.pm-log-add form').html('<small>You are disconnected and cannot chat.</small>');
 				$('.chat-log-add').html('<small>You are disconnected and cannot chat.</small>');
+				$('.battle-log-add').html('<small>You are disconnected and cannot chat.</small>');
 
 				self.reconnectPending = (message || true);
 				if (!self.popups.length) self.addPopup(ReconnectPopup, {message: message});


### PR DESCRIPTION
- apply same "You are disconnected and cannot chat" message to battles upon disconnecting from a server.  Just a tiny pet peeve when testing code on localhost.