### PR TITLE
Automatically filter types for monotype formats

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -1330,6 +1330,24 @@
 			this.curChartName = '';
 			this.update();
 			this.$('input[name=pokemon]').select();
+			if (this.curTeam.format.includes('monotype')) {
+				let typeTable = [];
+				for (const [i, pokemon] of this.curSetList.entries()) {
+					const species = Dex.forGen(this.curTeam.gen).species.get(pokemon.species);
+					if (!species.exists) continue;
+					if (i === 0) {
+						typeTable = species.types;
+					} else {
+						typeTable = typeTable.filter(function(type) {
+							return species.types.includes(type);
+						});
+					}
+				}
+				if (typeTable.length !== 1) return;
+				this.search.engine.addFilter(['type', typeTable[0]]);
+				this.search.filters = this.search.engine.filters;
+				this.search.find('');
+			}
 		},
 		pastePokemon: function (i, btn) {
 			if (!this.curTeam) return;

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -1332,10 +1332,12 @@
 			this.$('input[name=pokemon]').select();
 			if (this.curTeam.format.includes('monotype')) {
 				var typeTable = [];
+				var dex = Dex.forGen(this.curTeam.gen);
 				for (var i = 0; i < this.curSetList.length; i++) {
-					var species = Dex.forGen(this.curTeam.gen).species.get(this.curSetList[i].species);
+					var set = this.curSetList[i];
+					var species = dex.species.get(set.species);
 					if (species.isMega) {
-						species = Dex.forGen(this.curTeam.gen).species.get(species.baseSpecies);
+						species = dex.species.get(species.baseSpecies);
 					}
 					if (!species.exists) continue;
 					if (i === 0) {
@@ -1345,6 +1347,16 @@
 							return species.types.includes(type);
 						});
 						if (!typeTable.length) break;
+					}
+					if (this.curTeam.gen >= 6) {
+						var item = dex.items.get(set.item);
+						if (item.megaStone && species.baseSpecies === item.megaEvolves) {
+							species = dex.species.get(item.megaStone);
+							typeTable = typeTable.filter(function (type) {
+								return species.types.includes(type);
+							});
+							if (!typeTable.length) break;
+						}
 					}
 				}
 				if (typeTable.length === 1) {

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -1332,8 +1332,8 @@
 			this.$('input[name=pokemon]').select();
 			if (this.curTeam.format.includes('monotype')) {
 				var typeTable = [];
-				for (const [i, pokemon] of this.curSetList.entries()) {
-					const species = Dex.forGen(this.curTeam.gen).species.get(pokemon.species);
+				for (var i = 0; i < this.curSetList.length; i++) {
+					const species = Dex.forGen(this.curTeam.gen).species.get(this.curSetList[i].species);
 					if (!species.exists) continue;
 					if (i === 0) {
 						typeTable = species.types;

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -1334,6 +1334,9 @@
 				var typeTable = [];
 				for (var i = 0; i < this.curSetList.length; i++) {
 					var species = Dex.forGen(this.curTeam.gen).species.get(this.curSetList[i].species);
+					if (species.isMega) {
+						species = Dex.forGen(this.curTeam.gen).species.get(species.baseSpecies);
+					}
 					if (!species.exists) continue;
 					if (i === 0) {
 						typeTable = species.types;

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -1331,7 +1331,7 @@
 			this.update();
 			this.$('input[name=pokemon]').select();
 			if (this.curTeam.format.includes('monotype')) {
-				let typeTable = [];
+				var typeTable = [];
 				for (const [i, pokemon] of this.curSetList.entries()) {
 					const species = Dex.forGen(this.curTeam.gen).species.get(pokemon.species);
 					if (!species.exists) continue;

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -1333,12 +1333,12 @@
 			if (this.curTeam.format.includes('monotype')) {
 				var typeTable = [];
 				for (var i = 0; i < this.curSetList.length; i++) {
-					const species = Dex.forGen(this.curTeam.gen).species.get(this.curSetList[i].species);
+					var species = Dex.forGen(this.curTeam.gen).species.get(this.curSetList[i].species);
 					if (!species.exists) continue;
 					if (i === 0) {
 						typeTable = species.types;
 					} else {
-						typeTable = typeTable.filter(function(type) {
+						typeTable = typeTable.filter(function (type) {
 							return species.types.includes(type);
 						});
 					}

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -1341,12 +1341,14 @@
 						typeTable = typeTable.filter(function (type) {
 							return species.types.includes(type);
 						});
+						if (!typeTable.length) break;
 					}
 				}
-				if (typeTable.length !== 1) return;
-				this.search.engine.addFilter(['type', typeTable[0]]);
-				this.search.filters = this.search.engine.filters;
-				this.search.find('');
+				if (typeTable.length === 1) {
+					this.search.engine.addFilter(['type', typeTable[0]]);
+					this.search.filters = this.search.engine.filters;
+					this.search.find('');
+				}
 			}
 		},
 		pastePokemon: function (i, btn) {

--- a/src/battle-dex-data.ts
+++ b/src/battle-dex-data.ts
@@ -1399,7 +1399,7 @@ class Species implements Effect {
 		this.isTotem = false;
 		this.isMega = !!(this.forme && ['-mega', '-megax', '-megay'].includes(this.formeid));
 		this.canGigantamax = !!data.canGigantamax;
-		this.isPrimal = !!(this.forme && ['-primal'].includes(this.formeid));
+		this.isPrimal = !!(this.forme && this.formeid === '-primal');
 		this.battleOnly = data.battleOnly || undefined;
 		this.isNonstandard = data.isNonstandard || null;
 		this.unreleasedHidden = data.unreleasedHidden || false;

--- a/src/battle-dex-data.ts
+++ b/src/battle-dex-data.ts
@@ -1397,9 +1397,9 @@ class Species implements Effect {
 		this.tier = data.tier || '';
 
 		this.isTotem = false;
-		this.isMega = false;
+		this.isMega = !!(this.forme && ['-mega', '-megax', '-megay'].includes(this.formeid));
 		this.canGigantamax = !!data.canGigantamax;
-		this.isPrimal = false;
+		this.isPrimal = !!(this.forme && ['-primal'].includes(this.formeid));
 		this.battleOnly = data.battleOnly || undefined;
 		this.isNonstandard = data.isNonstandard || null;
 		this.unreleasedHidden = data.unreleasedHidden || false;
@@ -1409,13 +1409,8 @@ class Species implements Effect {
 				this.gen = 8;
 			} else if (this.num >= 722 || this.formeid === '-alola' || this.formeid === '-starter') {
 				this.gen = 7;
-			} else if (this.forme && ['-mega', '-megax', '-megay'].includes(this.formeid)) {
+			} else if (this.isMega || this.isPrimal) {
 				this.gen = 6;
-				this.isMega = true;
-				this.battleOnly = this.baseSpecies;
-			} else if (this.formeid === '-primal') {
-				this.gen = 6;
-				this.isPrimal = true;
 				this.battleOnly = this.baseSpecies;
 			} else if (this.formeid === '-totem' || this.formeid === '-alolatotem') {
 				this.gen = 7;


### PR DESCRIPTION
https://www.smogon.com/forums/threads/automatically-filter-by-type-when-teambuilding-for-monotype.3657897/

It will only filter if the 1st pokemon is a single type or when there is only 1 shared type between the team. (so the part in the suggestion I linked above about filtering dark and steel types at the same time for bisharp would be unfulfilled, but I didn't feel like changing how filters worked). I am also somewhat unsure if where I put the functionality is the best place to put it, but it seems to work pretty well in my testing.