### PR TITLE
Implement persistent server settings

### DIFF
--- a/js/client-rooms.js
+++ b/js/client-rooms.js
@@ -13,6 +13,8 @@
 			buf += '<p><button name="joinRoomPopup" class="button">Join other room</button></p></div>';
 			this.$el.html(buf);
 			app.on('response:rooms', this.update, this);
+			var settings = Dex.prefs('serversettings');
+			if (settings) app.send('/updatesettings ' + JSON.stringify(settings));
 			app.send('/cmd rooms');
 			app.user.on('change:named', this.updateUser, this);
 			this.update();


### PR DESCRIPTION
Turns out this is all it takes (though all of the groundwork was already laid)?

- the `serversettings` pref includes `hideNextBattle` and `inviteOnlyNextBattle`, but these are ignored `/updatesettings` (and I'm not sure its worth plucking them out to avoid roundtripping the ignored settings)
-  i'm not sure if its safe to access `Dex.prefs` in `RoomsRoom` (will it block if storage has'nt loaded etc), but it seems to work in my browser
- this needs to be done before the first message sent to the server (as opposed to before `/trn` as I originally thought) because the response of initial message is going to include the default `|updateuser|` for a Guest which would wipe out the settings otherwise.

*FINALLY* closes https://github.com/smogon/pokemon-showdown-client/issues/1271