### PR TITLE
Fix Z-move BP display in tooltips

### DIFF
--- a/src/battle-dex-data.ts
+++ b/src/battle-dex-data.ts
@@ -1193,7 +1193,8 @@ class Move implements Effect {
 				}
 			}
 		}
-		if (this.category !== 'Status' && !this.zMove && !this.isZ && !this.isMax) {
+
+		if (this.category !== 'Status' && !this.isZ && !this.isMax) {
 			let basePower = this.basePower;
 			this.zMove = {};
 			if (Array.isArray(this.multihit)) basePower *= 3;


### PR DESCRIPTION
Currently, Z-move BP is not displayed because of some additional check in the if statement. Removing it fixes the issue. @KrisXV do you know why it was originally added? 

Fixes bugs such as https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-8460441