### PR TITLE
Replays: Display !details better

### DIFF
--- a/js/replay-embed.js
+++ b/js/replay-embed.js
@@ -15,6 +15,7 @@ function requireScript(url) {
 linkStyle('https://play.pokemonshowdown.com/style/font-awesome.css?');
 linkStyle('https://play.pokemonshowdown.com/style/battle.css?a7');
 linkStyle('https://play.pokemonshowdown.com/style/replay.css?a7');
+linkStyle('https://play.pokemonshowdown.com/style/utilichart.css?a7');
 
 requireScript('https://play.pokemonshowdown.com/js/lib/jquery-1.11.0.min.js');
 requireScript('https://play.pokemonshowdown.com/js/lib/lodash.compat.js');

--- a/replays/theme/wrapper.inc.template.php
+++ b/replays/theme/wrapper.inc.template.php
@@ -29,6 +29,7 @@ function ThemeHeaderTemplate() {
 	<link rel="stylesheet" href="//pokemonshowdown.com/theme/main.css" />
 	<link rel="stylesheet" href="//play.pokemonshowdown.com/style/battle.css?" />
 	<link rel="stylesheet" href="//play.pokemonshowdown.com/style/replay.css?" />
+	<link rel="stylesheet" href="//play.pokemonshowdown.com/style/utilichart.css?" />
 
 	<!-- Workarounds for IE bugs to display trees correctly. -->
 	<!--[if lte IE 6]><style> li.tree { height: 1px; } </style><![endif]-->


### PR DESCRIPTION
(mostly) fixes #1560.
`<psicon>` tags still don't work in replays -- there's some sort of odd bug there where the CSS for the image gets removed from the `<span>` tag, and fixing it is much more complicated (and not something I'm making a priority to work on right now). If you don't want to merge this until that's fixed, feel free to draft it -- I might work on this more some other time.
However, !details looks much nicer, as you can see below or at https://replays.ps.annika.codes/gen8randombattle-223.
<img width="414" alt="image" src="https://user-images.githubusercontent.com/56906084/87921673-c4aa7300-ca2f-11ea-99c4-c37632c8ead1.png">
