### PR TITLE
Tooling: Preact Client server by URL; tslint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "editor.formatOnSave": false,
   "showdown.server": "", // e.g., "?~~localhost:8000"
-  "showdown.clientUrl": "http://localhost:8080"
+  "showdown.clientUrl": "http://localhost:8080",
+  "tslint.configFile": "tslint.json"
 }

--- a/testclient-beta.html
+++ b/testclient-beta.html
@@ -52,6 +52,23 @@
 		linkStyle("style/font-awesome.css");
 	</script>
 	<script src="https://play.pokemonshowdown.com/config/config.js"></script>
+	<script>
+		Config.testclient = true;
+		(function() {
+			if (location.search !== '') {
+				var m = /\?~~(([^:\/]*)(:[0-9]*)?)/.exec(location.search);
+				if (m) {
+					Config.defaultserver = {
+						id: m[1],
+						host: m[2],
+						port: (m[3] && parseInt(m[3].substr(1))) || 8000
+					};
+				} else {
+					alert('Unrecognised query string syntax: ' + location.search);
+				}
+			}
+		})();
+	</script>
 	<script src="config/testclient-key.js"></script>
 	<script src="js/client-core.js"></script>
 	<script nomodule src="/js/lib/ps-polyfill.js"></script>


### PR DESCRIPTION
These are tooling updates that I separated out from #1709

There are improvements that should be made here. Please discuss, and if we should move this PR to draft while they are taken care of, please do so:

1. `testclient-beta.html` should be brought up to parity with `testclient.html`
2. `tslint `is deprecated. Should it be converted to `eslint`?