### PR TITLE
Close uploaded replay when opening a new one

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -1316,6 +1316,7 @@
 		readReplayFile: function (file) {
 			var reader = new FileReader();
 			reader.onload = function (e) {
+				app.removeRoom('battle-uploadedreplay');
 				var html = e.target.result;
 				var titleStart = html.indexOf('<title>');
 				var titleEnd = html.indexOf('</title>');


### PR DESCRIPTION
Previously, if an uploaded replay was already open, trying to open a new one wouldn't replace it automatically.