### PR TITLE
Tooltips: Fix Victory Star and Battery

### DIFF
--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -1900,9 +1900,9 @@ class BattleTooltips {
 		if (!allyAbility) {
 			if (this.battle.myAllyPokemon) { // multi battle ally
 				allyAbility = Dex.abilities.get(this.battle.myAllyPokemon[ally.slot].ability).name;
-			} else if (this.battle.myPokemon){
+			} else if (this.battle.myPokemon) {
 				allyAbility = Dex.abilities.get(this.battle.myPokemon[ally.slot].ability).name;
-			}		
+			}
 		}
 		return allyAbility;
 	}

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -1897,8 +1897,12 @@ class BattleTooltips {
 		// this will only be available if the ability announced itself in some way
 		let allyAbility = Dex.abilities.get(ally.ability).name;
 		// otherwise fall back on the original set data sent from the server
-		if (!allyAbility && this.battle.myAllyPokemon) {
-			allyAbility = Dex.abilities.get(this.battle.myAllyPokemon[ally.slot].ability).name;
+		if (!allyAbility) {
+			if (this.battle.myAllyPokemon) { // multi battle ally
+				allyAbility = Dex.abilities.get(this.battle.myAllyPokemon[ally.slot].ability).name;
+			} else if (this.battle.myPokemon){
+				allyAbility = Dex.abilities.get(this.battle.myPokemon[ally.slot].ability).name;
+			}		
 		}
 		return allyAbility;
 	}


### PR DESCRIPTION
Minor regression from Multi Battles. Currently, when checking the ally's Ability, if it wasn't announced (i.e. an entrance ability like Fairy Aura or after Skill Swap or something), it falls back on the multi battle ally's ability. But this is null in doubles, so I readded logic to bring it back. Thanks to @pyuk-bot for her help!