### PR TITLE
Make ranges appear again in Firefox

### DIFF
--- a/style/battle-log.css
+++ b/style/battle-log.css
@@ -282,7 +282,7 @@ select {
 
 input[type=range] {
 	-webkit-appearance: none;
-	-moz-appearance: range;
+	-moz-appearance: revert;
 	cursor: pointer;
 	height: 18px;
 	background: transparent;

--- a/style/client.css
+++ b/style/client.css
@@ -2881,7 +2881,7 @@ a.ilink.yours {
 
 	border: 1px solid #999999;
 	border-radius: 5px;
-	background-image: linear-gradient(top, rgb(218,229,240) 10%, rgb(203,214,225) 55%);
+	background-image: linear-gradient(to bottom, rgb(218,229,240) 10%, rgb(203,214,225) 55%);
 	background-image: -o-linear-gradient(top, rgb(218,229,240) 10%, rgb(203,214,225) 55%);
 	background-image: -moz-linear-gradient(top, rgb(218,229,240) 10%, rgb(203,214,225) 55%);
 	background-image: -webkit-linear-gradient(top, rgb(218,229,240) 10%, rgb(203,214,225) 55%);


### PR DESCRIPTION
Firefox removed support for `-moz-appearance: range;` last year. I've replaced it with `revert` but you could also make a case for `auto`.

While I was checking the console I noticed an illegal linear gradient so I fixed that while I was there.