### PR TITLE
Introduce a "Don't allow spectators" checkbox

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -190,7 +190,7 @@ function toId() {
 			this.normalizeList = normalizeList;
 		},
 		updateSetting: function (setting, value) {
-			var settings = this.get('settings');
+			var settings = _.clone(this.get('settings'));
 			if (settings[setting] !== value) {
 				switch (setting) {
 				case 'blockPMs':
@@ -202,6 +202,7 @@ function toId() {
 				default:
 					throw new TypeError('Unknown setting:' + setting);
 				}
+				// Optimistically update, might get corrected by the |updateuser| response
 				settings[setting] = value;
 				this.set('settings', settings);
 			}
@@ -984,7 +985,7 @@ function toId() {
 					}, function () {}, 'text');
 				}
 
-				var settings = app.user.get('settings');
+				var settings = _.clone(app.user.get('settings'));
 				if (parts.length > 4) {
 					// Update our existing settings based on what the server has sent us.
 					// This approach is more robust as it works regardless of whether the

--- a/style/battle-log.css
+++ b/style/battle-log.css
@@ -158,7 +158,7 @@ button:disabled {
 .checkbox input {
 	width: 14px;
 	height: 14px;
-	vertical-align: 1px;
+	vertical-align: -3px;
 	cursor: pointer;
 }
 .checkbox i {


### PR DESCRIPTION
Client side portion of https://github.com/smogon/pokemon-showdown/issues/6950

![Screen Shot 2020-07-11 at 11 32 46](https://user-images.githubusercontent.com/117249/87231368-85af5a00-c36b-11ea-83f2-a1b6732182bc.png)

- CSS for `.checkbox` was changed to make it optimally aligned on the latest Chrome
- Persisting `serversettings` appropriately was fixed by adding `_.clone` calls so Backbone's change detection will work. This is important for #1271 (though that also requires we send `/updatesettings` on setup and can be done in a followup PR)
- `/ionext` is used instead of `/hidenext` intil https://github.com/smogon/pokemon-showdown/issues/6950 is finished (ie. passwords get added to hidden battle rooms)

One 'gotcha' is that toggling the privacy checkbox in a challenge will not cause the ladder checkbox to update (meaning all of the privacy checkboxes in the UI do not always reflect the current state of the `disallowspectators` pref). This is fine because:

1.  you dont always want the UI to reflect the state of the `disallowspectators` pref (for example, in the case of two difference challenge windows open at the same time that desire different settings)
2. the only requirement is that the checkbox state reflects the privacy of the battle it is scoped to. The persistence of `disallowspectators` is purely a convenience feature to avoid users constantly toggling the checkbox back and forth



