### PR TITLE
Fix FFA battles referring to nearSide as 'your' Pokemon

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -939,7 +939,9 @@
 									// Targeting your own side in doubles / triples
 									targetActive = this.battle.nearSide.active;
 									targetPos = -targetPos;
-									target += 'your ';
+									if (this.battle.gameType !== 'freeforall') {
+										target += 'your ';
+									}
 								}
 								if (targetActive[targetPos - 1]) {
 									target += targetActive[targetPos - 1].speciesForme;


### PR DESCRIPTION
Simple check to see if gameType is FFA.