### PR TITLE
Tooltips: Fix unique Z-move BP

### DIFF
--- a/src/battle-dex-data.ts
+++ b/src/battle-dex-data.ts
@@ -1229,6 +1229,7 @@ class Move implements Effect {
 			} else {
 				this.zMove.basePower = 100;
 			}
+			if (data.zMove) this.zMove.basePower = data.zMove.basePower;
 		}
 
 		this.num = data.num || 0;


### PR DESCRIPTION
Certain moves like Gear Grind or Grass Knot have custom BP that doesn't follow the standard Z-move BP chart. This fixes it so their proper Z-move BP is used.

I think this solution is dumb though - I don't get why we'd have to do it this way for Z-moves and not for Max Moves. I'm surely missing something.