### PR TITLE
Fix missing all BPs in FFA tooltips

### DIFF
--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -612,8 +612,7 @@ class BattleTooltips {
 			let basePower: string = '';
 			let difference = false;
 			let basePowers = [];
-			let targetsActive = this.battle.gameType === 'freeforall' ? foeActive.concat(allyActive) : foeActive;
-			for (const active of targetsActive) {
+			for (const active of foeActive) {
 				if (!active) continue;
 				value = this.getMoveBasePower(move, moveType, value, active);
 				basePower = '' + value;

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -530,6 +530,7 @@ class BattleTooltips {
 
 		let zEffect = '';
 		let foeActive = pokemon.side.foe.active;
+		let allyActive = pokemon.side.active;
 		// TODO: move this somewhere it makes more sense
 		if (pokemon.ability === '(suppressed)') serverPokemon.ability = '(suppressed)';
 		let ability = toID(serverPokemon.ability || pokemon.ability || serverPokemon.baseAbility);
@@ -609,7 +610,8 @@ class BattleTooltips {
 			let basePower: string = '';
 			let difference = false;
 			let basePowers = [];
-			for (const active of foeActive) {
+			let targetsActive = this.battle.gameType === 'freeforall' ? foeActive.concat(allyActive) : foeActive;
+			for (const active of targetsActive) {
 				if (!active) continue;
 				value = this.getMoveBasePower(move, moveType, value, active);
 				basePower = '' + value;

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -530,7 +530,9 @@ class BattleTooltips {
 
 		let zEffect = '';
 		let foeActive = pokemon.side.foe.active;
-		let allyActive = pokemon.side.active;
+		if (this.battle.gameType === 'freeforall') {
+			foeActive = [...foeActive, ...pokemon.side.active].filter(active => active !== pokemon);
+		}
 		// TODO: move this somewhere it makes more sense
 		if (pokemon.ability === '(suppressed)') serverPokemon.ability = '(suppressed)';
 		let ability = toID(serverPokemon.ability || pokemon.ability || serverPokemon.baseAbility);


### PR DESCRIPTION
This fix will add the adjacent pokemon (if active) to a check for multiple possible BP calculations in a Free-For-All battle.