### PR TITLE
Tooltips: Fix hover for opponent's right slot

### DIFF
--- a/src/battle-animations.ts
+++ b/src/battle-animations.ts
@@ -765,7 +765,7 @@ class BattleScene {
 			p1b: {top: 200, left: 350, width: 150, height: 160, tooltip: 'activepokemon|0|1'},
 		} : {
 			p2c: {top: 70, left: 250, width: 80, height: 100, tooltip: 'activepokemon|1|2'},
-			p2b: {top: 70, left: 250, width: 80, height: 100, tooltip: 'activepokemon|1|1'},
+			p2b: {top: 85, left: 320, width: 90, height: 100, tooltip: 'activepokemon|1|1'},
 			p2a: {top: 90, left: 390, width: 100, height: 100, tooltip: 'activepokemon|1|0'},
 			p1a: {top: 200, left: 130, width: 120, height: 160, tooltip: 'activepokemon|0|0'},
 			p1b: {top: 200, left: 250, width: 150, height: 160, tooltip: 'activepokemon|0|1'},


### PR DESCRIPTION
In doubles, the tooltip for p2b (opponent's right) was mistakenly given the same values as p2c in https://github.com/smogon/pokemon-showdown-client/pull/1738. I assume this was a typo, but just to be sure, @pyuk-bot do you remember if this was necessary for Multi Battles? I tested in FFA and Doubles and now it works correctly.