### PR TITLE
Display Mental Herb cure text

### DIFF
--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -585,7 +585,7 @@ class BattleTextParser {
 				template = this.template('endFromItem', effect);
 			}
 			if (!template) template = this.template(templateId, effect);
-			return line1 + template.replace('[POKEMON]', this.pokemon(pokemon)).replace('[EFFECT]', this.effect(effect)).replace('[SOURCE]', this.pokemon(kwArgs.of));
+			return line1 + template.replace('[POKEMON]', this.pokemon(pokemon)).replace('[EFFECT]', this.effect(effect)).replace('[SOURCE]', this.pokemon(kwArgs.of)).replace('[ITEM]', this.effect(kwArgs.from));
 		}
 
 		case '-ability': {


### PR DESCRIPTION
Fixes [this behavior](https://replay.pokemonshowdown.com/gen8metronomebattle-1286627515) (turn 5):
Waggling a finger let it use Attract!
The opposing Ampharos fell in love!
(The opposing Ampharos used its Mental Herb!)
The opposing Ampharos cured its infatuation using its [ITEM]!