### PR TITLE
Use getGen3Category to override move category for gen 3 and below

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -955,6 +955,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 			const curEntry = Dex.mod(gen).moves.get(id);
 			const nextEntry = Dex.mod(nextGen).moves.get(id);
 			for (const key of overrideMoveKeys) {
+				if (key === 'category' && genNum <= 3) continue;
 				if (JSON.stringify(curEntry[key]) !== JSON.stringify(nextEntry[key])) {
 					if (!overrideMoveData[id]) overrideMoveData[id] = {};
 					overrideMoveData[id][key] = curEntry[key];

--- a/src/battle-dex.ts
+++ b/src/battle-dex.ts
@@ -857,6 +857,9 @@ class ModdedDex {
 					Object.assign(data, table.overrideMoveData[id]);
 				}
 			}
+			if (this.gen <= 3 && data.category !== 'Status') {
+				data.category = Dex.getGen3Category(data.type);
+			}
 
 			const move = new Move(id, name, data);
 			this.cache.Moves[id] = move;


### PR DESCRIPTION
~~I probably shouldn't have removed this in the first place~~
It turns out new gen moves make it on to the `overrideMoveData` for gen 3 because of me not using `getGen3Category`, which probably shouldn't be happening.