### PR TITLE
FIx BattleTextParser#team

### DIFF
--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -274,9 +274,9 @@ class BattleTextParser {
 	team(side: string, isFar: boolean = false) {
 		side = side.slice(0, 2);
 		if (side === this.perspective || side === BattleTextParser.allyID(side as SideID)) {
-			return isFar ? BattleText.default.team : BattleText.default.opposingTeam;
+			return !isFar ? BattleText.default.team : BattleText.default.opposingTeam;
 		}
-		return !isFar ? BattleText.default.team : BattleText.default.opposingTeam;
+		return isFar ? BattleText.default.team : BattleText.default.opposingTeam;
 	}
 
 	own(side: string) {


### PR DESCRIPTION
Compared to what it was like before:
![](https://media.discordapp.net/attachments/689316506265321535/826581091791011900/Screen_Shot_2021-03-30_at_15.17.58.png)

The return cases should be returning the opposite of what they actually are.