### PR TITLE
Fix |updatepoke

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -3297,7 +3297,7 @@ class Battle {
 			const side = this.sides[siden];
 			for (let i = 0; i < side.pokemon.length; i++) {
 				const pokemon = side.pokemon[i];
-				if (pokemon.checkDetails(args[2])) {
+				if (pokemon.details !== args[2] && pokemon.checkDetails(args[2])) {
 					side.addPokemon('', '', args[2], i);
 					break;
 				}


### PR DESCRIPTION
While the use of `checkDetails` did allow for only the new details to be sent, I overlooked the fact that it didn't work if there is more than one zacian/zamazenta/xerneas (as shown [here](https://replay.pokemonshowdown.com/gen8anythinggoes-1337388488), where the battle log shows 2 `updatepoke` for 2 zacian-crowned but only 1 zacian gets updated). I've added an extra check to see if the details are already an exact match, which should fix the issue.