### PR TITLE
Simplify protocol for the Unnerve ability

### DIFF
--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -260,9 +260,9 @@ class BattleTextParser {
 		return `???side:${side}???`;
 	}
 
-	team(side: string) {
+	team(side: string, isFar: 0 | 1 = 0) {
 		side = side.slice(0, 2);
-		if (side === (this.perspective === 0 ? 'p1' : 'p2')) {
+		if (side === (this.perspective === isFar ? 'p1' : 'p2')) {
 			return BattleText.default.team;
 		}
 		return BattleText.default.opposingTeam;
@@ -609,7 +609,7 @@ class BattleTextParser {
 			const id = BattleTextParser.effectId(ability);
 			if (id === 'unnerve') {
 				const template = this.template('start', ability);
-				return line1 + template.replace('[TEAM]', this.team(arg4));
+				return line1 + template.replace('[TEAM]', this.team(pokemon.slice(0, 2), 1));
 			}
 			let templateId = 'start';
 			if (id === 'anticipation' || id === 'sturdy') templateId = 'activate';


### PR DESCRIPTION
I tested using [this old replay](https://replay.pokemonshowdown.com/nu-593386897), and this appears to be fully backwards compatible. I'll also make a server PR to remove the extraneous side data from Unnerve activation messages, but that one won't be totally compatible with an outdated client, so this for sure has to be merged and public before that is.