### PR TITLE
Support new challenge protocol

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1746,7 +1746,7 @@
 
 			var isHighlighted = userid !== app.user.get('userid') && this.getHighlight(message);
 			var parsedMessage = MainMenuRoom.parseChatMessage(message, name, ChatRoom.getTimestamp('chat', msgTime), isHighlighted, this.$chat, true);
-			if (parsedMessage.challenge) {
+			if (typeof parsedMessage.challenge === 'string') {
 				this.$chat.append('<div class="chat message-error">The server sent a challenge but this isn\'t a PM window!</div>');
 				return;
 			}

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1746,6 +1746,10 @@
 
 			var isHighlighted = userid !== app.user.get('userid') && this.getHighlight(message);
 			var parsedMessage = MainMenuRoom.parseChatMessage(message, name, ChatRoom.getTimestamp('chat', msgTime), isHighlighted, this.$chat, true);
+			if (parsedMessage.challenge) {
+				this.$chat.append('<div class="chat message-error">The server sent a challenge but this isn\'t a PM window!</div>');
+				return;
+			}
 			if (typeof parsedMessage === 'object' && 'noNotify' in parsedMessage) {
 				mayNotify = mayNotify && !parsedMessage.noNotify;
 				parsedMessage = parsedMessage.message;

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -232,14 +232,18 @@
 
 			var $challenge = $pmWindow.find('.challenge');
 			if (!formatName && !message) {
-				$challenge.remove();
-				this.closeNotification('challenge:' + oUserid);
+				if ($challenge.length) {
+					$challenge.remove();
+					this.closeNotification('challenge:' + oUserid);
+				}
 				return;
 			}
 
-			if ($challenge.length) {
+			if ($challenge.find('button[name=makeChallenge]').length) {
 				// we're currently trying to challenge that user; suppress the challenge and wait until later
 				// TODO: don't lose this challenge, but I'd rather wait for Preact client to fix that issue
+				// if we issue the challenge the window is open, the server will error out and re-send the
+				// challenge, but if we cancel, this challenge will be lost forever
 				return;
 			}
 
@@ -256,6 +260,7 @@
 				return;
 			}
 
+			app.playNotificationSound();
 			var buf = '<form class="battleform"><p>' + BattleLog.escapeHTML(message || (name + ' wants to battle!')) + '</p>';
 			if (formatName) {
 				buf += '<p><label class="label">' + (teamFormat ? 'Format' : 'Game') + ':</label>' + this.renderFormats(formatName, true) + '</p>';

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -224,14 +224,14 @@
 
 			var formatName = splitChallenge[0];
 			var teamFormat = splitChallenge[1];
-			var message = splitChallenge[2] || name + ' wants to battle!';
+			var message = splitChallenge[2];
 			var acceptButtonLabel = splitChallenge[3] || 'Accept';
 
 			var oUserid = toID(oName);
 			var userid = toID(name);
 
 			var $challenge = $pmWindow.find('.challenge');
-			if (!formatName) {
+			if (!formatName && !message) {
 				$challenge.remove();
 				this.closeNotification('challenge:' + oUserid);
 				return;
@@ -248,14 +248,18 @@
 			if (userid !== oUserid) {
 				// we are sending the challenge
 				var buf = '<form class="battleform"><p>Waiting for ' + BattleLog.escapeHTML(oName) + '...</p>';
-				buf += '<p><label class="label">' + (teamFormat ? 'Format' : 'Game') + ':</label>' + this.renderFormats(formatName, true) + '</p>';
+				if (formatName) {
+					buf += '<p><label class="label">' + (teamFormat ? 'Format' : 'Game') + ':</label>' + this.renderFormats(formatName, true) + '</p>';
+				}
 				buf += '<p class="buttonbar"><button name="cancelChallenge">Cancel</button></p></form>';
 				$challenge.html(buf);
 				return;
 			}
 
-			var buf = '<form class="battleform"><p>' + BattleLog.escapeHTML(message) + '</p>';
-			buf += '<p><label class="label">' + (teamFormat ? 'Format' : 'Game') + ':</label>' + this.renderFormats(formatName, true) + '</p>';
+			var buf = '<form class="battleform"><p>' + BattleLog.escapeHTML(message || (name + ' wants to battle!')) + '</p>';
+			if (formatName) {
+				buf += '<p><label class="label">' + (teamFormat ? 'Format' : 'Game') + ':</label>' + this.renderFormats(formatName, true) + '</p>';
+			}
 			if (teamFormat) {
 				buf += '<p><label class="label">Team:</label>' + this.renderTeams(teamFormat) + '</p>';
 				buf += '<p><label class="checkbox"><input type="checkbox" name="private" ' + (Storage.prefs('disallowspectators') ? 'checked' : '') + ' /> <abbr title="You can still invite spectators by giving them the URL or using the /invite command">Don\'t allow spectators</abbr></label></p>';

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -202,7 +202,7 @@
 			}
 
 			var $lastMessage = $chat.children().last();
-			var textContent = $lastMessage.html().indexOf('<span class="spoiler">') >= 0 ? '(spoiler)' : $lastMessage.children().last().text();
+			var textContent = $lastMessage.html().includes('<span class="spoiler">') ? '(spoiler)' : $lastMessage.children().last().text();
 			if (textContent && app.curSideRoom && app.curSideRoom.addPM && Dex.prefs('inchatpm')) {
 				app.curSideRoom.addPM(name, message, target);
 			}

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -186,7 +186,7 @@
 			var autoscroll = ($chatFrame.scrollTop() + 60 >= $chat.height() - $chatFrame.height());
 
 			var parsedMessage = MainMenuRoom.parseChatMessage(message, name, ChatRoom.getTimestamp('pms'), false, $chat, false);
-			if (parsedMessage.challenge) {
+			if (typeof parsedMessage.challenge === 'string') {
 				this.updateChallenge($pmWindow, parsedMessage.challenge, name, oName);
 				return;
 			}

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -226,6 +226,7 @@
 			var teamFormat = splitChallenge[1];
 			var message = splitChallenge[2];
 			var acceptButtonLabel = splitChallenge[3] || 'Accept';
+			var rejectButtonLabel = splitChallenge[4] || 'Reject';
 
 			var oUserid = toID(oName);
 			var userid = toID(name);
@@ -269,7 +270,7 @@
 				buf += '<p><label class="label">Team:</label>' + this.renderTeams(teamFormat) + '</p>';
 				buf += '<p><label class="checkbox"><input type="checkbox" name="private" ' + (Storage.prefs('disallowspectators') ? 'checked' : '') + ' /> <abbr title="You can still invite spectators by giving them the URL or using the /invite command">Don\'t allow spectators</abbr></label></p>';
 			}
-			buf += '<p class="buttonbar"><button name="acceptChallenge"><strong>' + BattleLog.escapeHTML(acceptButtonLabel) + '</strong></button> <button type="button" name="rejectChallenge">Reject</button></p></form>';
+			buf += '<p class="buttonbar"><button name="acceptChallenge"><strong>' + BattleLog.escapeHTML(acceptButtonLabel) + '</strong></button> <button type="button" name="rejectChallenge">' + BattleLog.escapeHTML(rejectButtonLabel) + '</button></p></form>';
 			$challenge.html(buf);
 		},
 		openPM: function (name, dontFocus) {


### PR DESCRIPTION
Previously, we'd get information for challenges in a single `|updatechallenges|` JSON blob.

That was designed for an even older UX, before challenges were integrated inside PM boxes.

The new format sends `/challenge` inside the PM, allowing the server to more directly control the challenge box inside the PM. This also makes it easier for things that aren't challenges to use the same UI, so e.g. FFA battles can ask for teams, or people can challenge each other to Rock Paper Scissors.

The new format looks like this: `|pm|SENDER|RECEIVER|/challenge GAME|TEAM|MESSAGE|ACCEPTBUTTON|REJECTBUTTON`.

Everything after `/challenge` is optional:

- `GAME` is the format name or game name - if left blank: the format/game name box won't show

- `TEAM` is the teambuilder format name - if left blank: the team dropdown won't show

- `MESSAGE` is the message up top - if left blank: "[user] wants to battle!"

- `ACCEPTBUTTON` is the label on the Accept button - if left blank: "Accept"

- `REJECTBUTTON` is the label on the Reject button - if left blank: "Reject"

1. A message containing `GAME` and `TEAM` is a regular challenge. If you are `RECEIVER`, it will display the format name, a team selector, and "Accept" / "Reject" buttons. Otherwise, you are `SENDER` and it will display the format and a "Cancel" button.

    `/challenge gen8ou|gen8ou`

   ![image](https://user-images.githubusercontent.com/551184/118364113-eab77b80-b54b-11eb-8597-8782e7cb189c.png)

2. A message containing `GAME` (with `TEAM` blank) will work as above, but with no team selector.

   `/challenge Rock Paper Scissors`

   ![image](https://user-images.githubusercontent.com/551184/118364133-01f66900-b54c-11eb-9523-fa0f61e4f071.png)

3. A message containing `MESSAGE` (with both `GAME` and `TEAM` blank) will work as above, but with no format or team box.

   `/challenge ||Do you like cheese?|Yes|No`

   ![image](https://user-images.githubusercontent.com/551184/118364261-9b257f80-b54c-11eb-9182-34637d57f11d.png)

4. `MESSAGE`, `ACCEPTBUTTON`, and `REJECTBUTTON` are optional for all of the above (unless `GAME` and `TEAM` are both blank, in which case `MESSAGE` is required), and can be mixed and matched:

   `/challenge gen8freeforall|gen8freeforall|Please pre-register your team for the upcoming tournament.||No thanks`

   ![image](https://user-images.githubusercontent.com/551184/118364560-c6f53500-b54d-11eb-8812-ec7621d71691.png)

5. If you are the sender, the message will always be replaced with "Waiting for [username]...", the Accept/Reject buttons will always be replaced with "Cancel", and there will never be a team selector.

   (as the sender) `/challenge gen8freeforall|gen8freeforall|Please pre-register your team for the upcoming tournament.||No thanks`
   ![image](https://user-images.githubusercontent.com/551184/118364879-2dc71e00-b54f-11eb-9941-73f24f85a4d2.png)

6. A blank message (`/challenge` by itself) will close any open challenge box

   `/challenge`

    ![image](https://user-images.githubusercontent.com/551184/118364338-eb044680-b54c-11eb-9cb9-d8ac06b45dd9.png)

7. Any other message is invalid (currently treated as a blank message, but don't rely on this)

No matter what they're labeled, the buttons send `/accept`, `/reject`, and `/cancelchallenge`. If a team dropdown exists, the team will be sent with `/utm` right before `/accept`.