### PR TITLE
Show correct typechange content for Pokemon with 3+ types

### DIFF
--- a/src/battle-animations.ts
+++ b/src/battle-animations.ts
@@ -2707,7 +2707,7 @@ class PokemonSprite extends Sprite {
 			status += '<span class="frz">FRZ</span> ';
 		}
 		if (pokemon.volatiles.typechange && pokemon.volatiles.typechange[1]) {
-			let types = pokemon.volatiles.typechange[1].split('/');
+			const types = pokemon.volatiles.typechange[1].split('/');
 			for (const type of types) {
 				status += '<img src="' + Dex.resourcePrefix + 'sprites/types/' + encodeURIComponent(type) + '.png" alt="' + type + '" class="pixelated" /> ';
 			}

--- a/src/battle-animations.ts
+++ b/src/battle-animations.ts
@@ -2708,8 +2708,7 @@ class PokemonSprite extends Sprite {
 		}
 		if (pokemon.volatiles.typechange && pokemon.volatiles.typechange[1]) {
 			let types = pokemon.volatiles.typechange[1].split('/');
-			for (let i in types) {
-				const type = types[i];
+			for (const type of types) {
 				status += '<img src="' + Dex.resourcePrefix + 'sprites/types/' + encodeURIComponent(type) + '.png" alt="' + type + '" class="pixelated" /> ';
 			}
 		}

--- a/src/battle-animations.ts
+++ b/src/battle-animations.ts
@@ -2708,9 +2708,9 @@ class PokemonSprite extends Sprite {
 		}
 		if (pokemon.volatiles.typechange && pokemon.volatiles.typechange[1]) {
 			let types = pokemon.volatiles.typechange[1].split('/');
-			status += '<img src="' + Dex.resourcePrefix + 'sprites/types/' + encodeURIComponent(types[0]) + '.png" alt="' + types[0] + '" class="pixelated" /> ';
-			if (types[1]) {
-				status += '<img src="' + Dex.resourcePrefix + 'sprites/types/' + encodeURIComponent(types[1]) + '.png" alt="' + types[1] + '" class="pixelated" /> ';
+			for (let i in types) {
+				const type = types[i];
+				status += '<img src="' + Dex.resourcePrefix + 'sprites/types/' + encodeURIComponent(type) + '.png" alt="' + type + '" class="pixelated" /> ';
 			}
 		}
 		if (pokemon.volatiles.typeadd) {


### PR DESCRIPTION
(First client pull request) I agree to make this code available under the MIT license.

This behaviour is exposed in Bonus Type. Currently, if a Pokemon's bonus type is its second type, it is correctly displayed by the typechange in the main battle UI. However, if the bonus type is its third type, it is not displayed except in the tooltip, and if a Pokemon increases from having two to three typing due to an in-battle forme change, the bonus type will disappear. With this change, all of the types are displayed consistently.