### PR TITLE
Update Preact Lib for Fragments

### DIFF
--- a/js/lib/preact.d.ts
+++ b/js/lib/preact.d.ts
@@ -890,5 +890,4 @@ declare global {
 			use: SVGAttributes;
 		}
 	}
-
 }

--- a/js/lib/preact.d.ts
+++ b/js/lib/preact.d.ts
@@ -122,6 +122,8 @@ declare namespace preact {
 		vnode?: (vnode: VNode<any>) => void;
 		event?: (event: Event) => Event;
 	};
+
+	const Fragment: ComponentConstructor<{}, {}>;
 }
 
 declare global {
@@ -888,4 +890,5 @@ declare global {
 			use: SVGAttributes;
 		}
 	}
+
 }


### PR DESCRIPTION
To support, for example:

(in loop):
`<preact.Fragment key={key}><h3>...</h3><ul>...</ul></preact.Fragment>`

This change also removes "\<undefined\>" tags from the DOM when Fragments are used.

I grabbed the latest from the CDN (2021/01/15):

https://cdn.jsdelivr.net/npm/preact/dist/preact.min.js