### PR TITLE
Don't show punishments twice

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -2513,8 +2513,7 @@ function toId() {
 			var globalGroupName = '';
 			if (globalGroup && globalGroup.name) {
 				if (globalGroup.type === 'punishment') {
-					globalGroupName = globalGroup.name;
-					groupName = '';
+					groupName = globalGroup.name;
 				} else if (!groupName || groupName === globalGroup.name) {
 					groupName = "Global " + globalGroup.name;
 				} else {

--- a/js/client.js
+++ b/js/client.js
@@ -2514,6 +2514,7 @@ function toId() {
 			if (globalGroup && globalGroup.name) {
 				if (globalGroup.type === 'punishment') {
 					globalGroupName = globalGroup.name;
+					groupName = '';
 				} else if (!groupName || groupName === globalGroup.name) {
 					groupName = "Global " + globalGroup.name;
 				} else {


### PR DESCRIPTION
Previously, punishments would be shown as both a user's global rank and their room rank when getting a usercard from the room list. (An example is below.)

<img width="300" alt="image" src="https://user-images.githubusercontent.com/56906084/88449525-782eb100-cdfc-11ea-94bd-b235c5f3a9a2.png">
