### PR TITLE
Clarify config whitelist settings

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -5,127 +5,14 @@ var Config = Config || {};
 Config.bannedHosts = ['cool.jit.su', 'pokeball-nixonserver.rhcloud.com'];
 
 Config.whitelist = [
-	// general sites
 	'wikipedia.org',
-	'wikimedia.org',
-	'wiktionary.org',
-	'github.com',
-	'reddit.com',
-	'gamefaqs.com',
-	'facebook.com',
-	'fbcdn.net',
-	'twitter.com',
-	'tumblr.com',
-	'deviantart.com',
-	'youtube.com',
-	'youtu.be',
-	'zombo.com',
-	'strawpoll.me',
-	'twitch.tv',
-	'take-a-screenshot.org',
-	'myanimelist.net',
-	'4chan.org',
-	'tumblr.com',
-	'git.io',
-	'mibbit.com',
-	'codecademy.com',
-	'xkcd.com',
-	'stackoverflow.com',
-	'stackexchange.com',
-	'malwarebytes.org',
-	'animenewsnetwork.com',
-	'animenewsnetwork.cc',
-	'zombo.com',
-	'html5zombo.com',
-	'whatismyipaddress.com',
 
-	// pokemon sites
-	'pokemonshowdown.com',
-	'psim.us',
-	'smogon.com',
-	'upokecenter.com',
-	'veekun.com',
-	'bulbagarden.net',
-	'serebii.net',
-	'nuggetbridge.com',
-	'pokecommunity.com',
-	'pokemon-online.eu',
-	'pokemonlab.com',
-	'shoddybattle.com',
-	'pokemonxy.com',
-	'pokemon.com',
-	'pokemon-gl.com',
-	'pokecheck.org',
-	'projectpokemon.org',
-	'pokemondb.net',
-	'pokemoncentral.it',
-	'poketrade.us',
-	'neverused.net',
-	'pokestrat.com',
-	'pokestrat.io',
-	'spo.ink',
-	'jooas.com',
-	'pokemongodb.net',
-	'pokeassistant.com',
-	'pokemon-sunmoon.com',
-	'gamepress.gg',
-	'trainertower.com',
-	'pokepast.es',
-	'pokepedia.fr',
-	'randbatscalc.github.io',
-	'ruins-of-alph.github.io',
+	// The full list is maintained outside of this repository so changes to it
+	// don't clutter the commit log. Feel free to copy our list for your own
+	// purposes; it's here: https://play.pokemonshowdown.com/config/config.js
 
-	// personal sites
-	'breakdown.forumotion.com',
-	'pokemonmillennium.net',
-	'thebattletower.no-ip.org',
-	'meltsner.com',
-	'guangcongluo.com',
-	'cathyjf.com',
-	'xiaotai.org',
-	'xfix.pw',
-	'pkmn.cc',
-	'bumba.me',
-	'strategydatabase.jimdo.com',
-	'hidden50.github.io',
-	'krisxv.github.io',
-	// personal hosting sites
-	'forumieren.com',
-	'soforums.com',
-	'proboards.com',
-	'weebly.com',
-	'freeforums.org',
-	'forumactif.com',
-	'forumotion.com',
-	'bigbangpokemon.com',
-	'sites.google.com',
-
-	// rich text
-	'docs.google.com',
-
-	// text
-	'pastebin.com',
-	'hastebin.com',
-	'pastie.io',
-	'trello.com',
-	'challonge.com',
-	'piratepad.net',
-	'pastebin.run',
-
-	// music
-	'plug.dj',
-	'openings.moe',
-
-	// images
-	'prntscr.com',
-	'prnt.sc',
-	'puu.sh',
-	'd.pr',
-	'snag.gy',
-	'gyazo.com',
-	'imgur.com',
-	'gfycat.com',
-	'4cdn.org'
+	// If you would like to change our list, simply message Zarel on Smogon or
+	// Discord.
 ];
 
 // `defaultserver` specifies the server to use when the domain name in the


### PR DESCRIPTION
Changes will need to be reflected in an update to config.js.

https://victoryroadvgc.com/ - very popular and influential VGC resource hub; manage streams, host team reports, provide samples / Speed tiers etc.

https://vgcstats.com/ - compiles IRL VGC stats. Not as useful with quarantine and all, but has been a good resource for IRL usage stats at a glance.

https://pikalytics.com/ - combines Battle Stadium and Showdown VGC usage stats. Supports a damage calculator and custom teambuilder.