### PR TITLE
Fix D O G A R S

### DIFF
--- a/src/battle-animations.ts
+++ b/src/battle-animations.ts
@@ -1592,6 +1592,8 @@ class BattleScene {
 			this.bgm = BattleSound.loadBgm('audio/sm-rival.mp3', 11389, 62158, this.bgm);
 			break;
 		}
+
+		this.updateBgm();
 	}
 	updateBgm() {
 		/**

--- a/src/battle-sound.ts
+++ b/src/battle-sound.ts
@@ -137,7 +137,10 @@ const BattleSound = new class {
 
 	/** loopstart and loopend are in milliseconds */
 	loadBgm(url: string, loopstart: number, loopend: number, replaceBGM?: BattleBGM | null) {
-		if (replaceBGM) this.deleteBgm(replaceBGM);
+		if (replaceBGM) {
+			replaceBGM.stop();
+			this.deleteBgm(replaceBGM);
+		}
 
 		const bgm = new BattleBGM(url, loopstart, loopend);
 		this.bgm.push(bgm);


### PR DESCRIPTION
Pokémon Showdown! Beta is absolutely unplayable without Roxie's JP gym theme playing in the background when I switch in a Koffing named Dogars. On a more serious note, it also does not trigger Miror B's theme when I use my extremely viable multi-Ludicolo team in AG.

This fixes the `setBgm` function to call `updateBgm` after changing the BGM. It also changes the `loadBgm` function to stop the current BGM from playing before removing it