### PR TITLE
User settings: Support new blockpms format

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -194,7 +194,9 @@ function toId() {
 			if (settings[setting] !== value) {
 				switch (setting) {
 				case 'blockPMs':
-					app.send(value ? '/blockpms' : '/unblockpms');
+					app.send(value ? '/blockpms ' + value : '/unblockpms');
+					// transform legacy boolean values to an object
+					value = {all: value, specific: []};
 					break;
 				case 'blockChallenges':
 					app.send(value ? '/blockchallenges' : '/unblockchallenges');


### PR DESCRIPTION
Will transform legacy boolean values stored in the client to match the new Object (`{all: AuthLevel, specific: []}`) type of `blockPMs` on the server (when server PR #7191 is merged.)