### PR TITLE
Keep yawn volatile on -status

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1935,7 +1935,6 @@ class Battle {
 			let effect = Dex.getEffect(kwArgs.from);
 			let ofpoke = this.getPokemon(kwArgs.of) || poke;
 			poke.status = args[2] as StatusName;
-			poke.removeVolatile('yawn' as ID);
 			this.activateAbility(ofpoke || poke, effect);
 			if (effect.effectType === 'Item') {
 				ofpoke.item = effect.name;


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-8845946

Removes an unnecessary removal of the yawn volatile during the `-status` event, as a pokemon can still be drowsy with a status condition if they received the status after they were drowsy, and the yawn volatile gets removed on its own after its duration is up anyway.