### PR TITLE
Add custom filters for Gmax formes

### DIFF
--- a/src/battle-dex-search.ts
+++ b/src/battle-dex-search.ts
@@ -931,8 +931,8 @@ class BattlePokemonSearch extends BattleTypedSearch<'pokemon'> {
 		// Filter out Gmax Pokemon from standard tier selection
 		if (!/^(battlestadium|vgc|doublesubers)/g.test(format)) {
 			tierSet = tierSet.filter(([type, id]) => {
-				if (type === 'header' && toID(id) === 'uberbytechnicality') return false;
-				return !id.endsWith('gmax');
+				if (type === 'pokemon') return !id.endsWith('gmax');
+				return true;
 			});
 		}
 

--- a/src/battle-dex-search.ts
+++ b/src/battle-dex-search.ts
@@ -889,8 +889,8 @@ class BattlePokemonSearch extends BattleTypedSearch<'pokemon'> {
 		else if (format === 'cap') tierSet = tierSet.slice(0, slices.Uber).concat(tierSet.slice(slices.OU));
 		else if (format === 'caplc') tierSet = tierSet.slice(slices['CAP LC'], slices.Uber).concat(tierSet.slice(slices.LC));
 		else if (format.startsWith('lc') || format.endsWith('lc')) tierSet = tierSet.slice(slices["LC Uber"]);
-		else if (format === 'anythinggoes' || format.endsWith('ag')) tierSet = tierSet.slice(dex.gen === 8 ? slices.Uber : slices.AG || slices.Uber);
-		else if (format === 'balancedhackmons' || format.endsWith('bh')) tierSet = tierSet.slice(dex.gen === 8 ? slices.Uber : slices.AG || slices.Uber);
+		else if (format === 'anythinggoes' || format.endsWith('ag')) tierSet = tierSet.slice(slices.AG);
+		else if (format === 'balancedhackmons' || format.endsWith('bh')) tierSet = tierSet.slice(slices.AG);
 		else if (format === 'doublesubers') tierSet = tierSet.slice(slices.DUber);
 		else if (format === 'doublesou' && dex.gen > 4) tierSet = tierSet.slice(slices.DOU);
 		else if (format === 'doublesuu') tierSet = tierSet.slice(slices.DUU);
@@ -900,7 +900,7 @@ class BattlePokemonSearch extends BattleTypedSearch<'pokemon'> {
 		else if (!isDoublesOrBS) {
 			tierSet = [
 				...tierSet.slice(slices.OU, slices.UU),
-				...(dex.gen === 8 ? [] : tierSet.slice(slices.AG, slices.Uber)),
+				...tierSet.slice(slices.AG, slices.Uber),
 				...tierSet.slice(slices.Uber, slices.OU),
 				...tierSet.slice(slices.UU),
 			];
@@ -913,8 +913,8 @@ class BattlePokemonSearch extends BattleTypedSearch<'pokemon'> {
 		}
 
 		if (format === 'zu' && dex.gen >= 7) {
-			tierSet = tierSet.filter(function (r) {
-				if (r[1] in table.zuBans) return false;
+			tierSet = tierSet.filter(([type, id]) => {
+				if (id in table.zuBans) return false;
 				return true;
 			});
 		}
@@ -925,6 +925,14 @@ class BattlePokemonSearch extends BattleTypedSearch<'pokemon'> {
 					'deoxys', 'deoxysattack', 'deoxysdefense', 'deoxysspeed', 'mew', 'celebi', 'shaymin', 'shayminsky', 'darkrai', 'victini', 'keldeo', 'keldeoresolute', 'meloetta', 'arceus', 'genesect', 'jirachi', 'manaphy', 'phione', 'hoopa', 'hoopaunbound', 'diancie', 'dianciemega',
 				];
 				return !(banned.includes(id) || id.startsWith('arceus'));
+			});
+		}
+
+		// Filter out Gmax Pokemon from standard tier selection
+		if (!/^(battlestadium|vgc|doublesubers)/g.test(format)) {
+			tierSet = tierSet.filter(([type, id]) => {
+				if (type === 'header' && toID(id) === 'uberbytechnicality') return false;
+				return !id.endsWith('gmax');
 			});
 		}
 


### PR DESCRIPTION
Now that Zacian-C is AG, we can't use simple hardcodes like before to get Gmax Pokemon out, and we can't just filter them out in build-indexes because some formats _do_ use them.