### PR TITLE
Limit /rank Formats in Battle Rooms

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -837,7 +837,10 @@
 			case 'rating':
 			case 'ladder':
 				if (app.localLadder) return text;
-				if (!target) target = app.user.get('userid');
+				if (!target) {
+					if (this.battle) target =  app.user.get('userid') + ", " + this.id.split('-')[1];
+					else target = app.user.get('userid');
+				}
 
 				var targets = target.split(',');
 				var formatTargeting = false;

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -838,7 +838,7 @@
 			case 'ladder':
 				if (app.localLadder) return text;
 				if (!target) {
-					if (this.battle) target =  app.user.get('userid') + ", " + this.id.split('-')[1];
+					if (this.battle) target = app.user.get('userid') + ", " + this.id.split('-')[1];
 					else target = app.user.get('userid');
 				}
 

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -838,8 +838,8 @@
 			case 'ladder':
 				if (app.localLadder) return text;
 				if (!target) {
-					if (this.battle) target = app.user.get('userid') + ", " + this.id.split('-')[1];
-					else target = app.user.get('userid');
+					target = app.user.get('userid');
+					if (this.battle) target += ", " + this.id.split('-')[1];
 				}
 
 				var targets = target.split(',');


### PR DESCRIPTION
If the room is a battle room, only display the current format.

https://www.smogon.com/forums/threads/make-rank-display-only-the-specific-tier-when-used-in-a-battle-room.3657423/
https://www.smogon.com/forums/threads/suggestion-a-rank-command-that-only-shows-your-rank-for-whatever-format-youre-currently-queued-for.3665167/

Neither of these were ever explicitly approved, though.