### PR TITLE
Chatroom-specific mute options

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1738,7 +1738,7 @@
 			} else if (mayNotify && this.id.substr(0, 5) === 'help-') {
 				this.notifyOnce("Help message from " + name, "\"" + message + "\"", 'pm');
 			} else if (mayNotify && name !== '~') { // |c:|~| prefixes a system message
-				if(!Dex.prefs('chatmute' + this.title)) {
+				if (!Dex.prefs('chatmute' + this.title)) {
 					this.subtleNotifyOnce();
 				}
 			}

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1727,7 +1727,9 @@
 			} else if (mayNotify && this.id.substr(0, 5) === 'help-') {
 				this.notifyOnce("Help message from " + name, "\"" + message + "\"", 'pm');
 			} else if (mayNotify && name !== '~') { // |c:|~| prefixes a system message
-				this.subtleNotifyOnce();
+				if(!Dex.prefs('chatmute' + this.title)) {
+					this.subtleNotifyOnce();
+				}
 			}
 
 			if (message.slice(0, 4) === '/me ' || message.slice(0, 5) === '/mee') {

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1738,7 +1738,8 @@
 			} else if (mayNotify && this.id.substr(0, 5) === 'help-') {
 				this.notifyOnce("Help message from " + name, "\"" + message + "\"", 'pm');
 			} else if (mayNotify && name !== '~') { // |c:|~| prefixes a system message
-				if (!Dex.prefs('chatmute' + this.title)) {
+				var mutedChats = Dex.prefs('mutedchats') || {};
+				if (!mutedChats[this.id]) {
 					this.subtleNotifyOnce();
 				}
 			}

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1738,8 +1738,8 @@
 			} else if (mayNotify && this.id.substr(0, 5) === 'help-') {
 				this.notifyOnce("Help message from " + name, "\"" + message + "\"", 'pm');
 			} else if (mayNotify && name !== '~') { // |c:|~| prefixes a system message
-				var mutedChats = Dex.prefs('mutedchats') || {};
-				if (!mutedChats[this.id]) {
+				var mutedRooms = Dex.prefs('mutedrooms') || {};
+				if (!mutedRooms[this.id]) {
 					this.subtleNotifyOnce();
 				}
 			}

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -1080,7 +1080,7 @@
 			var buf = '';
 			buf += '<p><strong>' + (sourceTab.context.innerText) + ' chat options</strong></p>';
 			buf += '<p><label class="optlabel"><input type="checkbox" name="chatmuted"' + (chatMuted ? ' checked' : '') + '/>Hide new message indicator</label></p>';
-			buf += '<p><button name="close">Close</button></p>';
+			buf += '<p><button name="closeRoom" value="' + roomId + '" aria-label="Leave Room">Leave Room</button></p>';
 			this.$el.html(buf).css('max-width', 200);
 		},
 		events: {
@@ -1091,6 +1091,10 @@
 			var mutedChats = Dex.prefs('mutedchats') || {};
 			mutedChats[this.roomId] = chatMuted;
 			Storage.prefs('mutedchats', mutedChats);
+		},
+		closeRoom: function (roomid, button, e) {
+			app.leaveRoom(roomid);
+			this.remove();
 		}
 	});
 

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -1089,7 +1089,11 @@
 		setChatMute: function (e) {
 			var chatMuted = !!e.currentTarget.checked;
 			var mutedChats = Dex.prefs('mutedchats') || {};
-			mutedChats[this.roomId] = chatMuted;
+			if (chatMuted) {
+				mutedChats[this.roomId] = 1;
+			} else {
+				delete mutedChats[this.roomId];
+			}
 			Storage.prefs('mutedchats', mutedChats);
 		},
 		closeRoom: function (roomid, button, e) {

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -245,7 +245,7 @@
 			app.addPopup(TabListPopup);
 		},
 		showRoomMuteButton: function (e) {
-			if($(e.currentTarget).data('chat')) {
+			if ($(e.currentTarget).data('chat')) {
 				app.addPopup(MutePopup, {
 					name: e.currentTarget.innerText,
 					sourceEl: e.currentTarget
@@ -1073,12 +1073,12 @@
 	var MutePopup = this.MutePopup = Popup.extend({
 		type: 'normal',
 		initialize: function (data) {
-			roomId = data.name;
+			var roomId = data.name;
 			var buf = '';
 			var chatMuted = !!Dex.prefs('chatmute' + roomId);
 			this.roomId = roomId;
 			buf += '<p><strong>' + roomId + ' chat options</strong></p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="chatmuted"' + (chatMuted ? ' checked' : '') +'/>Hide new message indicator</label></p>';
+			buf += '<p><label class="optlabel"><input type="checkbox" name="chatmuted"' + (chatMuted ? ' checked' : '') + '/>Hide new message indicator</label></p>';
 			this.$el.html(buf).css('max-width', 200);
 		},
 		events: {

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -246,7 +246,7 @@
 		},
 		showRoomMuteButton: function (e) {
 			if ($(e.currentTarget).data('chat')) {
-				app.addPopup(MutePopup, {
+				app.addPopup(TabRightClickPopup, {
 					sourceEl: e.currentTarget
 				});
 			}
@@ -1069,32 +1069,32 @@
 		}
 	});
 
-	var MutePopup = this.MutePopup = Popup.extend({
+	var TabRightClickPopup = this.TabRightClickPopup = Popup.extend({
 		type: 'normal',
 		initialize: function (data) {
 			var sourceTab = data.sourceEl;
 			var roomId = $(sourceTab).attr('href').slice(1);
 			this.roomId = roomId;
-			var mutedChats = Dex.prefs('mutedchats') || {};
-			var chatMuted = mutedChats[roomId];
+			var mutedRooms = Dex.prefs('mutedrooms') || {};
+			var roomMuted = mutedRooms[roomId];
 			var buf = '';
 			buf += '<p><strong>' + (sourceTab.context.innerText) + ' chat options</strong></p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="chatmuted"' + (chatMuted ? ' checked' : '') + '/>Hide new message indicator</label></p>';
+			buf += '<p><label class="optlabel"><input type="checkbox" name="roommuted"' + (roomMuted ? ' checked' : '') + '/>Hide new message indicator</label></p>';
 			buf += '<p><button name="closeRoom" value="' + roomId + '" aria-label="Leave Room">Leave Room</button></p>';
 			this.$el.html(buf).css('max-width', 200);
 		},
 		events: {
-			'change input[name=chatmuted]': 'setChatMute'
+			'change input[name=roommuted]': 'setRoomMute'
 		},
-		setChatMute: function (e) {
-			var chatMuted = !!e.currentTarget.checked;
-			var mutedChats = Dex.prefs('mutedchats') || {};
-			if (chatMuted) {
-				mutedChats[this.roomId] = 1;
+		setRoomMute: function (e) {
+			var roomMuted = !!e.currentTarget.checked;
+			var mutedRooms = Dex.prefs('mutedrooms') || {};
+			if (roomMuted) {
+				mutedRooms[this.roomId] = 1;
 			} else {
-				delete mutedChats[this.roomId];
+				delete mutedRooms[this.roomId];
 			}
-			Storage.prefs('mutedchats', mutedChats);
+			Storage.prefs('mutedrooms', mutedRooms);
 		},
 		closeRoom: function (roomid, button, e) {
 			app.leaveRoom(roomid);

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -247,7 +247,6 @@
 		showRoomMuteButton: function (e) {
 			if ($(e.currentTarget).data('chat')) {
 				app.addPopup(MutePopup, {
-					name: e.currentTarget.innerText,
 					sourceEl: e.currentTarget
 				});
 			}
@@ -1073,11 +1072,13 @@
 	var MutePopup = this.MutePopup = Popup.extend({
 		type: 'normal',
 		initialize: function (data) {
-			var roomId = data.name;
-			var buf = '';
-			var chatMuted = !!Dex.prefs('chatmute' + roomId);
+			var sourceTab = data.sourceEl;
+			var roomId = $(sourceTab).attr('href').slice(1);
 			this.roomId = roomId;
-			buf += '<p><strong>' + roomId + ' chat options</strong></p>';
+			var mutedChats = Dex.prefs('mutedchats') || {};
+			var chatMuted = mutedChats[roomId];
+			var buf = '';
+			buf += '<p><strong>' + (sourceTab.context.innerText) + ' chat options</strong></p>';
 			buf += '<p><label class="optlabel"><input type="checkbox" name="chatmuted"' + (chatMuted ? ' checked' : '') + '/>Hide new message indicator</label></p>';
 			buf += '<p><button name="close">Close</button></p>';
 			this.$el.html(buf).css('max-width', 200);
@@ -1087,7 +1088,9 @@
 		},
 		setChatMute: function (e) {
 			var chatMuted = !!e.currentTarget.checked;
-			Storage.prefs('chatmute' + this.roomId, chatMuted);
+			var mutedChats = Dex.prefs('mutedchats') || {};
+			mutedChats[this.roomId] = chatMuted;
+			Storage.prefs('mutedchats', mutedChats);
 		}
 	});
 

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -10,7 +10,9 @@
 			'dragstart .roomtab': 'dragStartRoom',
 			'dragend .roomtab': 'dragEndRoom',
 			'dragenter .roomtab': 'dragEnterRoom',
-			'dragover .roomtab': 'dragEnterRoom'
+			'dragover .roomtab': 'dragEnterRoom',
+
+			'contextmenu .roomtab': 'showRoomMuteButton'
 		},
 		initialize: function () {
 			// April Fool's 2016 - Digimon Showdown
@@ -112,7 +114,7 @@
 				}
 				return buf + ' draggable="true"><i class="text">' + BattleLog.escapeFormat(formatid) + '</i><span>' + name + '</span></a><button class="closebutton" name="closeRoom" value="' + id + '" aria-label="Close"><i class="fa fa-times-circle"></i></a></li>';
 			case 'chat':
-				return buf + ' draggable="true"><i class="fa fa-comment-o"></i> <span>' + (BattleLog.escapeHTML(room.title) || (id === 'lobby' ? 'Lobby' : id)) + '</span></a><button class="closebutton" name="closeRoom" value="' + id + '" aria-label="Close"><i class="fa fa-times-circle"></i></a></li>';
+				return buf + 'oncontextmenu="return false;" draggable="true" data-chat="true"><i class="fa fa-comment-o"></i> <span>' + (BattleLog.escapeHTML(room.title) || (id === 'lobby' ? 'Lobby' : id)) + '</span></a><button class="closebutton" name="closeRoom" value="' + id + '" aria-label="Close"><i class="fa fa-times-circle"></i></a></li>';
 			case 'html':
 			default:
 				if (room.title && room.title.charAt(0) === '[') {
@@ -241,6 +243,14 @@
 		},
 		tablist: function () {
 			app.addPopup(TabListPopup);
+		},
+		showRoomMuteButton: function (e) {
+			if($(e.currentTarget).data('chat')) {
+				app.addPopup(MutePopup, {
+					name: e.currentTarget.innerText,
+					sourceEl: e.currentTarget
+				});
+			}
 		},
 
 		// drag and drop
@@ -1059,5 +1069,26 @@
 			app.user.passwordRename(data.username, data.password);
 		}
 	});
+
+	var MutePopup = this.MutePopup = Popup.extend({
+		type: 'normal',
+		initialize: function (data) {
+			roomId = data.name;
+			var buf = '';
+			var chatMuted = !!Dex.prefs('chatmute' + roomId);
+			this.roomId = roomId;
+			buf += '<p><strong>' + roomId + ' chat options</strong></p>';
+			buf += '<p><label class="optlabel"><input type="checkbox" name="chatmuted"' + (chatMuted ? ' checked' : '') +'/>Hide new message indicator</label></p>';
+			this.$el.html(buf).css('max-width', 200);
+		},
+		events: {
+			'change input[name=chatmuted]': 'setChatMute'
+		},
+		setChatMute: function (e) {
+			var chatMuted = !!e.currentTarget.checked;
+			Storage.prefs('chatmute' + this.roomId, chatMuted);
+		}
+	});
+
 
 }).call(this, jQuery);

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -1079,6 +1079,7 @@
 			this.roomId = roomId;
 			buf += '<p><strong>' + roomId + ' chat options</strong></p>';
 			buf += '<p><label class="optlabel"><input type="checkbox" name="chatmuted"' + (chatMuted ? ' checked' : '') + '/>Hide new message indicator</label></p>';
+			buf += '<p><button name="close">Close</button></p>';
 			this.$el.html(buf).css('max-width', 200);
 		},
 		events: {

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -245,8 +245,8 @@
 			app.addPopup(TabListPopup);
 		},
 		showRoomTabRightClickMenu: function (e) {
-			e.preventDefault();
 			if ($(e.currentTarget).data('chat')) {
+				e.preventDefault();
 				app.addPopup(TabRightClickPopup, {
 					sourceEl: e.currentTarget
 				});

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -12,7 +12,7 @@
 			'dragenter .roomtab': 'dragEnterRoom',
 			'dragover .roomtab': 'dragEnterRoom',
 
-			'contextmenu .roomtab': 'showRoomMuteButton'
+			'contextmenu .roomtab': 'showRoomTabRightClickMenu'
 		},
 		initialize: function () {
 			// April Fool's 2016 - Digimon Showdown
@@ -114,7 +114,7 @@
 				}
 				return buf + ' draggable="true"><i class="text">' + BattleLog.escapeFormat(formatid) + '</i><span>' + name + '</span></a><button class="closebutton" name="closeRoom" value="' + id + '" aria-label="Close"><i class="fa fa-times-circle"></i></a></li>';
 			case 'chat':
-				return buf + 'oncontextmenu="return false;" draggable="true" data-chat="true"><i class="fa fa-comment-o"></i> <span>' + (BattleLog.escapeHTML(room.title) || (id === 'lobby' ? 'Lobby' : id)) + '</span></a><button class="closebutton" name="closeRoom" value="' + id + '" aria-label="Close"><i class="fa fa-times-circle"></i></a></li>';
+				return buf + ' draggable="true" data-chat="true"><i class="fa fa-comment-o"></i> <span>' + (BattleLog.escapeHTML(room.title) || (id === 'lobby' ? 'Lobby' : id)) + '</span></a><button class="closebutton" name="closeRoom" value="' + id + '" aria-label="Close"><i class="fa fa-times-circle"></i></a></li>';
 			case 'html':
 			default:
 				if (room.title && room.title.charAt(0) === '[') {
@@ -244,7 +244,8 @@
 		tablist: function () {
 			app.addPopup(TabListPopup);
 		},
-		showRoomMuteButton: function (e) {
+		showRoomTabRightClickMenu: function (e) {
+			e.preventDefault();
 			if ($(e.currentTarget).data('chat')) {
 				app.addPopup(TabRightClickPopup, {
 					sourceEl: e.currentTarget


### PR DESCRIPTION
Pull request for [this suggestion](https://www.smogon.com/forums/threads/muting-ps-chatrooms.3675505/). Was originally attempted [here](https://github.com/smogon/pokemon-showdown-client/pull/1703), but that ended up implementing a global notification setting instead of a chatroom-specific one.

The original suggestion proposed using either a right-click on the room tab or a chat command to do this. I opted for the former, mostly because I couldn't think of a succinct command name for this particular behavior, though if my current solution is deemed too clunky we should probably use a chat command instead. Right now a right-click on a chatroom tab brings up a popup that has a "Hide new message indicator" option.

![Right-click submenu](https://user-images.githubusercontent.com/49170515/103845343-e218db00-5069-11eb-8c42-ee109033ed9e.png)
