### PR TITLE
Add a horizontal scroll bar for "infobox-limited" class.

### DIFF
--- a/style/battle-log.css
+++ b/style/battle-log.css
@@ -555,7 +555,6 @@ details.readmore[open] summary:hover:before {
 .infobox-limited {
 	max-height: 200px;
 	overflow: auto;
-	overflow-x: hidden;
 }
 .broadcast-red {
 	background-color: #AA5544;


### PR DESCRIPTION
Ig infobox-limited class is in room intros and in the event box. On mobile phones, it is hard to check the whole room intro or event and you can't slide because overflow for the x axis is hidden. So just removing overflow-x: hidden.