### PR TITLE
Update sidebar for all forme changes

### DIFF
--- a/src/battle-animations.ts
+++ b/src/battle-animations.ts
@@ -2505,8 +2505,8 @@ class PokemonSprite extends Sprite {
 		});
 		this.scene.wait(500);
 
+		this.scene.updateSidebar(pokemon.side);
 		if (isPermanent) {
-			this.scene.updateSidebar(pokemon.side);
 			this.resetStatbar(pokemon);
 		} else {
 			this.updateStatbar(pokemon);


### PR DESCRIPTION
Currently it runs only when the forme change is permanent, which means changes like aegislash or minior don't get updated icons when they should unless you skip the turn.