### PR TITLE
Tooltips: Fix various Pressure related bugs

### DIFF
--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -982,8 +982,8 @@ class BattleTooltips {
 		let ability = toID(serverPokemon.ability || pokemon.ability || serverPokemon.baseAbility);
 		let ngasActive = false;
 		for (const side of this.battle.sides) {
-			for (const activePokemon of side.active) {
-				if (activePokemon && toID(activePokemon.ability) === 'neutralizinggas') {
+			for (const active of side.active) {
+				if (active && !active.fainted && toID(active.ability) === 'neutralizinggas' && !active.volatiles['gastroacid']) {
 					ngasActive = true;
 					break;
 				}

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1365,10 +1365,10 @@ class Battle {
 				}
 			}
 			if (!ngasActive) {
-				if (move.target === 'all') {
+				if (['foeSide', 'all', 'allAdjacent', 'allAdjacentFoes'].includes(move.target)) {
 					// Looping through all sides for FFA
 					for (const side of this.sides) {
-						if (side === pokemon.side) continue;
+						if (side === pokemon.side || side === pokemon.side.ally) continue;
 						for (const active of side.active) {
 							if (active && !active.fainted && toID(active.ability) === 'pressure') {
 								pp += 1;

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1364,8 +1364,17 @@ class Battle {
 					}
 				}
 			}
-			if (!ngasActive) {
-				if (['foeSide', 'all', 'allAdjacent', 'allAdjacentFoes'].includes(move.target)) {
+			// Sticky Web is never affected by pressure
+			if ((!target?.volatiles['gastroacid'] || !ngasActive) && move.id !== 'stickyweb') {
+				// Hardcode for moves without a target in singles
+				const activeFoe = pokemon.side.foe.active[0];
+				if (
+					!target && this.gameType === 'singles' &&
+					!['self', 'allies', 'allySide', 'adjacentAlly', 'adjacentAllyOrSelf'].includes(move.target) &&
+					!activeFoe?.fainted && toID(activeFoe?.ability) === 'pressure'
+				) {
+					pp += 1;
+				} else if (['all', 'allAdjacent', 'allAdjacentFoes', 'foeSide'].includes(move.target)) {
 					// Looping through all sides for FFA
 					for (const side of this.sides) {
 						if (side === pokemon.side || side === pokemon.side.ally) continue;

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1358,7 +1358,7 @@ class Battle {
 			let ngasActive = false;
 			for (const side of this.sides) {
 				for (const active of side.active) {
-					if (active && toID(active.ability) === 'neutralizinggas') {
+					if (active && !active.fainted && toID(active.ability) === 'neutralizinggas' && !active.volatiles['gastroacid']) {
 						ngasActive = true;
 						break;
 					}

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1375,7 +1375,7 @@ class Battle {
 					// Hardcode for moves without a target in singles
 					foeTargets.push(pokemon.side.foe.active[0]);
 				} else if (['all', 'allAdjacent', 'allAdjacentFoes', 'foeSide'].includes(move.target)) {
-					// Looping through all sides for FFA
+					// We loop through all sides here for FFA
 					for (const side of this.sides) {
 						if (side === pokemon.side || side === pokemon.side.ally) continue;
 						for (const active of side.active) {

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1365,27 +1365,31 @@ class Battle {
 				}
 			}
 			// Sticky Web is never affected by pressure
-			if ((!target?.volatiles['gastroacid'] || !ngasActive) && move.id !== 'stickyweb') {
-				// Hardcode for moves without a target in singles
-				const activeFoe = pokemon.side.foe.active[0];
+			if (!ngasActive && move.id !== 'stickyweb') {
+				const foeTargets = [];
+
 				if (
 					!target && this.gameType === 'singles' &&
-					!['self', 'allies', 'allySide', 'adjacentAlly', 'adjacentAllyOrSelf'].includes(move.target) &&
-					!activeFoe?.fainted && toID(activeFoe?.ability) === 'pressure'
+					!['self', 'allies', 'allySide', 'adjacentAlly', 'adjacentAllyOrSelf'].includes(move.target)
 				) {
-					pp += 1;
+					// Hardcode for moves without a target in singles
+					foeTargets.push(pokemon.side.foe.active[0]);
 				} else if (['all', 'allAdjacent', 'allAdjacentFoes', 'foeSide'].includes(move.target)) {
 					// Looping through all sides for FFA
 					for (const side of this.sides) {
 						if (side === pokemon.side || side === pokemon.side.ally) continue;
 						for (const active of side.active) {
-							if (active && !active.fainted && toID(active.ability) === 'pressure') {
-								pp += 1;
-							}
+							foeTargets.push(active);
 						}
 					}
-				} else if (target && target.side !== pokemon.side && !target.fainted && toID(target.ability) === 'pressure') {
-					pp += 1;
+				} else if (target && target.side !== pokemon.side) {
+					foeTargets.push(target);
+				}
+
+				for (const foe of foeTargets) {
+					if (foe && !foe.fainted && toID(foe.ability) === 'pressure' && !foe.volatiles['gastroacid']) {
+						pp += 1;
+					}
 				}
 			}
 			pokemon.rememberMove(moveName, pp);

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1355,14 +1355,29 @@ class Battle {
 				}
 			}
 			let pp = 1;
-			if (move.target === "all") {
-				for (const active of pokemon.side.foe.active) {
-					if (active && toID(active.ability) === 'pressure') {
-						pp += 1;
+			let ngasActive = false;
+			for (const side of this.sides) {
+				for (const active of side.active) {
+					if (active && toID(active.ability) === 'neutralizinggas') {
+						ngasActive = true;
+						break;
 					}
 				}
-			} else if (target && target.side !== pokemon.side && toID(target.ability) === 'pressure') {
-				pp += 1;
+			}
+			if (!ngasActive) {
+				if (move.target === 'all') {
+					// Looping through all sides for FFA
+					for (const side of this.sides) {
+						if (side === pokemon.side) continue;
+						for (const active of side.active) {
+							if (active && !active.fainted && toID(active.ability) === 'pressure') {
+								pp += 1;
+							}
+						}
+					}
+				} else if (target && target.side !== pokemon.side && !target.fainted && toID(target.ability) === 'pressure') {
+					pp += 1;
+				}
 			}
 			pokemon.rememberMove(moveName, pp);
 		}


### PR DESCRIPTION
- Makes sure neutralizing gas isn't active and that the target isn't affected by gastro acid
- Makes sure the pokemon with pressure isn't fainted
- Fixes pressure in FFA
- Adds a hardcode to singles for moves without a target (such as 2 turn moves and moves that fail).