### PR TITLE
Fix tab titles for non-battle games

### DIFF
--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -92,7 +92,7 @@
 				return buf + ' aria-label="Join chatroom"><i class="fa fa-plus" style="margin:7px auto -6px auto"></i> <span>&nbsp;</span></a></li>';
 			case 'battle':
 				var name = BattleLog.escapeHTML(room.title);
-				var offset = id.slice(0, 4) === 'game' ? 5 : 7;
+				var offset = id.startsWith('game-') ? 5 : 7;
 				var idChunks = id.substr(offset).split('-');
 				var formatid;
 				if (idChunks.length <= 1) {

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -92,7 +92,8 @@
 				return buf + ' aria-label="Join chatroom"><i class="fa fa-plus" style="margin:7px auto -6px auto"></i> <span>&nbsp;</span></a></li>';
 			case 'battle':
 				var name = BattleLog.escapeHTML(room.title);
-				var idChunks = id.substr(7).split('-');
+				var offset = id.slice(0, 4) === 'game' ? 5 : 7;
+				var idChunks = id.substr(offset).split('-');
 				var formatid;
 				if (idChunks.length <= 1) {
 					if (idChunks[0] === 'uploadedreplay') formatid = 'Uploaded Replay';

--- a/js/client.js
+++ b/js/client.js
@@ -1212,6 +1212,7 @@ function toId() {
 			var column = 0;
 			var columnChanged = false;
 
+			window.NonBattleGames = {rps: 'Rock Paper Scissors'};
 			window.BattleFormats = {};
 			for (var j = 1; j < formatsList.length; j++) {
 				if (isSection) {

--- a/src/battle-log.ts
+++ b/src/battle-log.ts
@@ -458,6 +458,9 @@ class BattleLog {
 		if (window.BattleFormats && BattleFormats[formatid]) {
 			return this.escapeHTML(BattleFormats[formatid].name);
 		}
+		if (window.NonBattleGames && NonBattleGames[formatid]) {
+			return this.escapeHTML(NonBattleGames[formatid]);
+		}
 		return this.escapeHTML(formatid);
 	}
 

--- a/src/panel-mainmenu.tsx
+++ b/src/panel-mainmenu.tsx
@@ -94,6 +94,7 @@ class MainMenuRoom extends PSRoom {
 
 		let column = 0;
 
+		window.NonBattleGames = {rps: 'Rock Paper Scissors'};
 		window.BattleFormats = {};
 		for (let j = 1; j < formatsList.length; j++) {
 			const entry = formatsList[j];

--- a/src/panel-teamdropdown.tsx
+++ b/src/panel-teamdropdown.tsx
@@ -732,6 +732,8 @@ interface FormatData {
 }
 
 declare var BattleFormats: {[id: string]: FormatData};
+/** id:name */
+declare var NonBattleGames: {[id: string]: string};
 
 class FormatDropdownPanel extends PSRoomPanel {
 	gen = '';


### PR DESCRIPTION
This allows support for Rock Paper Scissors games without making the title `s`.