### PR TITLE
Fix RBY accuracy/evasion tooltips

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -370,7 +370,8 @@ class Pokemon implements PokemonDetails, PokemonHealth {
 		}
 		if (this.boosts[boostStat] > 6) this.boosts[boostStat] = 6;
 		if (this.boosts[boostStat] < -6) this.boosts[boostStat] = -6;
-		if ((this.side.battle.tier.includes('Stadium') || this.side.battle.gen > 2) && (boostStat === 'accuracy' || boostStat === 'evasion')) {
+		const isRBY = this.side.battle.gen <= 1 && !this.side.battle.tier.includes('Stadium');
+		if (!isRBY && (boostStat === 'accuracy' || boostStat === 'evasion')) {
 			if (this.boosts[boostStat] > 0) {
 				let goodBoostTable = [
 					'1&times;', '1.33&times;', '1.67&times;', '2&times;', '2.33&times;', '2.67&times;', '3&times;',

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -370,7 +370,7 @@ class Pokemon implements PokemonDetails, PokemonHealth {
 		}
 		if (this.boosts[boostStat] > 6) this.boosts[boostStat] = 6;
 		if (this.boosts[boostStat] < -6) this.boosts[boostStat] = -6;
-		if (boostStat === 'accuracy' || boostStat === 'evasion') {
+		if ((this.side.battle.tier.includes('Stadium') || this.side.battle.gen > 2) && (boostStat === 'accuracy' || boostStat === 'evasion')) {
 			if (this.boosts[boostStat] > 0) {
 				let goodBoostTable = [
 					'1&times;', '1.33&times;', '1.67&times;', '2&times;', '2.33&times;', '2.67&times;', '3&times;',


### PR DESCRIPTION
In RBY, Accuracy and Evasion use the same boost table as the other stats. For example, -1 Accuracy or Evasion = 0.66 instead of 0.75. This is implemented on Showdown, but it is incorrectly displayed using the Accuracy/Evasion table from Stadium and GSC onwards.