### PR TITLE
Add -swapsideconditions for court change

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -648,8 +648,13 @@ class Side {
 			if (this.foe && this.avatar === this.foe.avatar) this.rollTrainerSprites();
 		}
 	}
-	addSideCondition(effect: Effect) {
+	addSideCondition(effect: Effect, info?: [string, number, number, number]) {
 		let condition = effect.id;
+		if (info) {
+			this.sideConditions[condition] = info;
+			this.battle.scene.addSideCondition(this.n, condition);
+			return;
+		}
 		if (this.sideConditions[condition]) {
 			if (condition === 'spikes' || condition === 'toxicspikes') {
 				this.sideConditions[condition][1]++;

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1315,7 +1315,7 @@ class Battle {
 			'mist', 'lightscreen', 'reflect', 'spikes', 'safeguard', 'tailwind', 'toxicspikes', 'stealthrock', 'waterpledge', 'firepledge', 'grasspledge', 'stickyweb', 'auroraveil', 'gmaxsteelsurge', 'gmaxcannonade', 'gmaxvinelash', 'gmaxwildfire',
 		];
 		if (this.gameType === 'freeforall') {
-			// placeholder for ffa
+			// TODO: Add FFA support
 			return;
 		} else {
 			let side1 = this.sides[0];

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -2783,6 +2783,32 @@ class Battle {
 			this.log(args, kwArgs);
 			break;
 		}
+		case '-sideswitch': {
+			let side1 = this.getSide(args[1]);
+			let side2 = this.getSide(args[2]);
+			let effect = Dex.getEffect(args[3]);
+			side2.addSideCondition(effect, side1.sideConditions[effect.id]);
+			side1.removeSideCondition(effect.name);
+			switch (effect.id) {
+			case 'tailwind':
+			case 'auroraveil':
+			case 'reflect':
+			case 'lightscreen':
+			case 'safeguard':
+			case 'mist':
+			case 'gmaxwildfire':
+			case 'gmaxvolcalith':
+			case 'gmaxvinelash':
+			case 'gmaxcannonade':
+			case 'grasspledge':
+			case 'firepledge':
+			case 'waterpledge':
+				this.scene.updateWeather();
+				break;
+			}
+			this.log(args, kwArgs);
+			break;
+		}
 		case '-weather': {
 			let effect = Dex.getEffect(args[1]);
 			let poke = this.getPokemon(kwArgs.of) || undefined;

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -2807,7 +2807,7 @@ class Battle {
 			this.log(args, kwArgs);
 			break;
 		}
-		case '-sideswitch': {
+		case '-swapsideconditions': {
 			this.swapSideConditions();
 			this.scene.updateWeather();
 			this.log(args, kwArgs);

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -2785,7 +2785,7 @@ class Battle {
 		}
 		case '-sideswitch': {
 			let effect = Dex.getEffect(args[1]);
-			if (this.sides.length > 2) {
+			if (this.gameType === 'freeforall') {
 				// placeholder for ffa
 				return;
 			} else {

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -2784,11 +2784,26 @@ class Battle {
 			break;
 		}
 		case '-sideswitch': {
-			let side1 = this.getSide(args[1]);
-			let side2 = this.getSide(args[2]);
-			let effect = Dex.getEffect(args[3]);
-			side2.addSideCondition(effect, side1.sideConditions[effect.id]);
-			side1.removeSideCondition(effect.name);
+			let effect = Dex.getEffect(args[1]);
+			if (this.sides.length > 2) {
+				return; //placeholder for ffa
+			} else {
+				let side1 = this.sides[0];
+				let side2 = this.sides[1];
+				if (side1.sideConditions[effect.id] && side2.sideConditions[effect.id]) {
+					[side1.sideConditions[effect.id], side2.sideConditions[effect.id]] = [
+						side2.sideConditions[effect.id], side1.sideConditions[effect.id],
+					];
+					this.scene.addSideCondition(side1.n, effect.id);
+					this.scene.addSideCondition(side2.n, effect.id);
+				} else if (side1.sideConditions[effect.id] && !side2.sideConditions[effect.id]) {
+					side2.addSideCondition(effect, side1.sideConditions[effect.id]);
+					side1.removeSideCondition(effect.name);
+				} else if (side2.sideConditions[effect.id] && !side1.sideConditions[effect.id]) {
+					side1.addSideCondition(effect, side2.sideConditions[effect.id]);
+					side2.removeSideCondition(effect.name);
+				}
+			}
 
 			switch (effect.id) {
 			case 'tailwind':

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -2786,7 +2786,8 @@ class Battle {
 		case '-sideswitch': {
 			let effect = Dex.getEffect(args[1]);
 			if (this.sides.length > 2) {
-				return; //placeholder for ffa
+				// placeholder for ffa
+				return;
 			} else {
 				let side1 = this.sides[0];
 				let side2 = this.sides[1];

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1310,27 +1310,32 @@ class Battle {
 		this.weather = weather;
 		this.scene.updateWeather();
 	}
-	switchConditionSide(effect: Effect) {
+	swapSideConditions() {
+		const sideConditions = [
+			'mist', 'lightscreen', 'reflect', 'spikes', 'safeguard', 'tailwind', 'toxicspikes', 'stealthrock', 'waterpledge', 'firepledge', 'grasspledge', 'stickyweb', 'auroraveil', 'gmaxsteelsurge', 'gmaxcannonade', 'gmaxvinelash', 'gmaxwildfire',
+		];
 		if (this.gameType === 'freeforall') {
 			// placeholder for ffa
 			return;
 		} else {
 			let side1 = this.sides[0];
 			let side2 = this.sides[1];
-			if (side1.sideConditions[effect.id] && side2.sideConditions[effect.id]) {
-				[side1.sideConditions[effect.id], side2.sideConditions[effect.id]] = [
-					side2.sideConditions[effect.id], side1.sideConditions[effect.id],
-				];
-				this.scene.addSideCondition(side1.n, effect.id);
-				this.scene.addSideCondition(side2.n, effect.id);
-			} else if (side1.sideConditions[effect.id] && !side2.sideConditions[effect.id]) {
-				side2.sideConditions[effect.id] = side1.sideConditions[effect.id];
-				this.scene.addSideCondition(side2.n, effect.id);
-				side1.removeSideCondition(effect.name);
-			} else if (side2.sideConditions[effect.id] && !side1.sideConditions[effect.id]) {
-				side1.sideConditions[effect.id] = side2.sideConditions[effect.id];
-				this.scene.addSideCondition(side1.n, effect.id);
-				side2.removeSideCondition(effect.name);
+			for (const id of sideConditions) {
+				if (side1.sideConditions[id] && side2.sideConditions[id]) {
+					[side1.sideConditions[id], side2.sideConditions[id]] = [
+						side2.sideConditions[id], side1.sideConditions[id],
+					];
+					this.scene.addSideCondition(side1.n, id as ID);
+					this.scene.addSideCondition(side2.n, id as ID);
+				} else if (side1.sideConditions[id] && !side2.sideConditions[id]) {
+					side2.sideConditions[id] = side1.sideConditions[id];
+					this.scene.addSideCondition(side2.n, id as ID);
+					side1.removeSideCondition(id);
+				} else if (side2.sideConditions[id] && !side1.sideConditions[id]) {
+					side1.sideConditions[id] = side2.sideConditions[id];
+					this.scene.addSideCondition(side1.n, id as ID);
+					side2.removeSideCondition(id);
+				}
 			}
 		}
 	}
@@ -2803,26 +2808,7 @@ class Battle {
 			break;
 		}
 		case '-sideswitch': {
-			let effect = Dex.getEffect(args[1]);
-			this.switchConditionSide(effect);
-
-			switch (effect.id) {
-			case 'tailwind':
-			case 'auroraveil':
-			case 'reflect':
-			case 'lightscreen':
-			case 'safeguard':
-			case 'mist':
-			case 'gmaxwildfire':
-			case 'gmaxvolcalith':
-			case 'gmaxvinelash':
-			case 'gmaxcannonade':
-			case 'grasspledge':
-			case 'firepledge':
-			case 'waterpledge':
-				this.scene.updateWeather();
-				break;
-			}
+			this.swapSideConditions();
 			this.log(args, kwArgs);
 			break;
 		}

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -2789,6 +2789,7 @@ class Battle {
 			let effect = Dex.getEffect(args[3]);
 			side2.addSideCondition(effect, side1.sideConditions[effect.id]);
 			side1.removeSideCondition(effect.name);
+			
 			switch (effect.id) {
 			case 'tailwind':
 			case 'auroraveil':

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -2809,6 +2809,7 @@ class Battle {
 		}
 		case '-sideswitch': {
 			this.swapSideConditions();
+			this.scene.updateWeather();
 			this.log(args, kwArgs);
 			break;
 		}

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -2789,7 +2789,7 @@ class Battle {
 			let effect = Dex.getEffect(args[3]);
 			side2.addSideCondition(effect, side1.sideConditions[effect.id]);
 			side1.removeSideCondition(effect.name);
-			
+
 			switch (effect.id) {
 			case 'tailwind':
 			case 'auroraveil':


### PR DESCRIPTION
Corresponding server change: smogon/pokemon-showdown#8287

Does 2 things:
- adds an optional `info` argument to `side.addSideCondition`, which will allow preexisting side condition info to be used when adding a side condition (similar to `replaceSlot` for `side.addPokemon`).
- adds a new `-swapsideconditions` action, which swaps side conditions between sides