### PR TITLE
Implement spacing functionality when user list is toggled

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1725,6 +1725,7 @@
 	var UserList = this.UserList = Backbone.View.extend({
 		initialize: function (options) {
 			this.room = options.room;
+			this.innerMessageLog = $('div.inner.message-log');
 		},
 		events: {
 			'click .userlist-count': 'toggleUserlist'
@@ -1754,15 +1755,14 @@
 		toggleUserlist: function (e) {
 			e.preventDefault();
 			e.stopPropagation();
-			const innerMessageLog = $('div.inner.message-log');
 			if (this.$el.hasClass('userlist-minimized')) {
 				this.$el.removeClass('userlist-minimized');
 				this.$el.addClass('userlist-maximized');
-				innerMessageLog.addClass('inner-chat-userlist-maximized');
+				this.innerMessageLog.addClass('inner-chat-userlist-maximized');
 			} else if (this.$el.hasClass('userlist-maximized')) {
 				this.$el.removeClass('userlist-maximized');
 				this.$el.addClass('userlist-minimized');
-				innerMessageLog.removeClass('inner-chat-userlist-maximized');
+				this.innerMessageLog.removeClass('inner-chat-userlist-maximized');
 			}
 		},
 		show: function () {

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1754,12 +1754,15 @@
 		toggleUserlist: function (e) {
 			e.preventDefault();
 			e.stopPropagation();
+			const innerMessageLog = $('div.inner.message-log');
 			if (this.$el.hasClass('userlist-minimized')) {
 				this.$el.removeClass('userlist-minimized');
 				this.$el.addClass('userlist-maximized');
+				innerMessageLog.addClass('inner-chat-userlist-maximized');
 			} else if (this.$el.hasClass('userlist-maximized')) {
 				this.$el.removeClass('userlist-maximized');
 				this.$el.addClass('userlist-minimized');
+				innerMessageLog.removeClass('inner-chat-userlist-maximized');
 			}
 		},
 		show: function () {

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -74,6 +74,13 @@
 				return;
 			}
 
+			if ($(target).closest('.battle-userlist, .userlist').length) {
+				return;
+			}
+
+			$('ul.battle-userlist.userlist').removeClass('userlist-maximized');
+			$('ul.battle-userlist.userlist').addClass('userlist-minimized');
+			$('div.inner.message-log').removeClass('inner-chat-userlist-maximized');
 			if (window.isiOS) {
 				// Preventing the on-screen keyboard leads to other bugs, so we have to
 				// avoid focusing the textbox altogether. Sorry, Bluetooth keyboard users!

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1758,11 +1758,15 @@
 			if (this.$el.hasClass('userlist-minimized')) {
 				this.$el.removeClass('userlist-minimized');
 				this.$el.addClass('userlist-maximized');
-				this.innerMessageLog.addClass('inner-chat-userlist-maximized');
+				if (this.innerMessageLog != null) {
+					this.innerMessageLog.addClass('inner-chat-userlist-maximized');
+				}
 			} else if (this.$el.hasClass('userlist-maximized')) {
 				this.$el.removeClass('userlist-maximized');
 				this.$el.addClass('userlist-minimized');
-				this.innerMessageLog.removeClass('inner-chat-userlist-maximized');
+				if (this.innerMessageLog != null) {
+					this.innerMessageLog.removeClass('inner-chat-userlist-maximized');
+				}
 			}
 		},
 		show: function () {

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1,15 +1,5 @@
 (function ($) {
 
-	// function to hide the user list and widen the chat
-	const removeUserList = () => {
-		$('ul.battle-userlist.userlist').removeClass('userlist-maximized');
-		$('ul.battle-userlist.userlist').addClass('userlist-minimized');
-		const innerMessageLog = $('div.inner.message-log');
-		console.log(innerMessageLog);
-		if (this.innerMessageLog != null) {
-			this.innerMessageLog.removeClass('inner-chat-userlist-maximized');
-		}
-	}
 	var ConsoleRoom = this.ConsoleRoom = Room.extend({
 		type: 'chat',
 		title: '',
@@ -70,7 +60,9 @@
 						$(target).focus();
 					}, 0);
 				} */
-				removeUserList();
+				$('ul.battle-userlist.userlist').removeClass('userlist-maximized');
+				$('ul.battle-userlist.userlist').addClass('userlist-minimized');
+				$('div.inner.message-log').removeClass('inner-chat-userlist-maximized');
 				return;
 			}
 			if (!this.$chatbox) {
@@ -1142,7 +1134,7 @@
 			app.user.off('change', this.updateUser, this);
 			Room.prototype.destroy.call(this, alreadyLeft);
 		}
-	}, 
+	},
 	{
 		toggleFormatChar: function (textbox, formatChar) {
 			if (!textbox.setSelectionRange) return false;

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1,5 +1,15 @@
 (function ($) {
 
+	// function to hide the user list and widen the chat
+	const removeUserList = () => {
+		$('ul.battle-userlist.userlist').removeClass('userlist-maximized');
+		$('ul.battle-userlist.userlist').addClass('userlist-minimized');
+		const innerMessageLog = $('div.inner.message-log');
+		console.log(innerMessageLog);
+		if (this.innerMessageLog != null) {
+			this.innerMessageLog.removeClass('inner-chat-userlist-maximized');
+		}
+	}
 	var ConsoleRoom = this.ConsoleRoom = Room.extend({
 		type: 'chat',
 		title: '',
@@ -60,6 +70,7 @@
 						$(target).focus();
 					}, 0);
 				} */
+				removeUserList();
 				return;
 			}
 			if (!this.$chatbox) {
@@ -1131,7 +1142,8 @@
 			app.user.off('change', this.updateUser, this);
 			Room.prototype.destroy.call(this, alreadyLeft);
 		}
-	}, {
+	}, 
+	{
 		toggleFormatChar: function (textbox, formatChar) {
 			if (!textbox.setSelectionRange) return false;
 
@@ -1728,7 +1740,7 @@
 			this.innerMessageLog = $('div.inner.message-log');
 		},
 		events: {
-			'click .userlist-count': 'toggleUserlist'
+			'click .userlist-count': 'toggleUserlist',
 		},
 		construct: function () {
 			var buf = '';

--- a/style/client.css
+++ b/style/client.css
@@ -1725,6 +1725,7 @@ a.ilink.yours {
 .inner-chat-userlist-maximized {
 	position: absolute;
 	left: 145px;
+	right: 0px;
 }
 .chat-log.hasuserlist,
 .chat-log-add.hasuserlist,

--- a/style/client.css
+++ b/style/client.css
@@ -1723,7 +1723,8 @@ a.ilink.yours {
 	background: #DEE4EA;
 }
 .inner-chat-userlist-maximized {
-	transform: translateX(146px);
+	position: absolute;
+	left: 145px;
 }
 .chat-log.hasuserlist,
 .chat-log-add.hasuserlist,

--- a/style/client.css
+++ b/style/client.css
@@ -1722,6 +1722,9 @@ a.ilink.yours {
 .pm-buttonbar button:hover {
 	background: #DEE4EA;
 }
+.inner-chat-userlist-maximized {
+	transform: translateX(146px);
+}
 .chat-log.hasuserlist,
 .chat-log-add.hasuserlist,
 .tournament-wrapper.hasuserlist {


### PR DESCRIPTION
Context: While playing in tournaments with friends I would get annoyed the user list would overlap the chat so I couldn't read parts of the chat while the user list was open, not the biggest issue so understand if this change is unnecessary, but thought I give a quick go at fixing it. 

before: https://streamable.com/8pz2bu
after: https://streamable.com/2qhnar

Kinda a hacky fix: Just get the inner chat div using JQuery selectors and apply a new class thats just translateX(146px) to it if the user list is open, since 146 seems to be the standard size of the chat window. I can see how adding a magic number here would be bad, but not sure how else to get the width of the column. Ran npm run test/lint and everything seems fine there. 