### PR TITLE
Don't display 100% HP lost if HP still exists

### DIFF
--- a/src/battle-animations.ts
+++ b/src/battle-animations.ts
@@ -1408,6 +1408,7 @@ class BattleScene {
 			callback = () => { $hp.addClass('hp-yellow hp-red'); };
 		}
 
+		if (damage === '100%' && pokemon.hp > 0) damage = '99%';
 		this.resultAnim(pokemon, this.battle.hardcoreMode ? 'Damage' : '&minus;' + damage, 'bad');
 
 		$hp.animate({


### PR DESCRIPTION
If an attack deals more than 99.5% damage, the display will round up on the animation that shows up mid-screen above the Pokemon's sprite in red to indicate the Pokemon took "100%" damage even when it survived. Now, it only displays "99%" damage if the Pokemon were to take near-100% damage.

Note that this only affects player perspective mid-battle; you wouldn't have this issue as a spectator or from the opponent's perspective because it's truncated to 99% earlier.

I originally tried modifying this in getFormattedRange() but encountered problems getting it to return the more precise percentages in the battle log itself.

Replay: https://replay.pokemonshowdown.com/gen8ubers-1346819616
![image](https://user-images.githubusercontent.com/23667022/119423063-0b0fd480-bcc8-11eb-9e2c-2e627e6d671b.png)
![image](https://user-images.githubusercontent.com/23667022/119423121-309cde00-bcc8-11eb-919e-c2942dce69ef.png)