### PR TITLE
Tooltips: Fix Max Move typing / name

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -667,6 +667,9 @@
 								// might not exist, such as for Z status moves - fall back on base move to determine type then
 								var specialMove = gigantamax || this.battle.dex.moves.get(specialMoves[i].move);
 								var moveType = this.tooltips.getMoveType(specialMove.exists && !specialMove.isMax ? specialMove : baseMove, typeValueTracker, specialMove.isMax ? gigantamax || switchables[pos].gigantamax || true : undefined)[0];
+								if (specialMove.isMax && specialMove.name !== 'Max Guard') {
+									specialMove = this.tooltips.getMaxMoveFromType(moveType);
+								}
 								var tooltipArgs = classType + 'move|' + baseMove.id + '|' + pos;
 								if (specialMove.id.startsWith('gmax')) tooltipArgs += '|' + specialMove.id;
 								var isDisabled = specialMoves[i].disabled ? 'disabled="disabled"' : '';

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -1372,7 +1372,7 @@ class BattleTooltips {
 		const noTypeOverride = [
 			'judgment', 'multiattack', 'naturalgift', 'revelationdance', 'struggle', 'technoblast', 'terrainpulse', 'weatherball',
 		];
-		const allowTypeOverride = !forMaxMove && !noTypeOverride.includes(move.id);
+		const allowTypeOverride = !noTypeOverride.includes(move.id);
 
 		if (allowTypeOverride && category !== 'Status' && !move.isZ) {
 			if (moveType === 'Normal') {


### PR DESCRIPTION
The change in client-battle.js fixes an issue where a move like Weather Ball would display as its effective type but be called base name.

Before:
![image](https://user-images.githubusercontent.com/23667022/115095324-79ea5880-9ee6-11eb-8308-f4dd98a174bf.png)

After:
![image](https://user-images.githubusercontent.com/23667022/115095286-58896c80-9ee6-11eb-8925-b8f8debd29f8.png)

The change in battle-tooltips.js removes the restriction on -ate Abilities displaying relative typing. _Technically_ the games don't display Pixilate Max Hyper Voice as Max Starfall, but that's what it becomes when used during the turn. The games don't display regular Pixilate Hyper Voice as Fairy-type either though, and I think it's better to be consistent and display the effective typing for convenience.