### PR TITLE
Ensure that the BGM restarts when starting a new battle

### DIFF
--- a/src/battle-sound.ts
+++ b/src/battle-sound.ts
@@ -17,13 +17,17 @@ class BattleBGM {
 	 */
 	isPlaying = false;
 	isActuallyPlaying = false;
+	/**
+	 * The sound should be rewound when it next plays.
+	 */
+	willRewind = true;
 	constructor(url: string, loopstart: number, loopend: number) {
 		this.url = url;
 		this.loopstart = loopstart;
 		this.loopend = loopend;
 	}
 	play() {
-		if (this.sound) this.sound.currentTime = 0;
+		this.willRewind = true;
 		this.resume();
 	}
 	resume() {
@@ -37,7 +41,7 @@ class BattleBGM {
 	}
 	stop() {
 		this.pause();
-		if (this.sound) this.sound.currentTime = 0;
+		this.willRewind = true;
 	}
 	destroy() {
 		BattleSound.deleteBgm(this);
@@ -50,6 +54,8 @@ class BattleBGM {
 
 		if (!this.sound) this.sound = BattleSound.getSound(this.url);
 		if (!this.sound) return;
+		if (this.willRewind) this.sound.currentTime = 0;
+		this.willRewind = false;
 		this.isActuallyPlaying = true;
 		this.sound.volume = BattleSound.bgmVolume / 100;
 		this.sound.play();


### PR DESCRIPTION
I don't claim to understand the old BGM code, but somehow the BGM would always restart when starting a new battle. This doesn't happen with the new BGM code from PR #1563.
- When starting a new battle, we don't have a sound yet. So although we ask to reset it, nothing happens.
- When stopping a sound instance, if it's never played, it won't get rewound.

This changes fixes the second part, and indirectly the first part by making new sound objects always rewind, but if you don't want that, I can fix the first by part instead by changing `src/battle-animations.ts` something like this:
```diff
	resetBgm() {
-		if (this.bgm) this.bgm.stop();
+		if (!this.bgm) this.rollBgm();
+		this.bgm!.stop();
	}
```