### PR TITLE
Use JSON.parse for parsing teambuilder tables

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -1018,7 +1018,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 		}
 	}
 
-	buf += 'exports.BattleTeambuilderTable = ' + JSON.stringify(BattleTeambuilderTable) + ';\n\n';
+	buf += `exports.BattleTeambuilderTable = JSON.parse('${JSON.stringify(BattleTeambuilderTable).replace(/['\\]/g, "\\$&")}');\n\n`;
 
 	fs.writeFileSync('data/teambuilder-tables.js', buf);
 }


### PR DESCRIPTION
This optimizes JavaScript parsing performance. V8 developers recommend applying this optimization for objects of 10 kB or larger, see <https://v8.dev/blog/cost-of-javascript-2019#json> for more details. Teambuilder tables are 3.5 MBs which is much more than 10 kB.

I have tested this optimization, albeit I don't know whether I have done this correctly. Over multiple attempts, with this change or not, in Firefox, this reduces parsing time from 600ms to 500ms. In Chrome, this reduces parsing time from 200ms to 100ms.

This was inspired by https://blog.guillaume-gomez.fr/articles/2021-01-22+Performance+improvement+on+front-end+generated+by+rustdoc blog post specifically which talks about optimization of rustdoc frontend code, and that was one of optimizations that was done (rustdoc PR: https://github.com/rust-lang/rust/pull/71250).