### PR TITLE
Explicitly notate messages sent to lobby

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -816,7 +816,7 @@ function toId() {
 		 * Send to sim server
 		 */
 		send: function (data, room) {
-			if (room && room !== 'lobby' && room !== true) {
+			if (room && room !== true) {
 				data = room + '|' + data;
 			} else if (room !== true) {
 				data = '|' + data;

--- a/src/client-main.ts
+++ b/src/client-main.ts
@@ -539,8 +539,7 @@ class PSRoom extends PSStreamModel<Args | null> implements RoomOptions {
 		if (!direct && !msg) return;
 		if (!direct && this.handleMessage(msg)) return;
 
-		const id = this.id === 'lobby' ? '' : this.id;
-		PS.send(id + '|' + msg);
+		PS.send(this.id + '|' + msg);
 	}
 	destroy() {
 		if (this.connected) {


### PR DESCRIPTION
Explanation from Zarel:

PS's client-to-server messages are in the format `ROOMID|MESSAGE`, but with a special exception: Lobby uses a blank roomid. This exception saves a small amount of bandwidth, but causes a few weird bugs, and the bandwidth savings are no longer worth it.

-----

Necessary before server changes to make `|MSG` send to a console, instead of lobby.