### PR TITLE
Add sourceMaps and vscode debug configurations

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -31,5 +31,6 @@
 	],
 	"compact": true,
 	"comments": false,
-	"retainLines": true
+	"retainLines": true,
+	"sourceMaps": true
 }

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ Thumbs.db
 npm-debug.log
 package-lock.json
 /vendor/
-.vscode/settings.json
 
 /js/battle.js
 /js/battledata.js
@@ -43,6 +42,7 @@ package-lock.json
 /js/panel-teamdropdown.js
 /js/panel-battle.js
 /js/replay-embed.js
+/js/*.js.map
 
 /replays/caches/
 /replays/replay-config.inc.php

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ Thumbs.db
 npm-debug.log
 package-lock.json
 /vendor/
-.vscode
+.vscode/settings.json
 
 /js/battle.js
 /js/battledata.js

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,13 +2,22 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Chrome: Preact",
+            "name": "Chrome: Test Client Beta (Preact)",
             "port": 9222,
             "request": "launch",
-            "url": "http://localhost:8080/testclient-beta.html",
+            "url": "${config:showdown.url}/testclient-beta.html${config:showdown.server}",
             "type": "pwa-chrome",
             "webRoot": "${workspaceFolder}",
             "preLaunchTask": "npm: build"
-        } 
+        },
+        {
+            "name": "Chrome: Test Client",
+            "port": 9222,
+            "request": "launch",
+            "url": "${config:showdown.url}/testclient.html${config:showdown.server}",
+            "type": "pwa-chrome",
+            "webRoot": "${workspaceFolder}",
+            "preLaunchTask": "npm: build"
+        }
     ]
 } 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Chrome: Preact",
+            "port": 9222,
+            "request": "launch",
+            "url": "http://localhost:8080/testclient-beta.html",
+            "type": "pwa-chrome",
+            "webRoot": "${workspaceFolder}",
+            "preLaunchTask": "npm: build"
+        } 
+    ]
+} 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
             "name": "Chrome: Test Client Beta (Preact)",
             "port": 9222,
             "request": "launch",
-            "url": "${config:showdown.url}/testclient-beta.html${config:showdown.server}",
+            "url": "${config:showdown.clientUrl}/testclient-beta.html${config:showdown.server}",
             "type": "pwa-chrome",
             "webRoot": "${workspaceFolder}",
             "preLaunchTask": "npm: build"
@@ -14,7 +14,7 @@
             "name": "Chrome: Test Client",
             "port": 9222,
             "request": "launch",
-            "url": "${config:showdown.url}/testclient.html${config:showdown.server}",
+            "url": "${config:showdown.clientUrl}/testclient.html${config:showdown.server}",
             "type": "pwa-chrome",
             "webRoot": "${workspaceFolder}",
             "preLaunchTask": "npm: build"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.formatOnSave": false,
+  "showdown.server": "", // e.g., "?~~localhost:8000"
+  "showdown.url": "http://localhost:8080"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
   "editor.formatOnSave": false,
   "showdown.server": "", // e.g., "?~~localhost:8000"
-  "showdown.url": "http://localhost:8080"
+  "showdown.clientUrl": "http://localhost:8080"
 }

--- a/build-tools/update
+++ b/build-tools/update
@@ -82,7 +82,7 @@ if (process.argv[2] === 'full') {
 	} catch (e) {}
 }
 
-child_process.execSync(`node build-tools/babel-cli/bin/babel.js src --out-dir js --extensions ".ts,.tsx" --incremental${ignoreGraphics}`);
+child_process.execSync(`node build-tools/babel-cli/bin/babel.js src --out-dir js --extensions ".ts,.tsx" --incremental${ignoreGraphics} --source-maps`);
 
 let textData = '';
 try {


### PR DESCRIPTION
These are tooling changes that I made for another upcoming change. I want to get them reviewed in their own separate PR.

**Source maps:**
Unlike the server, these maps are stored alongside the transpired js. Browsers make requests for them when dev tools are in use.

**Launch configs:**
These require an already running HTTP server. You can launch the debugger from vscode and it will build and then launch Chrome.
