### PR TITLE
Tooltips: account halved BP from certain ground moves in grassy terrain

### DIFF
--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -1764,6 +1764,10 @@ class BattleTooltips {
 			if (target ? target.isGrounded() : true) {
 				value.modify(0.5, 'Misty Terrain + grounded target');
 			}
+		} else if (this.battle.hasPseudoWeather('Grassy Terrain') && ['earthquake', 'bulldoze', 'magnitude'].includes(move.id)) {
+			if (target ? target.isGrounded() : true) {
+				value.modify(0.5, 'Grassy Terrain + grounded target');
+			}
 		}
 		if (
 			move.id === 'expandingforce' &&


### PR DESCRIPTION
https://www.smogon.com/forums/threads/show-grassy-terrains-effect-on-the-3-ground-moves.3683343/

before

![image](https://user-images.githubusercontent.com/66930476/116643938-23e2cf80-a940-11eb-80ae-deee05af8037.png)

after

![image](https://user-images.githubusercontent.com/66930476/116643999-3ceb8080-a940-11eb-8789-362eb799da39.png)
