### PR TITLE
Properly interpret Max Moves from base move type

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -333,7 +333,7 @@
 			var switchables = [];
 			if (this.request) {
 				// TODO: investigate when to do this
-				this.updateSide(this.request.side);
+				this.updateSide();
 
 				act = this.request.requestType;
 				if (this.request.side) {
@@ -526,11 +526,13 @@
 			var canUltraBurst = curActive.canUltraBurst || switchables[pos].canUltraBurst;
 			var canDynamax = curActive.canDynamax || switchables[pos].canDynamax;
 			var maxMoves = curActive.maxMoves || switchables[pos].maxMoves;
+			var gigantamax = curActive.gigantamax;
 			if (canZMove && typeof canZMove[0] === 'string') {
 				canZMove = _.map(canZMove, function (move) {
 					return {move: move, target: Dex.getMove(move).target};
 				});
 			}
+			if (gigantamax) gigantamax = Dex.getMove(gigantamax);
 
 			this.finalDecisionMove = curActive.maybeDisabled || false;
 			this.finalDecisionSwitch = curActive.maybeTrapped || false;
@@ -648,8 +650,8 @@
 								// when possible, use Z move to decide type, for cases like Z-Hidden Power
 								var baseMove = this.battle.dex.getMove(curActive.moves[i].move);
 								// might not exist, such as for Z status moves - fall back on base move to determine type then
-								var specialMove = this.battle.dex.getMove(specialMoves[i].move);
-								var moveType = this.tooltips.getMoveType(specialMove.exists ? specialMove : baseMove, typeValueTracker)[0];
+								var specialMove = gigantamax || this.battle.dex.getMove(specialMoves[i].move);
+								var moveType = this.tooltips.getMoveType(specialMove.exists && !specialMove.isMax ? specialMove : baseMove, typeValueTracker, specialMove.isMax ? gigantamax || switchables[pos].gigantamax || true : undefined)[0];
 								var tooltipArgs = classType + 'move|' + baseMove.id + '|' + pos;
 								if (specialMove.id.startsWith('gmax')) tooltipArgs += '|' + specialMove.id;
 								movebuttons += '<button class="type-' + moveType + ' has-tooltip" name="chooseMove" value="' + (i + 1) + '" data-move="' + BattleLog.escapeHTML(specialMoves[i].move) + '" data-target="' + BattleLog.escapeHTML(specialMoves[i].target) + '" data-tooltip="' + BattleLog.escapeHTML(tooltipArgs) + '">';
@@ -1004,10 +1006,12 @@
 				this.$chat = this.$chatFrame.find('.inner');
 			}
 		},
-		updateSide: function (sideData) {
+		updateSide: function () {
+			var sideData = this.request.side;
 			this.battle.myPokemon = sideData.pokemon;
 			for (var i = 0; i < sideData.pokemon.length; i++) {
 				var pokemonData = sideData.pokemon[i];
+				if (this.request.active && this.request.active[i]) pokemonData.canGmax = this.request.active[i].gigantamax || false;
 				this.battle.parseDetails(pokemonData.ident.substr(4), pokemonData.ident, pokemonData.details, pokemonData);
 				this.battle.parseHealth(pokemonData.condition, pokemonData);
 				pokemonData.hpDisplay = Pokemon.prototype.hpDisplay;

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -1316,7 +1316,7 @@ class BattleTooltips {
 		const noTypeOverride = [
 			'judgment', 'multiattack', 'naturalgift', 'revelationdance', 'struggle', 'technoblast', 'terrainpulse', 'weatherball',
 		];
-		const allowTypeOverride = !noTypeOverride.includes(move.id);
+		const allowTypeOverride = !forMaxMove && !noTypeOverride.includes(move.id);
 
 		if (allowTypeOverride && category !== 'Status' && !move.isZ) {
 			if (moveType === 'Normal') {

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -491,6 +491,14 @@ class BattleTooltips {
 		"???": "",
 	};
 
+	getMaxMoveFromType(type: TypeName, gmaxMove?: string | Move) {
+		if (gmaxMove) {
+			gmaxMove = Dex.getMove(gmaxMove);
+			if (type === gmaxMove.type) return gmaxMove;
+		}
+		return Dex.getMove(BattleTooltips.maxMoveTable[type]);
+	}
+
 	showMoveTooltip(move: Move, isZOrMax: string, pokemon: Pokemon, serverPokemon: ServerPokemon, gmaxMove?: Move) {
 		let text = '';
 
@@ -502,6 +510,7 @@ class BattleTooltips {
 		let item = this.battle.dex.getItem(serverPokemon.item);
 
 		let value = new ModifiableValue(this.battle, pokemon, serverPokemon);
+		let [moveType, category] = this.getMoveType(move, value, gmaxMove || isZOrMax === 'maxmove');
 
 		if (isZOrMax === 'zmove') {
 			if (item.zMoveFrom === move.name) {
@@ -548,50 +557,7 @@ class BattleTooltips {
 			if (move.category === 'Status') {
 				move = this.battle.dex.getMove('Max Guard');
 			} else {
-				// TODO look into if client knows if a pokemon (on its side) can gmax rather than dynamax.
-				// If not, tell client so we can use it for tooltips.
-				let maxMove = gmaxMove ? gmaxMove :
-					this.battle.dex.getMove(BattleTooltips.maxMoveTable[move.type]);
-				if (move.id === 'aurawheel' && pokemon.getSpeciesForme() === 'Morpeko-Hangry') {
-					maxMove = this.battle.dex.getMove(BattleTooltips.maxMoveTable['Dark']);
-				}
-				if (move.id === 'weatherball') {
-					switch (this.battle.weather) {
-					case 'sunnyday':
-					case 'desolateland':
-						if (item.id === 'utilityumbrella') break;
-						maxMove = this.battle.dex.getMove(BattleTooltips.maxMoveTable['Fire']);
-						break;
-					case 'raindance':
-					case 'primordialsea':
-						if (item.id === 'utilityumbrella') break;
-						maxMove = this.battle.dex.getMove(BattleTooltips.maxMoveTable['Water']);
-						break;
-					case 'sandstorm':
-						maxMove = this.battle.dex.getMove(BattleTooltips.maxMoveTable['Rock']);
-						break;
-					case 'hail':
-						maxMove = this.battle.dex.getMove(BattleTooltips.maxMoveTable['Ice']);
-						break;
-					}
-				}
-				if (move.id === 'terrainpulse') {
-					if (this.battle.hasPseudoWeather('Electric Terrain')) {
-						maxMove = this.battle.dex.getMove(BattleTooltips.maxMoveTable['Electric']);
-					} else if (this.battle.hasPseudoWeather('Grassy Terrain')) {
-						maxMove = this.battle.dex.getMove(BattleTooltips.maxMoveTable['Grass']);
-					} else if (this.battle.hasPseudoWeather('Misty Terrain')) {
-						maxMove = this.battle.dex.getMove(BattleTooltips.maxMoveTable['Fairy']);
-					} else if (this.battle.hasPseudoWeather('Psychic Terrain')) {
-						maxMove = this.battle.dex.getMove(BattleTooltips.maxMoveTable['Psychic']);
-					}
-				}
-				if (move.id === 'multiattack' && item.onMemory) {
-					maxMove = this.battle.dex.getMove(BattleTooltips.maxMoveTable[item.onMemory]);
-				}
-				if (move.id === 'technoblast' && item.onDrive) {
-					maxMove = this.battle.dex.getMove(BattleTooltips.maxMoveTable[item.onDrive]);
-				}
+				let maxMove = this.getMaxMoveFromType(moveType, gmaxMove);
 				const basePower = ['gmaxdrumsolo', 'gmaxfireball', 'gmaxhydrosnipe'].includes(maxMove.id) ?
 					maxMove.basePower : move.maxMove.basePower;
 				move = new Move(maxMove.id, maxMove.name, {
@@ -603,9 +569,6 @@ class BattleTooltips {
 		}
 
 		text += '<h2>' + move.name + '<br />';
-
-		// Handle move type for moves that vary their type.
-		let [moveType, category] = this.getMoveType(move, value);
 
 		text += Dex.getTypeIcon(moveType);
 		text += ` ${Dex.getCategoryIcon(category)}</h2>`;
@@ -1286,7 +1249,7 @@ class BattleTooltips {
 	/**
 	 * Gets the proper current type for moves with a variable type.
 	 */
-	getMoveType(move: Move, value: ModifiableValue): [TypeName, 'Physical' | 'Special' | 'Status'] {
+	getMoveType(move: Move, value: ModifiableValue, forMaxMove?: boolean | Move): [TypeName, 'Physical' | 'Special' | 'Status'] {
 		let moveType = move.type;
 		let category = move.category;
 		// can happen in obscure situations
@@ -1355,9 +1318,6 @@ class BattleTooltips {
 		];
 		const allowTypeOverride = !noTypeOverride.includes(move.id);
 
-		if (allowTypeOverride && move.flags['sound'] && value.abilityModify(0, 'Liquid Voice')) {
-			moveType = 'Water';
-		}
 		if (allowTypeOverride && category !== 'Status' && !move.isZ) {
 			if (moveType === 'Normal') {
 				if (value.abilityModify(0, 'Aerilate')) moveType = 'Flying';
@@ -1366,6 +1326,11 @@ class BattleTooltips {
 				if (value.abilityModify(0, 'Refrigerate')) moveType = 'Ice';
 			}
 			if (value.abilityModify(0, 'Normalize')) moveType = 'Normal';
+		}
+		// There aren't any max moves with the sound flag, but if there were, Liquid Voice would make them water type
+		const isSound = !!(forMaxMove ? this.getMaxMoveFromType(moveType, forMaxMove !== true && forMaxMove || undefined) : move).flags['sound'];
+		if (allowTypeOverride && isSound && value.abilityModify(0, 'Liquid Voice')) {
+			moveType = 'Water';
 		}
 		if (this.battle.gen <= 3 && category !== 'Status') {
 			category = Dex.getGen3Category(moveType);

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1006,6 +1006,8 @@ interface ServerPokemon extends PokemonDetails, PokemonHealth {
 	item: string;
 	/** currently an ID, will revise to name */
 	pokeball: string;
+	/** false if the pokemon cannot gigantamax, otherwise a string containing the full name of its G-max move */
+	gigantamax: string | false;
 }
 
 class Battle {


### PR DESCRIPTION
This covers the rest of the missing cases where a tooltip should show the true max move. For example:
- Pixilate Sylveon's Max Strike from Hyper Voice will show Max Starfall
- Galvanize Toxtricity-Gmax's Max Strike from Hyper Voice will show G-Max Stun Shock
- Refrigerate Genesect's Max Strike from Techno Blast will show Max Hailstorm
- Normalize Bug Memory Silvally's Max Strike from Multi Attack will show Max Strike.

This also changes the type shown by the max move buttons themselves to match the true max move.