### PR TITLE
Implement Zacian/Zamazenta/Xerneas forme leak

### DIFF
--- a/src/battle-animations.ts
+++ b/src/battle-animations.ts
@@ -794,6 +794,10 @@ class BattleScene {
 			let lombreCount = 0;
 			for (let i = 0; i < side.pokemon.length; i++) {
 				let pokemon = side.pokemon[i];
+				if (pokemon.speciesForme === 'Xerneas-*') {
+					side.pokemon[i].name = 'Xerneas-Neutral';
+					side.pokemon[i].speciesForme = 'Xerneas-Neutral';
+				}
 				if (pokemon.speciesForme === 'Ludicolo') ludicoloCount++;
 				if (pokemon.speciesForme === 'Lombre') lombreCount++;
 

--- a/src/battle-animations.ts
+++ b/src/battle-animations.ts
@@ -795,8 +795,8 @@ class BattleScene {
 			for (let i = 0; i < side.pokemon.length; i++) {
 				let pokemon = side.pokemon[i];
 				if (pokemon.speciesForme === 'Xerneas-*') {
-					side.pokemon[i].name = 'Xerneas-Neutral';
-					side.pokemon[i].speciesForme = 'Xerneas-Neutral';
+					pokemon.name = 'Xerneas-Neutral';
+					pokemon.speciesForme = 'Xerneas-Neutral';
 				}
 				if (pokemon.speciesForme === 'Ludicolo') ludicoloCount++;
 				if (pokemon.speciesForme === 'Lombre') lombreCount++;

--- a/src/battle-animations.ts
+++ b/src/battle-animations.ts
@@ -795,7 +795,6 @@ class BattleScene {
 			for (let i = 0; i < side.pokemon.length; i++) {
 				let pokemon = side.pokemon[i];
 				if (pokemon.speciesForme === 'Xerneas-*') {
-					pokemon.name = 'Xerneas-Neutral';
 					pokemon.speciesForme = 'Xerneas-Neutral';
 				}
 				if (pokemon.speciesForme === 'Ludicolo') ludicoloCount++;

--- a/src/battle-dex-data.ts
+++ b/src/battle-dex-data.ts
@@ -258,6 +258,7 @@ const BattlePokemonIconIndexes: {[id: string]: number} = {
 	furfroustar: 900 + 114,
 	meowsticf: 900 + 115,
 	aegislashblade: 900 + 116,
+	xerneasneutral: 900 + 117,
 	hoopaunbound: 900 + 118,
 	rattataalola: 900 + 119,
 	raticatealola: 900 + 120,

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -3292,6 +3292,18 @@ class Battle {
 			}
 			break;
 		}
+		case 'updatepokemon': {
+			const {siden} = this.parsePokemonId(args[1]);
+			const side = this.sides[siden]
+			for (var i = 0; i < side.pokemon.length; i++) {
+				const pokemon = side.pokemon[i];
+				if (pokemon.details === args[2]) {
+					side.addPokemon('', '', args[3], i)
+					break;
+				}
+			}
+			break;
+		}
 		case 'teampreview': {
 			this.teamPreviewCount = parseInt(args[1], 10);
 			this.scene.teamPreview();

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -3294,11 +3294,11 @@ class Battle {
 		}
 		case 'updatepokemon': {
 			const {siden} = this.parsePokemonId(args[1]);
-			const side = this.sides[siden]
-			for (var i = 0; i < side.pokemon.length; i++) {
+			const side = this.sides[siden];
+			for (let i = 0; i < side.pokemon.length; i++) {
 				const pokemon = side.pokemon[i];
 				if (pokemon.details === args[2]) {
-					side.addPokemon('', '', args[3], i)
+					side.addPokemon('', '', args[3], i);
 					break;
 				}
 			}

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -3297,8 +3297,8 @@ class Battle {
 			const side = this.sides[siden];
 			for (let i = 0; i < side.pokemon.length; i++) {
 				const pokemon = side.pokemon[i];
-				if (pokemon.details === args[2]) {
-					side.addPokemon('', '', args[3], i);
+				if (pokemon.checkDetails(args[2])) {
+					side.addPokemon('', '', args[2], i);
 					break;
 				}
 			}


### PR DESCRIPTION
Corresponding server changes here: https://github.com/smogon/pokemon-showdown/pull/8261

More info on the mechanic is in this twitter thread: https://twitter.com/DaWoblefet/status/1353213137785380864

This does a couple things:

- Point Neutral Xerneas to the correct icon
- Makes Xerneas show its Neutral forme on Team Preview (only the icon for now as Neutral Xerneas currently uses Active forme sprites for everything else)
- Adds support for a new protocol `updatepokemon` to change the icons of Zacian/Zamazenta/Xerneas. Normally I would've used `findCorrespondingPokemon` to get the pokemon to update it, however `searchid` isn't resolved until the pokemon is sent into battle, so I couldn't use that to search for a pokemon and instead had to use only the details to search.

Let me know if the code can be cleaned up anywhere.