### PR TITLE
Actually remove healing berries after they're eaten

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1519,6 +1519,7 @@ class Battle {
 		if (kwArgs.then) this.waitForAnimations = false;
 		if (kwArgs.simult) this.waitForAnimations = 'simult';
 
+		const CONSUMED = ['eaten', 'popped', 'consumed', 'held up'];
 		switch (args[0]) {
 		case '-damage': {
 			let poke = this.getPokemon(args[1])!;
@@ -1532,7 +1533,7 @@ class Battle {
 				this.activateAbility(ofpoke, effect);
 				if (effect.effectType === 'Item') {
 					const itemPoke = ofpoke || poke;
-					if (itemPoke.prevItem !== effect.name) {
+					if (itemPoke.prevItem !== effect.name && !CONSUMED.includes(itemPoke.prevItemEffect)) {
 						itemPoke.item = effect.name;
 					}
 				}
@@ -1586,8 +1587,10 @@ class Battle {
 			if (kwArgs.from) {
 				let effect = Dex.getEffect(kwArgs.from);
 				this.activateAbility(poke, effect);
-				if (effect.effectType === 'Item') {
-					poke.item = effect.name;
+				if (effect.effectType === 'Item' && !CONSUMED.includes(poke.prevItemEffect)) {
+					if (poke.prevItem !== effect.name) {
+						poke.item = effect.name;
+					}
 				}
 				switch (effect.id) {
 				case 'lunardance':


### PR DESCRIPTION
~I think this should also fix a rare case where a Pokemon A's Sticky Barb is stolen by an opponent through an effect like Magician, then Pokemon A gets the Sticky Barb back via Sticky Barb's effect (which has no message), because it looks like the old code would not have set Pokemon A's item to be a Sticky Barb again after the damage effect since it's previously held item was also a Sticky Barb.~ Edit: nah, that wasn't a problem to begin with.