### PR TITLE
Allow for challenging users with multiple rules

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -447,7 +447,7 @@
 				var self = this;
 				var challenge = function (targets) {
 					target = toID(targets[0]);
-					self.challengeData = {userid: target, format: targets[1] || '', team: targets[2] || ''};
+					self.challengeData = {userid: target, format: targets.length > 1 ? targets.slice(1).join(',') : '', team: ''};
 					app.on('response:userdetails', self.challengeUserdetails, self);
 					app.send('/cmd userdetails ' + target);
 				};

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -776,7 +776,7 @@
 				var formatParts = format.split('@@@');
 				formatParts[0] = toID(formatParts[0]);
 				if (!formatParts[0].startsWith('gen')) formatParts[0] = 'gen8' + formatParts[0];
-				format = formatParts[1] ? formatParts[0] + '@@@' + formatParts[1] : formatParts[0];
+				format = formatParts[1] ? formatParts[0] + '@@@' + formatParts.slice(1).join(',') : formatParts[0];
 			}
 
 			var teamIndex;

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -776,7 +776,7 @@
 				var formatParts = format.split('@@@');
 				formatParts[0] = toID(formatParts[0]);
 				if (!formatParts[0].startsWith('gen')) formatParts[0] = 'gen8' + formatParts[0];
-				format = formatParts[1] ? formatParts[0] + '@@@' + formatParts.slice(1).join(',') : formatParts[0];
+				format = formatParts.length > 1 ? formatParts[0] + '@@@' + formatParts.slice(1).join(',') : formatParts[0];
 			}
 
 			var teamIndex;

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -773,27 +773,16 @@
 			}
 
 			if (format) {
-				var formatParts = format.split('@@@');
+				var formatParts = format.split('@@@', 2);
 				formatParts[0] = toID(formatParts[0]);
 				if (!formatParts[0].startsWith('gen')) formatParts[0] = 'gen8' + formatParts[0];
-				format = formatParts.length > 1 ? formatParts[0] + '@@@' + formatParts.slice(1).join(',') : formatParts[0];
-			}
-
-			var teamIndex;
-			if (Storage.teams && team) {
-				team = toID(team);
-				for (var i = 0; i < Storage.teams.length; i++) {
-					if (team === toID(Storage.teams[i].name || '')) {
-						teamIndex = i;
-						break;
-					}
-				}
+				format = formatParts.length > 1 ? formatParts[0] + '@@@' + formatParts[1] : formatParts[0];
 			}
 
 			$challenge = this.openChallenge(name);
 			var buf = '<form class="battleform"><p>Challenge ' + BattleLog.escapeHTML(name) + '?</p>';
 			buf += '<p><label class="label">Format:</label>' + this.renderFormats(format) + '</p>';
-			buf += '<p><label class="label">Team:</label>' + this.renderTeams(format, teamIndex) + '</p>';
+			buf += '<p><label class="label">Team:</label>' + this.renderTeams(format) + '</p>';
 			buf += '<p><label class="checkbox"><input type="checkbox" name="private" ' + (Storage.prefs('disallowspectators') ? 'checked' : '') + ' /> <abbr title="You can still invite spectators by giving them the URL or using the /invite command">Don\'t allow spectators</abbr></label></p>';
 			buf += '<p class="buttonbar"><button name="makeChallenge"><strong>Challenge</strong></button> <button name="dismissChallenge">Cancel</button></p></form>';
 			$challenge.html(buf);


### PR DESCRIPTION
Currently, when you do `/chall user, gen8ou@@@inversemod,scalemonsmod`, it only detects the first additional rule. This allows users to do the aforementioned command and actually challenge the target user to [Gen 8] OU + Inverse Mod + Scalemons Mod. This works correctly with `/chall user, gen8ou@@@customrule1,customrule2, customrule(n)` as well.