### PR TITLE
Teambuilder: Improve Attack stat guesser

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -3103,10 +3103,10 @@
 						}
 					}
 					if (!hasMoveBesidesTransform) minAtk = false;
-				} else if (move.category === 'Physical' &&
-						!move.damage && !move.ohko && move.id !== 'rapidspin' && move.id !== 'foulplay' && move.id !== 'endeavor' && move.id !== 'counter' && move.id !== 'bodypress') {
+				} else if (move.category === 'Physical' && !move.damage && !move.ohko &&
+					!['foulplay', 'endeavor', 'counter', 'bodypress'].includes(move.id) && (this.gen < 8 && move.id !== 'rapidspin')) {
 					minAtk = false;
-				} else if (move.id === 'metronome' || move.id === 'assist' || move.id === 'copycat' || move.id === 'mefirst') {
+				} else if (['metronome', 'assist', 'copycat', 'mefirst', 'photongeyser', 'shellsidearm'].includes(move.id)) {
 					minAtk = false;
 				}
 				if (minSpe === false && moveName === 'Gyro Ball') {

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -3104,7 +3104,7 @@
 					}
 					if (!hasMoveBesidesTransform) minAtk = false;
 				} else if (move.category === 'Physical' && !move.damage && !move.ohko &&
-					!['foulplay', 'endeavor', 'counter', 'bodypress'].includes(move.id) && !(this.curTeam.gen < 8 && move.id === 'rapidspin')) {
+					!['foulplay', 'endeavor', 'counter', 'bodypress', 'seismictoss', 'bide', 'metalburst', 'superfang'].includes(move.id) && !(this.curTeam.gen < 8 && move.id === 'rapidspin')) {
 					minAtk = false;
 				} else if (['metronome', 'assist', 'copycat', 'mefirst', 'photongeyser', 'shellsidearm'].includes(move.id)) {
 					minAtk = false;

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -3104,7 +3104,7 @@
 					}
 					if (!hasMoveBesidesTransform) minAtk = false;
 				} else if (move.category === 'Physical' && !move.damage && !move.ohko &&
-					!['foulplay', 'endeavor', 'counter', 'bodypress'].includes(move.id) && (this.gen < 8 && move.id !== 'rapidspin')) {
+					!['foulplay', 'endeavor', 'counter', 'bodypress'].includes(move.id) && !(this.curTeam.gen < 8 && move.id === 'rapidspin')) {
 					minAtk = false;
 				} else if (['metronome', 'assist', 'copycat', 'mefirst', 'photongeyser', 'shellsidearm'].includes(move.id)) {
 					minAtk = false;

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -2097,7 +2097,7 @@ class BattleStatGuesser {
 			if (move.category === 'Status') {
 				if (['batonpass', 'healingwish', 'lunardance'].includes(move.id)) {
 					moveCount['Support']++;
-				} else if (['metronome', 'assist', 'copycat', 'mefirst'].includes(move.id)) {
+				} else if (['metronome', 'assist', 'copycat', 'mefirst', 'photongeyser', 'shellsidearm'].includes(move.id)) {
 					moveCount['Physical'] += 0.5;
 					moveCount['Special'] += 0.5;
 				} else if (move.id === 'naturepower') {
@@ -2131,7 +2131,7 @@ class BattleStatGuesser {
 			} else if (['counter', 'endeavor', 'metalburst', 'mirrorcoat', 'rapidspin'].includes(move.id)) {
 				moveCount['Support']++;
 			} else if ([
-				'nightshade', 'seismictoss', 'psywave', 'superfang', 'naturesmadness', 'foulplay', 'endeavor', 'finalgambit',
+				'nightshade', 'seismictoss', 'psywave', 'superfang', 'naturesmadness', 'foulplay', 'endeavor', 'finalgambit', 'bodypress'
 			].includes(move.id)) {
 				moveCount['Offense']++;
 			} else if (move.id === 'fellstinger') {
@@ -2143,7 +2143,7 @@ class BattleStatGuesser {
 				if (move.id === 'knockoff') {
 					moveCount['Support']++;
 				}
-				if (['scald', 'voltswitch', 'uturn'].includes(move.id)) {
+				if (['scald', 'voltswitch', 'uturn', 'flipturn'].includes(move.id)) {
 					moveCount[move.category] -= 0.2;
 				}
 			}


### PR DESCRIPTION
This implements a number of suggestions for attacks being counted towards Atk IVs or EVs when they shouldn't.

- Flip Turn now recommends -Attack on sets which use Flip Turn as their only physical move ([suggestion](https://www.smogon.com/forums/threads/make-flip-turn-use-a-atk-nature-when-it-is-the-only-physical-move.3684010/))
- Rapid Spin now only recommends 31 Atk IVs before Gen 8 ([suggestion](https://www.smogon.com/forums/threads/dont-default-to-0-atk-iv-rapid-spin-in-gen-8-formats.3677574/))
- Photon Geyser and Shell Side Arm now no longer recommend 0 Atk IVs ([suggestion](https://www.smogon.com/forums/threads/dont-default-to-0-atk-ivs-on-photon-geyser-and-shell-side-arm.3680527/))
- Body Press now no longer recommends Attack EVs if it is the only physical attack on the set ([bug report](https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-8476114))
- Seismic Toss, Bide, Super Fang, and Metal Burst all now no longer recommend 31 Atk IVs ([bug report](https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-8821705))