### PR TITLE
Fix challenging "boolean" usernames

### DIFF
--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -697,7 +697,7 @@
 			var self = this;
 			this.$('.pm-window').each(function (i, el) {
 				var $pmWindow = $(el);
-				var userid = $pmWindow.getAttribute('data-userid');
+				var userid = el.getAttribute('data-userid');
 				var name = $pmWindow.data('name');
 				if (data.challengesFrom[userid]) {
 					var format = data.challengesFrom[userid];

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -697,7 +697,7 @@
 			var self = this;
 			this.$('.pm-window').each(function (i, el) {
 				var $pmWindow = $(el);
-				var userid = '' + $pmWindow.data('userid');
+				var userid = $pmWindow.getAttribute('data-userid');
 				var name = $pmWindow.data('name');
 				if (data.challengesFrom[userid]) {
 					var format = data.challengesFrom[userid];

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -697,7 +697,7 @@
 			var self = this;
 			this.$('.pm-window').each(function (i, el) {
 				var $pmWindow = $(el);
-				var userid = $pmWindow.data('userid');
+				var userid = '' + $pmWindow.data('userid');
 				var name = $pmWindow.data('name');
 				if (data.challengesFrom[userid]) {
 					var format = data.challengesFrom[userid];
@@ -727,6 +727,9 @@
 								$challenge.html('<form class="battleform"><p>The challenge was cancelled.</p><p class="buttonbar"><button name="dismissChallenge">OK</button></p></form>');
 							}
 						} else if ($challenge.find('button[name=cancelChallenge]').length && challengeToUserid !== userid) {
+							//console.log($challenge.find('button[name=cancelChallenge]').length);
+							//console.log(challengeToUserid);
+							//console.log(userid);
 							// You were challenging someone else, and they either accepted
 							// or rejected it
 							$challenge.remove();

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -727,9 +727,6 @@
 								$challenge.html('<form class="battleform"><p>The challenge was cancelled.</p><p class="buttonbar"><button name="dismissChallenge">OK</button></p></form>');
 							}
 						} else if ($challenge.find('button[name=cancelChallenge]').length && challengeToUserid !== userid) {
-							//console.log($challenge.find('button[name=cancelChallenge]').length);
-							//console.log(challengeToUserid);
-							//console.log(userid);
 							// You were challenging someone else, and they either accepted
 							// or rejected it
 							$challenge.remove();


### PR DESCRIPTION
This particularly affected challenging user false, who would properly receive the challenge, but it would be canceled on the challenger's end later due to 'false' !== false in the later check on client-mainmenu:729. I'm not sure if there's a smarter way to do this.

We have more calls to data.('userid') - should I just go ahead and sanitize all of them?

Before:
![image](https://user-images.githubusercontent.com/23667022/99623558-00f7db00-29f2-11eb-912d-b35b83ff7743.png)

After:
![image](https://user-images.githubusercontent.com/23667022/99623538-f76e7300-29f1-11eb-809f-3a1076d2da0d.png)