### PR TITLE
Fix sorting move because of header

### DIFF
--- a/src/battle-dex-search.ts
+++ b/src/battle-dex-search.ts
@@ -647,7 +647,7 @@ abstract class BattleTypedSearch<T extends SearchType> {
 				}
 			}
 		} else {
-			results = [...this.baseResults];
+			results = this.baseResults.filter(result => result[0] !== 'header');
 			illegalResults = null;
 		}
 


### PR DESCRIPTION
Fix sorting move because of header.

the results to be sorted includes headers such as
```
["header", "Moves"]
["header", "Usually useless moves"]
```

and it caused the sorting function when selecting pokemon's moves to not function at all.
<img width="678" alt="Screen Shot 2020-05-08 at 3 46 58 pm" src="https://user-images.githubusercontent.com/6029549/81374701-34080a80-9143-11ea-9a56-b077f0cd134a.png">
