### PR TITLE
Fix display of Max Move used in doubles

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -869,7 +869,12 @@
 					var parts = this.choice.choices[i].split(' ');
 					switch (parts[0]) {
 					case 'move':
-						var move = this.request.active[i].moves[parseInt(parts[1], 10) - 1].move;
+						var move;
+						if (this.request.active[i].maxMoves && !this.request.active[i].canDynamax) { // it's a max move
+							move = this.request.active[i].maxMoves.maxMoves[parseInt(parts[1], 10) - 1].move;
+						} else { // it's a normal move
+							move = this.request.active[i].moves[parseInt(parts[1], 10) - 1].move;
+						}
 						var target = '';
 						buf += myActive[i].speciesForme + ' will ';
 						if (parts.length > 2) {
@@ -884,7 +889,7 @@
 							}
 							if (targetPos === 'dynamax') {
 								move = this.request.active[i].maxMoves.maxMoves[parseInt(parts[1], 10) - 1].move;
-								buf += 'dynamax, then ';
+								buf += 'Dynamax, then ';
 								targetPos = parts[3];
 							}
 							if (targetPos) {
@@ -900,10 +905,6 @@
 								} else {
 									target = ''; // targeting an empty slot
 								}
-							}
-						} else {
-							if (this.request.active[i].maxMoves && !this.request.active[i].canDynamax) {
-								move = this.request.active[i].maxMoves.maxMoves[parseInt(parts[1], 10) - 1].move;
 							}
 						}
 						buf += 'use ' + Dex.getMove(move).name + (target ? ' against ' + target : '') + '.<br />';


### PR DESCRIPTION
Max Moves were previously displaying in doubles as regular attacks on any turn that wasn't the initial turn of Dynamax. This was because the conditions for showing the Max Move as the max move proper would only occur when the length of the array of parts for a user command was less than 2, which doesn't happen in doubles because doubles also sends the target of its attack.

This also sneaks in a capitalization for Dynamax; the game text capitalizes Dynamax, unlike mega evolve.

Before:
![image](https://user-images.githubusercontent.com/23667022/79927809-88eb1780-8406-11ea-970d-bcece6782361.png)

After:
![image](https://user-images.githubusercontent.com/23667022/79927818-8ee0f880-8406-11ea-8960-68116f214acf.png)