### PR TITLE
Fix support for OMs in the teambuilder

### DIFF
--- a/src/battle-dex-data.ts
+++ b/src/battle-dex-data.ts
@@ -1233,7 +1233,11 @@ class Move implements Effect {
 
 		this.num = data.num || 0;
 		if (!this.gen) {
-			if (this.num >= 560) {
+			if (this.num >= 743) {
+				this.gen = 8;
+			} else if (this.num >= 622) {
+				this.gen = 7;
+			} else if (this.num >= 560) {
 				this.gen = 6;
 			} else if (this.num >= 468) {
 				this.gen = 5;

--- a/src/battle-dex-search.ts
+++ b/src/battle-dex-search.ts
@@ -889,7 +889,7 @@ class BattlePokemonSearch extends BattleTypedSearch<'pokemon'> {
 		else if (format === 'cap') tierSet = tierSet.slice(0, slices.Uber).concat(tierSet.slice(slices.OU));
 		else if (format === 'caplc') tierSet = tierSet.slice(slices['CAP LC'], slices.Uber).concat(tierSet.slice(slices.LC));
 		else if (format === 'anythinggoes' || format.endsWith('ag')) tierSet = tierSet.slice(slices.AG);
-		else if (format === 'balancedhackmons' || format.endsWith('bh')) tierSet = tierSet.slice(slices.AG);
+		else if (format.includes('hackmons') || format.endsWith('bh')) tierSet = tierSet.slice(slices.AG);
 		else if (format === 'doublesubers') tierSet = tierSet.slice(slices.DUber);
 		else if (format === 'doublesou' && dex.gen > 4) tierSet = tierSet.slice(slices.DOU);
 		else if (format === 'doublesuu') tierSet = tierSet.slice(slices.DUU);
@@ -1405,6 +1405,7 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 				} else {
 					if (!(dex.gen < 8 || this.formatType === 'natdex') && move.isZ) continue;
 					if (typeof move.isMax === 'string') continue;
+					if (move.isNonstandard === 'LGPE' && this.formatType !== 'letsgo') continue;
 					if (move.isNonstandard === 'Past' && this.formatType !== 'natdex' && dex.gen === 8) continue;
 					moves.push(move.id);
 				}
@@ -1412,7 +1413,7 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 		}
 		if (this.formatType === 'metronome') moves = ['metronome'];
 		if (isSTABmons) {
-			for (let id in BattleMovedex) {
+			for (let id in this.getTable()) {
 				let types: string[] = [];
 				let baseSpecies = dex.getSpecies(species.changesFrom || species.name);
 				if (!species.battleOnly) types.push(...species.types);


### PR DESCRIPTION
this fixes the Pure Hackmons teambuilder to show AG first and properly divides gen6/7/8 moves so astral barrage and z moves dont show up in gen 6