### PR TITLE
Fix double escape in battle and browser tab

### DIFF
--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -91,7 +91,7 @@
 			case 'rooms':
 				return buf + ' aria-label="Join chatroom"><i class="fa fa-plus" style="margin:7px auto -6px auto"></i> <span>&nbsp;</span></a></li>';
 			case 'battle':
-				var name = BattleLog.escapeHTML(room.title);
+				var name = room.title;
 				var idChunks = id.substr(7).split('-');
 				var formatid;
 				if (idChunks.length <= 1) {

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -91,7 +91,7 @@
 			case 'rooms':
 				return buf + ' aria-label="Join chatroom"><i class="fa fa-plus" style="margin:7px auto -6px auto"></i> <span>&nbsp;</span></a></li>';
 			case 'battle':
-				var name = room.title;
+				var name = BattleLog.escapeHTML(room.title);
 				var idChunks = id.substr(7).split('-');
 				var formatid;
 				if (idChunks.length <= 1) {

--- a/js/client.js
+++ b/js/client.js
@@ -937,7 +937,7 @@ function toId() {
 					var replayLink = 'https://' + Config.routes.replays + '/' + replayid;
 					$.ajax(replayLink + '.json', {dataType: 'json'}).done(function (replay) {
 						if (replay) {
-							var title = BattleLog.escapeHTML(replay.p1) + ' vs. ' + BattleLog.escapeHTML(replay.p2);
+							var title = replay.p1 + ' vs. ' + replay.p2;
 							app.receive('>battle-' + replayid + '\n|init|battle\n|title|' + title + '\n' + replay.log);
 							app.receive('>battle-' + replayid + '\n|expire|<a href=' + replayLink + ' target="_blank" class="no-panel-intercept">Open replay in new tab</a>');
 						} else {


### PR DESCRIPTION
Hopefully this is the correct place to remove the escape (sample replay: https://replay.pokemonshowdown.com/gen81v1-1148003675)

Before:
![image](https://user-images.githubusercontent.com/23667022/115128430-491c2900-9fa3-11eb-8137-61f59c3bc9af.png)

After:
![image](https://user-images.githubusercontent.com/23667022/115128401-30ac0e80-9fa3-11eb-8682-f1ffc4ac62b2.png)
