### PR TITLE
Tooltips: Fix Hidden Power and -ate Abilities

### DIFF
--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -1375,7 +1375,7 @@ class BattleTooltips {
 		];
 		const allowTypeOverride = !noTypeOverride.includes(move.id);
 
-		if (allowTypeOverride && category !== 'Status' && !move.isZ) {
+		if (allowTypeOverride && category !== 'Status' && !move.isZ && !move.id.startsWith('hiddenpower')) {
 			if (moveType === 'Normal') {
 				if (value.abilityModify(0, 'Aerilate')) moveType = 'Flying';
 				if (value.abilityModify(0, 'Galvanize')) moveType = 'Electric';
@@ -1694,7 +1694,7 @@ class BattleTooltips {
 		const noTypeOverride = [
 			'judgment', 'multiattack', 'naturalgift', 'revelationdance', 'struggle', 'technoblast', 'terrainpulse', 'weatherball',
 		];
-		if (move.category !== 'Status' && !noTypeOverride.includes(move.id) && !move.isZ && !move.isMax) {
+		if (move.category !== 'Status' && !noTypeOverride.includes(move.id) && !move.isZ && !move.isMax && !move.id.startsWith('hiddenpower')) {
 			if (move.type === 'Normal') {
 				value.abilityModify(this.battle.gen > 6 ? 1.2 : 1.3, "Aerilate");
 				value.abilityModify(this.battle.gen > 6 ? 1.2 : 1.3, "Galvanize");


### PR DESCRIPTION
Previously, effects like Normalize would override the typing of Hidden Power and incorrectly indicate it would receive a BP boost. It does not.