### PR TITLE
Disable Max Guard choice on Taunt / Assault Vest

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -663,7 +663,6 @@
 									pp = '&ndash;';
 								}
 								movebuttons += specialMove.name + '<br /><small class="type">' + (moveType ? Dex.getType(moveType).name : "Unknown") + '</small> <small class="pp">' + pp + '</small>&nbsp;</button> ';
-							
 							} else {
 								movebuttons += '<button disabled="disabled">&nbsp;</button>';
 							}

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -654,7 +654,8 @@
 								var moveType = this.tooltips.getMoveType(specialMove.exists && !specialMove.isMax ? specialMove : baseMove, typeValueTracker, specialMove.isMax ? gigantamax || switchables[pos].gigantamax || true : undefined)[0];
 								var tooltipArgs = classType + 'move|' + baseMove.id + '|' + pos;
 								if (specialMove.id.startsWith('gmax')) tooltipArgs += '|' + specialMove.id;
-								movebuttons += '<button class="type-' + moveType + ' has-tooltip" name="chooseMove" value="' + (i + 1) + '" data-move="' + BattleLog.escapeHTML(specialMoves[i].move) + '" data-target="' + BattleLog.escapeHTML(specialMoves[i].target) + '" data-tooltip="' + BattleLog.escapeHTML(tooltipArgs) + '">';
+								var isDisabled = specialMoves[i].disabled ? 'disabled="disabled"' : '';
+								movebuttons += '<button ' + isDisabled + ' class="type-' + moveType + ' has-tooltip" name="chooseMove" value="' + (i + 1) + '" data-move="' + BattleLog.escapeHTML(specialMoves[i].move) + '" data-target="' + BattleLog.escapeHTML(specialMoves[i].target) + '" data-tooltip="' + BattleLog.escapeHTML(tooltipArgs) + '">';
 								var pp = curActive.moves[i].pp + '/' + curActive.moves[i].maxpp;
 								if (canZMove) {
 									pp = '1/1';
@@ -662,6 +663,7 @@
 									pp = '&ndash;';
 								}
 								movebuttons += specialMove.name + '<br /><small class="type">' + (moveType ? Dex.getType(moveType).name : "Unknown") + '</small> <small class="pp">' + pp + '</small>&nbsp;</button> ';
+							
 							} else {
 								movebuttons += '<button disabled="disabled">&nbsp;</button>';
 							}


### PR DESCRIPTION
Before, despite having disabled move data, Max Guard would display as clickable, leading to a number of bug reports where users would try to click Max Guard and get confused, not realizing the server had properly rejected their request. I tested with a number of other situations like Disable, Choice locks etc. and everything else seems to be behaving nicely.

Before:
![image](https://user-images.githubusercontent.com/23667022/103323387-3e478380-4a08-11eb-8ce1-f4c6de830ec6.png)

After:
![image](https://user-images.githubusercontent.com/23667022/103323377-2e2fa400-4a08-11eb-9d8a-83e7a3940e75.png)
