### PR TITLE
Fix Weather Ball display with Delta Stream

### DIFF
--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -1519,7 +1519,9 @@ class BattleTooltips {
 			}
 		}
 		if (move.id === 'weatherball') {
-			value.weatherModify(2);
+			if (this.battle.weather !== 'deltastream') {
+				value.weatherModify(2);
+			}
 		}
 		if (move.id === 'terrainpulse') {
 			if (


### PR DESCRIPTION
Before, Weather Ball displayed as having 100 BP in Delta Stream, which it doesn't.