### PR TITLE
Tooltips: Improve accuracy

### DIFF
--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -1484,12 +1484,12 @@ class BattleTooltips {
 			accuracyModifiers.push(5325);
 			value.abilityModify(1.3, "Compound Eyes");
 		}
-		
+
 		if (value.tryItem('Wide Lens')) {
 			accuracyModifiers.push(4505);
 			value.itemModify(1.1, "Wide Lens");
 		}
-		
+
 		// Chaining modifiers
 		let chain = 4096;
 		for (const mod of accuracyModifiers) {
@@ -1519,7 +1519,7 @@ class BattleTooltips {
 				value.set(Math.floor(value.value * 3 / (3 - pokemon.boosts.accuracy)));
 			}
 		}
-		
+
 		// 1/256 glitch
 		if (this.battle.gen === 1 && !toID(this.battle.tier).includes('stadium')) {
 			value.set((Math.floor(value.value * 255 / 100) / 256) * 100);

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -1509,17 +1509,17 @@ class BattleTooltips {
 		// Chained modifiers round down on 0.5
 		let accuracyAfterChain = (value.value * chain) / 4096;
 		accuracyAfterChain = accuracyAfterChain % 1 > 0.5 ? Math.ceil(accuracyAfterChain) : Math.floor(accuracyAfterChain);
-		if (accuracyAfterChain > 100) accuracyAfterChain = 100;
 		value.set(accuracyAfterChain);
 
 		// Unlike for Atk, Def, etc. accuracy and evasion boosts are applied after modifiers
 		if (pokemon?.boosts.accuracy) {
 			if (pokemon.boosts.accuracy > 0) {
-				value.set(Math.min(100, Math.floor(value.value * (pokemon.boosts.accuracy + 3) / 3)));
+				value.set(Math.floor(value.value * (pokemon.boosts.accuracy + 3) / 3));
 			} else {
 				value.set(Math.floor(value.value * 3 / (3 - pokemon.boosts.accuracy)));
 			}
 		}
+		value.set(Math.min(100, value.value));
 		
 		// 1/256 glitch
 		if (this.battle.gen === 1 && !toID(this.battle.tier).includes('stadium')) {

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -1519,7 +1519,6 @@ class BattleTooltips {
 				value.set(Math.floor(value.value * 3 / (3 - pokemon.boosts.accuracy)));
 			}
 		}
-		value.set(Math.min(100, value.value));
 		
 		// 1/256 glitch
 		if (this.battle.gen === 1 && !toID(this.battle.tier).includes('stadium')) {

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -1422,6 +1422,7 @@ class BattleTooltips {
 		value.reset(move.accuracy === true ? 0 : move.accuracy, true);
 
 		let pokemon = value.pokemon!;
+		// Sure-hit accuracy
 		if (move.id === 'toxic' && this.battle.gen >= 6 && this.pokemonHasType(pokemon, 'Poison')) {
 			value.set(0, "Poison type");
 			return value;
@@ -1432,18 +1433,18 @@ class BattleTooltips {
 		if (move.id === 'hurricane' || move.id === 'thunder') {
 			value.weatherModify(0, 'Rain Dance');
 			value.weatherModify(0, 'Primordial Sea');
-			if (value.tryWeather('Sunny Day')) value.set(50, 'Sunny Day');
-			if (value.tryWeather('Desolate Land')) value.set(50, 'Desolate Land');
 		}
 		value.abilityModify(0, 'No Guard');
 		if (!value.value) return value;
+
+		// OHKO moves don't use standard accuracy / evasion modifiers
 		if (move.ohko) {
 			if (this.battle.gen === 1) {
 				value.set(value.value, `fails if target's Speed is higher`);
 				return value;
 			}
-			if (move.id === 'sheercold' && this.battle.gen >= 7) {
-				if (!this.pokemonHasType(pokemon, 'Ice')) value.set(20, 'not Ice-type');
+			if (move.id === 'sheercold' && this.battle.gen >= 7 && !this.pokemonHasType(pokemon, 'Ice')) {
+				value.set(20, 'not Ice-type');
 			}
 			if (target) {
 				if (pokemon.level < target.level) {
@@ -1458,28 +1459,68 @@ class BattleTooltips {
 			}
 			return value;
 		}
-		if (pokemon?.boosts.accuracy) {
-			if (pokemon.boosts.accuracy > 0) {
-				value.modify((pokemon.boosts.accuracy + 3) / 3);
-			} else {
-				value.modify(3 / (3 - pokemon.boosts.accuracy));
-			}
+
+		// Accuracy modifiers start
+
+		let accuracyModifiers = [];
+		if (this.battle.hasPseudoWeather('Gravity')) {
+			accuracyModifiers.push(6840);
+			value.modify(5 / 3, "Gravity");
 		}
-		if (move.category === 'Physical') {
-			value.abilityModify(0.8, "Hustle");
-		}
-		value.abilityModify(1.3, "Compound Eyes");
+
 		for (const active of pokemon.side.active) {
 			if (!active || active.fainted) continue;
-			let ability = this.getAllyAbility(active);
+			const ability = this.getAllyAbility(active);
 			if (ability === 'Victory Star') {
+				accuracyModifiers.push(4506);
 				value.modify(1.1, "Victory Star");
 			}
 		}
-		value.itemModify(1.1, "Wide Lens");
-		if (this.battle.hasPseudoWeather('Gravity')) {
-			value.modify(5 / 3, "Gravity");
+
+		if (value.tryAbility('Hustle') && move.category === 'Physical') {
+			accuracyModifiers.push(3277);
+			value.abilityModify(0.8, "Hustle");
+		} else if (value.tryAbility('Compound Eyes')) {
+			accuracyModifiers.push(5325);
+			value.abilityModify(1.3, "Compound Eyes");
 		}
+		
+		if (value.tryItem('Wide Lens')) {
+			accuracyModifiers.push(4505);
+			value.itemModify(1.1, "Wide Lens");
+		}
+		
+		// Chaining modifiers
+		let chain = 4096;
+		for (const mod of accuracyModifiers) {
+			if (mod !== 4096) {
+				chain = (chain * mod + 2048) >> 12;
+			}
+		}
+
+		// Applying modifiers
+		value.set(move.accuracy as number);
+
+		if (move.id === 'hurricane' || move.id === 'thunder') {
+			if (value.tryWeather('Sunny Day')) value.set(50, 'Sunny Day');
+			if (value.tryWeather('Desolate Land')) value.set(50, 'Desolate Land');
+		}
+
+		// Chained modifiers round down on 0.5
+		let accuracyAfterChain = (value.value * chain) / 4096;
+		accuracyAfterChain = accuracyAfterChain % 1 > 0.5 ? Math.ceil(accuracyAfterChain) : Math.floor(accuracyAfterChain);
+		if (accuracyAfterChain > 100) accuracyAfterChain = 100;
+		value.set(accuracyAfterChain);
+
+		// Unlike for Atk, Def, etc. accuracy and evasion boosts are applied after modifiers
+		if (pokemon?.boosts.accuracy) {
+			if (pokemon.boosts.accuracy > 0) {
+				value.set(Math.min(100, Math.floor(value.value * (pokemon.boosts.accuracy + 3) / 3)));
+			} else {
+				value.set(Math.floor(value.value * 3 / (3 - pokemon.boosts.accuracy)));
+			}
+		}
+		
 		// 1/256 glitch
 		if (this.battle.gen === 1 && !toID(this.battle.tier).includes('stadium')) {
 			value.set((Math.floor(value.value * 255 / 100) / 256) * 100);


### PR DESCRIPTION
This fixes a number of display issues with accuracy:

- Accuracy values are more precise in their display, while keeping relative values for multipliers for regular users to understand. For example, the difference between Victory Star Fire Blast and Wide Lens Fire Blast:
![image](https://user-images.githubusercontent.com/23667022/119917565-6e01a580-bf2c-11eb-8482-f6ecf368d543.png)
![image](https://user-images.githubusercontent.com/23667022/119917583-7954d100-bf2c-11eb-91f9-63e9a201bd2e.png)

- Related to the above, accuracy values are now properly rounded. For example, Compound Eyes Sleep Powder:
![image](https://user-images.githubusercontent.com/23667022/119917677-a1443480-bf2c-11eb-9d7a-057ee7b8040e.png)

Note that this chaining process is not _technically 100% correct_ because of the potential of multiple Victory Star. The order of Abilities being chained would depend on raw Speed (like LightningRod). However, in order to get it 100% correct, you'd have to start tracking host stuff, when a Pokemon last acquired an ability relative to other mons, etc. We don't even have a way to sort by Speed on client afaik, and I don't feel like doing the extra work for such miniscule gains. If someone uses Role Play on their Victini in doubles, they may have to deal with rare cases of the accuracy tooltip being 1% off (it may not even matter mathematically speaking, but I have not crunched the numbers).

One point of discussion might be whether or not we want to cap accuracy calculations at 100% or not. Currently, we do not cap accuracy calculations at 100%, presumably because we don't account for the opponent at all in our calculations. I left this as-is.