### PR TITLE
Override more Pokedex and Move data

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -933,80 +933,38 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 		const gen = 'gen' + genNum;
 		const genData = Dex.mod(gen).data;
 		const nextGenData = Dex.mod('gen' + (genNum + 1)).data;
-		const overrideStats = {};
-		BattleTeambuilderTable[gen].overrideStats = overrideStats;
-		const overrideType = {};
-		BattleTeambuilderTable[gen].overrideType = overrideType;
-		const overrideAbility = {};
-		BattleTeambuilderTable[gen].overrideAbility = overrideAbility;
-		const overrideHiddenAbility = {};
-		BattleTeambuilderTable[gen].overrideHiddenAbility = overrideHiddenAbility;
-		const removeSecondAbility = {};
-		BattleTeambuilderTable[gen].removeSecondAbility = removeSecondAbility;
+		const overrideDexData = {};
+		BattleTeambuilderTable[gen].overrideDexData = overrideDexData;
 		for (const id in genData.Pokedex) {
 			const pastEntry = genData.Pokedex[id];
 			const nowEntry = Dex.data.Pokedex[id];
-			const nowType = nowEntry.types.join('/');
-			for (const stat in pastEntry.baseStats) {
-				if (stat === 'spd' && genNum === 1) continue;
-				if (pastEntry.baseStats[stat] !== nowEntry.baseStats[stat]) {
-					if (!overrideStats[id]) overrideStats[id] = {};
-					overrideStats[id][stat] = pastEntry.baseStats[stat];
+			for (const key in pastEntry) {
+				const pastString = JSON.stringify(pastEntry[key]);
+				const nowString = JSON.stringify(nowEntry[key]);
+				if (pastString !== nowString) {
+					if (!overrideDexData[id]) overrideDexData[id] = {};
+					overrideDexData[id][key] = pastEntry[key];
 				}
-			}
-			if (pastEntry.types.join('/') !== nowType) {
-				overrideType[id] = pastEntry.types.join('/');
-			}
-			if (pastEntry.abilities['0'] !== nowEntry.abilities['0']) {
-				overrideAbility[id] = pastEntry.abilities['0'];
-			}
-			if (pastEntry.abilities['H'] !== nowEntry.abilities['H']) {
-				overrideHiddenAbility[id] = pastEntry.abilities['H'];
-			}
-			// in the gen 3 dex, Pokemon already have the abilities that were added in gen 4
-			const hasAbilityFromNewerGen = Dex.species.get(id).gen <= genNum && Dex.abilities.get(pastEntry.abilities['1']).gen > genNum;
-			if ((!pastEntry.abilities['1'] && nowEntry.abilities['1']) || hasAbilityFromNewerGen) {
-				removeSecondAbility[id] = true;
 			}
 		}
 
-		const overrideBP = {};
-		BattleTeambuilderTable[gen].overrideBP = overrideBP;
-		const overrideAcc = {};
-		BattleTeambuilderTable[gen].overrideAcc = overrideAcc;
-		const overridePP = {};
-		BattleTeambuilderTable[gen].overridePP = overridePP;
-		const overrideMoveType = {};
-		BattleTeambuilderTable[gen].overrideMoveType = overrideMoveType;
-		const overrideMoveCategory = {};
-		BattleTeambuilderTable[gen].overrideMoveCategory = overrideMoveCategory;
-		const overrideMoveDesc = {};
-		BattleTeambuilderTable[gen].overrideMoveDesc = overrideMoveDesc;
-		const overrideMoveShortDesc = {};
-		BattleTeambuilderTable[gen].overrideMoveShortDesc = overrideMoveShortDesc;
+		const overrideMoveData = {};
+		BattleTeambuilderTable[gen].overrideMoveData = overrideMoveData;
 		for (const id in genData.Moves) {
-			const pastEntry = Dex.mod(gen).moves.get(id);
-			const nowEntry = Dex.moves.get(id);
-			if (pastEntry.basePower !== nowEntry.basePower) {
-				overrideBP[id] = pastEntry.basePower;
-			}
-			if (pastEntry.accuracy !== nowEntry.accuracy) {
-				overrideAcc[id] = pastEntry.accuracy;
-			}
-			if (pastEntry.pp !== nowEntry.pp) {
-				overridePP[id] = pastEntry.pp;
-			}
-			if (pastEntry.type !== nowEntry.type) {
-				overrideMoveType[id] = pastEntry.type;
-			}
-			if (pastEntry.category !== nowEntry.category) {
-				overrideMoveCategory[id] = pastEntry.category;
-			}
-			if (pastEntry.desc !== nowEntry.desc) {
-				overrideMoveDesc[id] = pastEntry.desc;
-			}
-			if (pastEntry.shortDesc !== nowEntry.shortDesc) {
-				overrideMoveShortDesc[id] = pastEntry.shortDesc;
+			const pastEntry = genData.Moves[id];
+			const nowEntry = Dex.data.Moves[id];
+			const pastDescs = Dex.mod(gen).getDescs('Moves', id, pastEntry);
+			const nowDescs = Dex.getDescs('Moves', id, nowEntry);
+			[pastEntry.desc, pastEntry.shortDesc] = [pastDescs.desc, pastDescs.shortDesc];
+			[nowEntry.desc, nowEntry.shortDesc] = [nowDescs.desc, nowDescs.shortDesc];
+
+			for (const key in pastEntry) {
+				const pastString = JSON.stringify(pastEntry[key]);
+				const nowString = JSON.stringify(nowEntry[key]);
+				if (pastString !== nowString) {
+					if (!overrideMoveData[id]) overrideMoveData[id] = {};
+					overrideMoveData[id][key] = pastEntry[key];
+				}
 			}
 		}
 

--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -955,8 +955,10 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 			const nowEntry = Dex.data.Moves[id];
 			const pastDescs = Dex.mod(gen).getDescs('Moves', id, pastEntry);
 			const nowDescs = Dex.getDescs('Moves', id, nowEntry);
-			[pastEntry.desc, pastEntry.shortDesc] = [pastDescs.desc, pastDescs.shortDesc];
-			[nowEntry.desc, nowEntry.shortDesc] = [nowDescs.desc, nowDescs.shortDesc];
+			pastEntry.desc = pastDescs.desc;
+			pastEntry.shortDesc = pastDescs.shortDesc;
+			nowEntry.desc = nowDescs.desc;
+			nowEntry.shortDesc = nowDescs.shortDesc;
 
 			for (const key in pastEntry) {
 				const pastString = JSON.stringify(pastEntry[key]);

--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -931,41 +931,33 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 
 	for (const genNum of [7, 6, 5, 4, 3, 2, 1]) {
 		const gen = 'gen' + genNum;
+		const nextGen = 'gen' + (genNum + 1);
 		const genData = Dex.mod(gen).data;
-		const nextGenData = Dex.mod('gen' + (genNum + 1)).data;
-		const overrideDexData = {};
-		BattleTeambuilderTable[gen].overrideDexData = overrideDexData;
+		const nextGenData = Dex.mod(nextGen).data;
+		const overrideSpeciesData = {};
+		BattleTeambuilderTable[gen].overrideSpeciesData = overrideSpeciesData;
+		const overrideSpeciesKeys = ['abilities', 'baseStats', 'requiredItem', 'types'];
 		for (const id in genData.Pokedex) {
-			const pastEntry = genData.Pokedex[id];
-			const nowEntry = Dex.data.Pokedex[id];
-			for (const key in pastEntry) {
-				const pastString = JSON.stringify(pastEntry[key]);
-				const nowString = JSON.stringify(nowEntry[key]);
-				if (pastString !== nowString) {
-					if (!overrideDexData[id]) overrideDexData[id] = {};
-					overrideDexData[id][key] = pastEntry[key];
+			const curEntry = genData.Pokedex[id];
+			const nextEntry = nextGenData.Pokedex[id];
+			for (const key of overrideSpeciesKeys) {
+				if (JSON.stringify(curEntry[key]) !== JSON.stringify(nextEntry[key])) {
+					if (!overrideSpeciesData[id]) overrideSpeciesData[id] = {};
+					overrideSpeciesData[id][key] = curEntry[key];
 				}
 			}
 		}
 
 		const overrideMoveData = {};
 		BattleTeambuilderTable[gen].overrideMoveData = overrideMoveData;
+		const overrideMoveKeys = ['accuracy', 'basePower', 'category', 'desc', 'flags', 'pp', 'shortDesc', 'target', 'type'];
 		for (const id in genData.Moves) {
-			const pastEntry = genData.Moves[id];
-			const nowEntry = Dex.data.Moves[id];
-			const pastDescs = Dex.mod(gen).getDescs('Moves', id, pastEntry);
-			const nowDescs = Dex.getDescs('Moves', id, nowEntry);
-			pastEntry.desc = pastDescs.desc;
-			pastEntry.shortDesc = pastDescs.shortDesc;
-			nowEntry.desc = nowDescs.desc;
-			nowEntry.shortDesc = nowDescs.shortDesc;
-
-			for (const key in pastEntry) {
-				const pastString = JSON.stringify(pastEntry[key]);
-				const nowString = JSON.stringify(nowEntry[key]);
-				if (pastString !== nowString) {
+			const curEntry = Dex.mod(gen).moves.get(id);
+			const nextEntry = Dex.mod(nextGen).moves.get(id);
+			for (const key of overrideMoveKeys) {
+				if (JSON.stringify(curEntry[key]) !== JSON.stringify(nextEntry[key])) {
 					if (!overrideMoveData[id]) overrideMoveData[id] = {};
-					overrideMoveData[id][key] = pastEntry[key];
+					overrideMoveData[id][key] = curEntry[key];
 				}
 			}
 		}
@@ -973,20 +965,20 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 		const overrideItemDesc = {};
 		BattleTeambuilderTable[gen].overrideItemDesc = overrideItemDesc;
 		for (const id in genData.Items) {
-			const pastEntry = Dex.mod(gen).items.get(id);
-			const nowEntry = Dex.items.get(id);
-			if ((pastEntry.shortDesc || pastEntry.desc) !== (nowEntry.shortDesc || nowEntry.desc)) {
-				overrideItemDesc[id] = (pastEntry.shortDesc || pastEntry.desc);
+			const curEntry = Dex.mod(gen).items.get(id);
+			const nextEntry = Dex.mod(nextGen).items.get(id);
+			if ((curEntry.shortDesc || curEntry.desc) !== (nextEntry.shortDesc || nextEntry.desc)) {
+				overrideItemDesc[id] = (curEntry.shortDesc || curEntry.desc);
 			}
 		}
 
 		const overrideAbilityDesc = {};
 		BattleTeambuilderTable[gen].overrideAbilityDesc = overrideAbilityDesc;
 		for (const id in genData.Abilities) {
-			const pastEntry = Dex.mod(gen).abilities.get(id);
-			const nowEntry = Dex.abilities.get(id);
-			if ((pastEntry.shortDesc || pastEntry.desc) !== (nowEntry.shortDesc || nowEntry.desc)) {
-				overrideAbilityDesc[id] = (pastEntry.shortDesc || pastEntry.desc);
+			const curEntry = Dex.mod(gen).abilities.get(id);
+			const nextEntry = Dex.mod(nextGen).abilities.get(id);
+			if ((curEntry.shortDesc || curEntry.desc) !== (nextEntry.shortDesc || nextEntry.desc)) {
+				overrideAbilityDesc[id] = (curEntry.shortDesc || curEntry.desc);
 			}
 		}
 
@@ -995,14 +987,14 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 		const removeType = {};
 		BattleTeambuilderTable[gen].removeType = removeType;
 		for (const id in nextGenData.TypeChart) {
+			const curEntry = genData.TypeChart[id];
 			const nextEntry = nextGenData.TypeChart[id];
-			const pastEntry = genData.TypeChart[id];
-			if (pastEntry.isNonstandard) {
+			if (curEntry.isNonstandard) {
 				removeType[id] = true;
 				continue;
 			}
-			if (JSON.stringify(nextEntry) !== JSON.stringify(pastEntry)) {
-				overrideTypeChart[id] = pastEntry;
+			if (JSON.stringify(nextEntry) !== JSON.stringify(curEntry)) {
+				overrideTypeChart[id] = curEntry;
 			}
 		}
 	}

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -20,6 +20,7 @@
 			if (this.curTeam) {
 				this.curTeam.iconCache = '!';
 				this.curTeam.gen = this.getGen(this.curTeam.format);
+				this.curTeam.dex = Dex.forGen(this.curTeam.gen);
 				Storage.activeSetList = this.curSetList;
 			}
 		},
@@ -677,6 +678,7 @@
 			this.curTeam = teams[i];
 			this.curTeam.iconCache = '!';
 			this.curTeam.gen = this.getGen(this.curTeam.format);
+			this.curTeam.dex = Dex.forGen(this.curTeam.gen);
 			Storage.activeSetList = this.curSetList = Storage.unpackTeam(this.curTeam.team);
 			this.curTeamIndex = i;
 			this.update();
@@ -1146,7 +1148,7 @@
 			if ($(window).width() < 640) this.show();
 		},
 		renderSet: function (set, i) {
-			var species = Dex.species.get(set.species);
+			var species = this.curTeam.dex.species.get(set.species);
 			var isLetsGo = this.curTeam.format.includes('letsgo');
 			var isNatDex = this.curTeam.format.includes('nationaldex');
 			var buf = '<li value="' + i + '">';
@@ -1212,15 +1214,13 @@
 			buf += '<div class="setcell">';
 			var itemicon = '<span class="itemicon"></span>';
 			if (set.item) {
-				var item = Dex.items.get(set.item);
+				var item = this.curTeam.dex.items.get(set.item);
 				itemicon = '<span class="itemicon" style="' + Dex.getItemIcon(item) + '"></span>';
 			}
 			buf += itemicon;
 			buf += '</div>';
 			buf += '<div class="setcell setcell-typeicons">';
 			var types = species.types;
-			var table = (this.curTeam.gen < 7 ? BattleTeambuilderTable['gen' + this.curTeam.gen] : null);
-			if (table && species.id in table.overrideType) types = table.overrideType[species.id].split('/');
 			if (types) {
 				for (var i = 0; i < types.length; i++) buf += Dex.getTypeIcon(types[i]);
 			}
@@ -1332,7 +1332,7 @@
 			this.$('input[name=pokemon]').select();
 			if (this.curTeam.format.includes('monotype')) {
 				var typeTable = [];
-				var dex = Dex.forGen(this.curTeam.gen);
+				var dex = this.curTeam.dex;
 				for (var i = 0; i < this.curSetList.length; i++) {
 					var set = this.curSetList[i];
 					var species = dex.species.get(set.species);
@@ -1427,6 +1427,7 @@
 		changeFormat: function (format) {
 			this.curTeam.format = format;
 			this.curTeam.gen = this.getGen(this.curTeam.format);
+			this.curTeam.dex = Dex.forGen(this.curTeam.gen);
 			this.save();
 			if (this.curTeam.gen === 5 && !Dex.loadedSpriteData['bw']) Dex.loadSpriteData('bw');
 			this.update();
@@ -1471,7 +1472,7 @@
 			var buf = '';
 			for (var i = 0; i < this.clipboardCount(); i++) {
 				var res = this.clipboard[i];
-				var species = Dex.species.get(res.species);
+				var species = this.curTeam.dex.species.get(res.species);
 
 				buf += '<div class="result" data-id="' + i + '">';
 				buf += '<div class="section"><span class="icon" style="' + Dex.getPokemonIcon(species.name) + '"></span>';
@@ -1769,9 +1770,9 @@
 					buf += '<button disabled="disabled" class="addpokemon" aria-label="Add Pok&eacute;mon"><i class="fa fa-plus"></i></button> ';
 					isAdd = true;
 				} else if (i == this.curSetLoc) {
-					buf += '<button disabled="disabled" class="pokemon">' + pokemonicon + BattleLog.escapeHTML(set.name || Dex.species.get(set.species).baseSpecies || '<i class="fa fa-plus"></i>') + '</button> ';
+					buf += '<button disabled="disabled" class="pokemon">' + pokemonicon + BattleLog.escapeHTML(set.name || this.curTeam.dex.species.get(set.species).baseSpecies || '<i class="fa fa-plus"></i>') + '</button> ';
 				} else {
-					buf += '<button name="selectPokemon" value="' + i + '" class="pokemon">' + pokemonicon + BattleLog.escapeHTML(set.name || Dex.species.get(set.species).baseSpecies) + '</button> ';
+					buf += '<button name="selectPokemon" value="' + i + '" class="pokemon">' + pokemonicon + BattleLog.escapeHTML(set.name || this.curTeam.dex.species.get(set.species).baseSpecies) + '</button> ';
 				}
 			}
 			if (this.curSetList.length < this.curTeam.capacity && !isAdd) {
@@ -1787,7 +1788,7 @@
 
 			this.$('.pokemonicon-' + this.curSetLoc).css('background', Dex.getPokemonIcon(set).substr(11));
 
-			var item = Dex.items.get(set.item);
+			var item = this.curTeam.dex.items.get(set.item);
 			if (item.id) {
 				this.$('.setcol-details .itemicon').css('background', Dex.getItemIcon(item).substr(11));
 			} else {
@@ -1956,7 +1957,7 @@
 		plus: '',
 		minus: '',
 		smogdexLink: function (s) {
-			var species = Dex.species.get(s);
+			var species = this.curTeam.dex.species.get(s);
 			var format = this.curTeam && this.curTeam.format;
 			var smogdexid = toID(species.baseSpecies);
 
@@ -2017,7 +2018,7 @@
 		updateStatForm: function (setGuessed) {
 			var buf = '';
 			var set = this.curSet;
-			var species = Dex.forGen(this.curTeam.gen).species.get(this.curSet.species);
+			var species = this.curTeam.dex.species.get(this.curSet.species);
 
 			var baseStats = species.baseStats;
 
@@ -2540,7 +2541,7 @@
 			var set = this.curSet;
 			var isLetsGo = this.curTeam.format.includes('letsgo');
 			var isNatDex = this.curTeam.gen === 8 && this.curTeam.format.includes('nationaldex');
-			var species = Dex.species.get(set.species);
+			var species = this.curTeam.dex.species.get(set.species);
 			if (!set) return;
 			buf += '<div class="resultheader"><h3>Details</h3></div>';
 			buf += '<form class="detailsform">';
@@ -2591,7 +2592,7 @@
 			if (this.curTeam.gen > 2) {
 				buf += '<div class="formrow" style="display:none"><label class="formlabel">Pokeball:</label><div><select name="pokeball">';
 				buf += '<option value=""' + (!set.pokeball ? ' selected="selected"' : '') + '></option>'; // unset
-				var balls = Dex.forGen(this.curTeam.gen).getPokeballs();
+				var balls = this.curTeam.dex.getPokeballs();
 				for (var i = 0; i < balls.length; i++) {
 					buf += '<option value="' + balls[i] + '"' + (set.pokeball === balls[i] ? ' selected="selected"' : '') + '>' + balls[i] + '</option>';
 				}
@@ -2622,7 +2623,7 @@
 			e.stopPropagation();
 			var set = this.curSet;
 			if (!set) return;
-			var species = Dex.species.get(set.species);
+			var species = this.curTeam.dex.species.get(set.species);
 			var isLetsGo = this.curTeam.format.includes('letsgo');
 			var isNatDex = this.curTeam.format.includes('nationaldex');
 
@@ -2665,7 +2666,7 @@
 
 			// pokeball
 			var pokeball = this.$chart.find('select[name=pokeball]').val();
-			if (pokeball && Dex.forGen(this.curTeam.gen).items.get(pokeball).isPokeball) {
+			if (pokeball && this.curTeam.dex.items.get(pokeball).isPokeball) {
 				set.pokeball = pokeball;
 			} else {
 				delete set.pokeball;
@@ -2870,7 +2871,7 @@
 			var val = '';
 			switch (name) {
 			case 'pokemon':
-				val = (id in BattlePokedex ? Dex.species.get(e.currentTarget.value).name : '');
+				val = (id in BattlePokedex ? this.curTeam.dex.species.get(e.currentTarget.value).name : '');
 				break;
 			case 'ability':
 				if (id in BattleItems && this.curTeam.format == "gen8dualwielding") {
@@ -3055,12 +3056,12 @@
 
 					set.ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
 					if (this.curTeam.gen > 2) {
-						var HPivs = Dex.types.get(hpType).HPivs;
+						var HPivs = this.curTeam.dex.types.get(hpType).HPivs;
 						for (var i in HPivs) {
 							set.ivs[i] = HPivs[i];
 						}
 					} else {
-						var HPdvs = Dex.types.get(hpType).HPdvs;
+						var HPdvs = this.curTeam.dex.types.get(hpType).HPdvs;
 						for (var i in HPdvs) {
 							set.ivs[i] = HPdvs[i] * 2;
 						}
@@ -3091,7 +3092,7 @@
 			for (var i = 0; i < moves.length; ++i) {
 				if (!moves[i]) continue;
 				if (moves[i].substr(0, 13) === 'Hidden Power ') hasHiddenPower = true;
-				var move = Dex.forGen(this.curTeam.gen).moves.get(moves[i]);
+				var move = this.curTeam.dex.moves.get(moves[i]);
 				if (move.id === 'transform') {
 					hasHiddenPower = true; // A Pokemon with Transform can copy another Pokemon that knows Hidden Power
 
@@ -3138,7 +3139,7 @@
 		},
 		setPokemon: function (val, selectNext) {
 			var set = this.curSet;
-			var species = Dex.forGen(this.curTeam.gen).species.get(val);
+			var species = this.curTeam.dex.species.get(val);
 			if (!species.exists || set.species === species.name) {
 				if (selectNext) this.$('input[name=item]').select();
 				return;
@@ -3205,7 +3206,7 @@
 
 			// do this after setting set.evs because it's assumed to exist
 			// after getStat is run
-			var species = Dex.forGen(this.curTeam.gen).species.get(set.species);
+			var species = this.curTeam.dex.species.get(set.species);
 			if (!species.exists) return 0;
 
 			if (!set.level) set.level = 100;
@@ -3309,7 +3310,7 @@
 			this.room = data.room;
 			this.curSet = data.curSet;
 			this.chartIndex = data.index;
-			var species = Dex.species.get(this.curSet.species);
+			var species = this.curTeam.dex.species.get(this.curSet.species);
 			var baseid = toID(species.baseSpecies);
 			var forms = [baseid].concat(species.cosmeticFormes.map(toID));
 			var spriteDir = Dex.resourcePrefix + 'sprites/';
@@ -3345,9 +3346,9 @@
 			this.$el.html(buf).css({'max-width': (4 + spriteSize) * width, 'height': 42 + (4 + spriteSize) * height});
 		},
 		setForm: function (form) {
-			var species = Dex.species.get(this.curSet.species);
+			var species = this.curTeam.dex.species.get(this.curSet.species);
 			if (form && form !== species.form) {
-				this.curSet.species = Dex.species.get(species.baseSpecies + form).name;
+				this.curSet.species = this.curTeam.dex.species.get(species.baseSpecies + form).name;
 			} else if (!form) {
 				this.curSet.species = species.baseSpecies;
 			}

--- a/src/battle-dex.ts
+++ b/src/battle-dex.ts
@@ -924,14 +924,10 @@ class ModdedDex {
 
 			let data = {...Dex.species.get(name)};
 
-			const overrideSpeciesKeys = ['abilities', 'baseStats', 'requiredItem', 'types'];
-			for (const key of overrideSpeciesKeys) {
-				for (var i = this.gen; i < 8; i++) {
-					const table = window.BattleTeambuilderTable['gen' + i];
-					if (id in table.overrideSpeciesData && key in table.overrideSpeciesData[id]) {
-						data[key] = table.overrideSpeciesData[key];
-						break;
-					}
+			for (let i = Dex.gen - 1; i >= this.gen; i--) {
+				const table = window.BattleTeambuilderTable[`gen${i}`];
+				if (id in table.overrideSpeciesData) {
+					Object.assign(data, table.overrideSpeciesData[id]);
 				}
 			}
 			if (this.gen < 3) {

--- a/src/battle-dex.ts
+++ b/src/battle-dex.ts
@@ -851,9 +851,15 @@ class ModdedDex {
 
 			let data = {...Dex.moves.get(name)};
 
-			const table = window.BattleTeambuilderTable[this.modid];
-			if (id in table.overrideMoveData) {
-				data = {...data, ...table.overrideMoveData[id]};
+			const overrideMoveKeys = ['accuracy', 'basePower', 'category', 'desc', 'flags', 'pp', 'shortDesc', 'target', 'type'];
+			for (const key of overrideMoveKeys) {
+				for (var i = this.gen; i < 8; i++) {
+					const table = window.BattleTeambuilderTable['gen' + i];
+					if (id in table.overrideMoveData && key in table.overrideMoveData[id]) {
+						data[key] = table.overrideMoveData[key];
+						break;
+					}
+				}
 			}
 			const move = new Move(id, name, data);
 			this.cache.Moves[id] = move;
@@ -912,14 +918,21 @@ class ModdedDex {
 
 			let data = {...Dex.species.get(name)};
 
-			const table = window.BattleTeambuilderTable[this.modid];
-			if (id in table.overrideDexData) {
-				data = {...data, ...table.overrideDexData[id]};
+			const overrideSpeciesKeys = ['abilities', 'baseStats', 'requiredItem', 'types'];
+			for (const key of overrideSpeciesKeys) {
+				for (var i = this.gen; i < 8; i++) {
+					const table = window.BattleTeambuilderTable['gen' + i];
+					if (id in table.overrideSpeciesData && key in table.overrideSpeciesData[id]) {
+						data[key] = table.overrideSpeciesData[key];
+						break;
+					}
+				}
 			}
 			if (this.gen < 3) {
 				data.abilities = {0: "None"};
 			}
 
+			const table = window.BattleTeambuilderTable[this.modid];
 			if (id in table.overrideTier) data.tier = table.overrideTier[id];
 			if (!data.tier && id.slice(-5) === 'totem') {
 				data.tier = this.species.get(id.slice(0, -5)).tier;
@@ -945,13 +958,14 @@ class ModdedDex {
 			let data = {...Dex.types.get(name)};
 
 			for (let i = 7; i >= this.gen; i--) {
-				if (id in window.BattleTeambuilderTable['gen' + i].removeType) {
+				const table = window.BattleTeambuilderTable['gen' + i];
+				if (id in table.removeType) {
 					data.exists = false;
 					// don't bother correcting its attributes given it doesn't exist
 					break;
 				}
-				if (id in window.BattleTeambuilderTable['gen' + i].overrideTypeChart) {
-					data = {...data, ...window.BattleTeambuilderTable['gen' + i].overrideTypeChart[id]};
+				if (id in table.overrideTypeChart) {
+					data = {...data, ...table.overrideTypeChart[id]};
 				}
 			}
 

--- a/src/battle-dex.ts
+++ b/src/battle-dex.ts
@@ -852,14 +852,9 @@ class ModdedDex {
 			let data = {...Dex.moves.get(name)};
 
 			const table = window.BattleTeambuilderTable[this.modid];
-			if (id in table.overrideAcc) data.accuracy = table.overrideAcc[id];
-			if (id in table.overrideBP) data.basePower = table.overrideBP[id];
-			if (id in table.overridePP) data.pp = table.overridePP[id];
-			if (id in table.overrideMoveType) data.type = table.overrideMoveType[id];
-			if (id in table.overrideMoveCategory) data.category = table.overrideMoveCategory[id];
-			if (id in table.overrideMoveDesc) data.desc = table.overrideMoveDesc[id];
-			if (id in table.overrideMoveShortDesc) data.shortDesc = table.overrideMoveShortDesc[id];
-
+			if (id in table.overrideMoveData) {
+				data = {...data, ...table.overrideMoveData[id]};
+			}
 			const move = new Move(id, name, data);
 			this.cache.Moves[id] = move;
 			return move;
@@ -918,28 +913,12 @@ class ModdedDex {
 			let data = {...Dex.species.get(name)};
 
 			const table = window.BattleTeambuilderTable[this.modid];
+			if (id in table.overrideDexData) {
+				data = {...data, ...table.overrideDexData[id]};
+			}
 			if (this.gen < 3) {
 				data.abilities = {0: "None"};
-			} else {
-				let abilities = {...data.abilities};
-				if (id in table.overrideAbility) {
-					abilities['0'] = table.overrideAbility[id];
-				}
-				if (id in table.removeSecondAbility) {
-					delete abilities['1'];
-				}
-				if (id in table.overrideHiddenAbility) {
-					abilities['H'] = table.overrideHiddenAbility[id];
-				}
-				if (this.gen < 5) delete abilities['H'];
-				if (this.gen < 7) delete abilities['S'];
-
-				data.abilities = abilities;
 			}
-			if (id in table.overrideStats) {
-				data.baseStats = {...data.baseStats, ...table.overrideStats[id]};
-			}
-			if (id in table.overrideType) data.types = table.overrideType[id].split('/');
 
 			if (id in table.overrideTier) data.tier = table.overrideTier[id];
 			if (!data.tier && id.slice(-5) === 'totem') {

--- a/src/battle-dex.ts
+++ b/src/battle-dex.ts
@@ -878,8 +878,13 @@ class ModdedDex {
 
 			let data = {...Dex.items.get(name)};
 
-			const table = window.BattleTeambuilderTable[this.modid];
-			if (id in table.overrideItemDesc) data.shortDesc = table.overrideItemDesc[id];
+			for (let i = this.gen; i < 8; i++) {
+				const table = window.BattleTeambuilderTable['gen' + i];
+				if (id in table.overrideItemDesc) {
+					data.shortDesc = table.overrideItemDesc[id];
+					break;
+				}
+			}
 
 			const item = new Item(id, name, data);
 			this.cache.Items[id] = item;
@@ -898,8 +903,13 @@ class ModdedDex {
 
 			let data = {...Dex.abilities.get(name)};
 
-			const table = window.BattleTeambuilderTable[this.modid];
-			if (id in table.overrideAbilityDesc) data.shortDesc = table.overrideAbilityDesc[id];
+			for (let i = this.gen; i < 8; i++) {
+				const table = window.BattleTeambuilderTable['gen' + i];
+				if (id in table.overrideAbilityDesc) {
+					data.shortDesc = table.overrideAbilityDesc[id];
+					break;
+				}
+			}
 
 			const ability = new Ability(id, name, data);
 			this.cache.Abilities[id] = ability;

--- a/src/battle-dex.ts
+++ b/src/battle-dex.ts
@@ -857,6 +857,7 @@ class ModdedDex {
 					Object.assign(data, table.overrideMoveData[id]);
 				}
 			}
+
 			const move = new Move(id, name, data);
 			this.cache.Moves[id] = move;
 			return move;

--- a/src/battle-dex.ts
+++ b/src/battle-dex.ts
@@ -851,14 +851,10 @@ class ModdedDex {
 
 			let data = {...Dex.moves.get(name)};
 
-			const overrideMoveKeys = ['accuracy', 'basePower', 'category', 'desc', 'flags', 'pp', 'shortDesc', 'target', 'type'];
-			for (const key of overrideMoveKeys) {
-				for (var i = this.gen; i < 8; i++) {
-					const table = window.BattleTeambuilderTable['gen' + i];
-					if (id in table.overrideMoveData && key in table.overrideMoveData[id]) {
-						data[key] = table.overrideMoveData[key];
-						break;
-					}
+			for (let i = Dex.gen - 1; i >= this.gen; i--) {
+				const table = window.BattleTeambuilderTable[`gen${i}`];
+				if (id in table.overrideMoveData) {
+					Object.assign(data, table.overrideMoveData[id]);
 				}
 			}
 			const move = new Move(id, name, data);


### PR DESCRIPTION
Rather than individually picking and choosing which data to override, I think it's best to just have one object containing all the data to override, at least for the Pokedex and Moves since those have a lot of data to override. The new way I implemented the override allows for more data to be overridden without having to manually add each attribute.

For example, the Arceus formes will now automatically get their plate in gen 6 and below. It also doesn't show unreleased hidden abilities from gen 5 (right now Zapdos, for example, shows static in gen 5 despite it not being valid).

As for moves, the target of a move can be overridden now, as well as its flags (one example of flags needing to be overridden is rock blast, which wasn't considered a bullet move in gen 6 but is gen 7, so right now it incorrectly shows rock blast being a bullet move in gen 6 games).

I also went ahead and added a `dex` attribute to `curTeam`, so that `Dex.forGen` doesn't have to be called everytime, and so that `overrideType` doesn't have to be used there.