### PR TITLE
Show locked status in all trainer cards

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -2509,13 +2509,13 @@ function toId() {
 			var name = data.name;
 			var avatar = data.avatar || '';
 			var group = ((Config.groups[data.roomGroup] || {}).name || '');
-			var globalgroup = ((Config.groups[(data.group || Config.defaultGroup || ' ')] || {}).name || '');
-			if (globalgroup) {
-				if (!group || group === globalgroup) {
-					group = "Global " + globalgroup;
-					globalgroup = '';
+			var globalGroupObject = (Config.groups[(data.group || Config.defaultGroup || ' ')] || null);
+			var globalgroup = '';
+			if (globalGroupObject && globalGroupObject.name) {
+				if (!group || group === globalGroupObject.name) {
+					group = (globalGroupObject.type === 'punishment' ? "" : "Global ") + globalGroupObject.name;
 				} else {
-					globalgroup = "Global " + globalgroup;
+					globalgroup = (globalGroupObject.type === 'punishment' ? "" : "Global ") + globalGroupObject.name;
 				}
 			}
 			var ownUserid = app.user.get('userid');

--- a/js/client.js
+++ b/js/client.js
@@ -2508,14 +2508,16 @@ function toId() {
 			var userid = data.userid;
 			var name = data.name;
 			var avatar = data.avatar || '';
-			var group = ((Config.groups[data.roomGroup] || {}).name || '');
+			var groupName = ((Config.groups[data.roomGroup] || {}).name || '');
 			var globalGroup = (Config.groups[data.group || Config.defaultGroup || ' '] || null);
 			var globalGroupName = '';
 			if (globalGroup && globalGroup.name) {
-				if (!group || group === globalGroup.name) {
-					group = (globalGroup.type === 'punishment' ? "" : "Global ") + globalGroup.name;
+				if (globalGroup.type === 'punishment') {
+					globalGroupName = globalGroup.name;
+				} else if (!groupName || groupName === globalGroup.name) {
+					groupName = "Global " + globalGroup.name;
 				} else {
-					globalGroupName = (globalGroup.type === 'punishment' ? "" : "Global ") + globalGroup.name;
+					globalGroupName = "Global " + globalGroup.name;
 				}
 			}
 			var ownUserid = app.user.get('userid');
@@ -2528,8 +2530,8 @@ function toId() {
 				var status = offline ? '(Offline)' : data.status.startsWith('!') ? data.status.slice(1) : data.status;
 				buf += '<span class="userstatus' + (offline ? ' offline' : '') + '">' + BattleLog.escapeHTML(status) + '<br /></span>';
 			}
-			if (group) {
-				buf += '<small class="usergroup roomgroup">' + group + '</small>';
+			if (groupName) {
+				buf += '<small class="usergroup roomgroup">' + groupName + '</small>';
 				if (globalGroupName) buf += '<br />';
 			}
 			if (globalGroupName) {

--- a/js/client.js
+++ b/js/client.js
@@ -2509,13 +2509,13 @@ function toId() {
 			var name = data.name;
 			var avatar = data.avatar || '';
 			var group = ((Config.groups[data.roomGroup] || {}).name || '');
-			var globalGroupObject = (Config.groups[(data.group || Config.defaultGroup || ' ')] || null);
-			var globalgroup = '';
-			if (globalGroupObject && globalGroupObject.name) {
-				if (!group || group === globalGroupObject.name) {
-					group = (globalGroupObject.type === 'punishment' ? "" : "Global ") + globalGroupObject.name;
+			var globalGroup = (Config.groups[data.group || Config.defaultGroup || ' '] || null);
+			var globalGroupName = '';
+			if (globalGroup && globalGroup.name) {
+				if (!group || group === globalGroup.name) {
+					group = (globalGroup.type === 'punishment' ? "" : "Global ") + globalGroup.name;
 				} else {
-					globalgroup = (globalGroupObject.type === 'punishment' ? "" : "Global ") + globalGroupObject.name;
+					globalGroupName = (globalGroup.type === 'punishment' ? "" : "Global ") + globalGroup.name;
 				}
 			}
 			var ownUserid = app.user.get('userid');
@@ -2530,10 +2530,10 @@ function toId() {
 			}
 			if (group) {
 				buf += '<small class="usergroup roomgroup">' + group + '</small>';
-				if (globalgroup) buf += '<br />';
+				if (globalGroupName) buf += '<br />';
 			}
-			if (globalgroup) {
-				buf += '<small class="usergroup globalgroup">' + globalgroup + '</small>';
+			if (globalGroupName) {
+				buf += '<small class="usergroup globalgroup">' + globalGroupName + '</small>';
 			}
 			if (data.rooms) {
 				var battlebuf = '';


### PR DESCRIPTION
Previously, you would only be able to tell that a user was locked through their usercard if you got that usercard from a room's user list. Now, along with the server PR (https://github.com/smogon/pokemon-showdown/pull/7041) to send groups for locked & namelocked users, locked status will show in all usercards.