### PR TITLE
Mainmenu: Show out-of-date app users an error

### DIFF
--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -104,7 +104,7 @@
 				}
 				app.roomsFirstOpen = 2;
 			}
-			if ('nw' in window && !nw.process.version.startsWith('v13')) {
+			if ('nw' in window && !nw.process.version.startsWith('v13.')) {
 				app.addPopupMessage(
 					"Your version of the app is out of date.\n" +
 					"Go to pokemonshowdown.com to update it."

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -104,6 +104,12 @@
 				}
 				app.roomsFirstOpen = 2;
 			}
+			if ('nw' in window && !nw.process.version.startsWith('v13')) {
+				app.addPopupMessage(
+					"Your version of the app is out of date.\n" +
+					"Go to pokemonshowdown.com to update it."
+				);
+			}
 		},
 
 		addPseudoPM: function (options) {

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -107,7 +107,7 @@
 			if ('nw' in window && !nw.process.version.startsWith('v13.')) {
 				app.addPopupMessage(
 					"Your version of the app is out of date.\n" +
-					"Go to pokemonshowdown.com to update it."
+					"Please go to pokemonshowdown.com to update it."
 				);
 			}
 		},


### PR DESCRIPTION
Not sure if this is the right way to do this, but doing it in mainmenu gave access to tools to make the popup easier, and made the most sense since similar initialization things are done there.