### PR TITLE
Add an administration panel for side servers

### DIFF
--- a/lib/ntbb-servermodlog.sql
+++ b/lib/ntbb-servermodlog.sql
@@ -16,7 +16,6 @@ CREATE TABLE `ntbb_servermodlog` (
   KEY `ip` (`ip`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-CREATE INDEX type_idx ON `ntbb_servermodlog` (`serverid`);
 CREATE INDEX server_idx ON `ntbb_servermodlog` (`serverid`, `type`);
 CREATE INDEX user_idx ON `ntbb_servermodlog` (`serverid`, `actorid`);
 CREATE INDEX mixed_search ON `ntbb_servermodlog` (`serverid`, `actorid`, `type`);

--- a/lib/ntbb-servermodlog.sql
+++ b/lib/ntbb-servermodlog.sql
@@ -1,0 +1,22 @@
+--
+-- Table structure for table `ntbb_servermodlog`
+-- Effectively taken from ntbb_usermodlog, as they serve a similar function.
+-- We just happen to use a `type` column to make it easier to narrow searches.
+
+CREATE TABLE `ntbb_servermodlog` (
+  `entryid` int(11) NOT NULL AUTO_INCREMENT,
+  `serverid` varchar(63) CHARACTER SET latin1 NOT NULL,
+  `actorid` varchar(63) CHARACTER SET latin1 NOT NULL,
+  `date` int(11) NOT NULL,
+  `ip` varchar(63) CHARACTER SET latin1 NOT NULL,
+  `type` varchar(63) CHARACTER SET latin1 NOT NULL,
+  `note` varchar(1023) CHARACTER SET latin1 NOT NULL,
+  PRIMARY KEY (`entryid`),
+  KEY `actorid` (`actorid`),
+  KEY `ip` (`ip`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE INDEX type_idx ON `ntbb_servermodlog` (`serverid`);
+CREATE INDEX server_idx ON `ntbb_servermodlog` (`serverid`, `type`);
+CREATE INDEX user_idx ON `ntbb_servermodlog` (`serverid`, `actorid`);
+CREATE INDEX mixed_search ON `ntbb_servermodlog` (`serverid`, `actorid`, `type`);

--- a/lib/ntbb-servermodlog.sql
+++ b/lib/ntbb-servermodlog.sql
@@ -17,5 +17,4 @@ CREATE TABLE `ntbb_servermodlog` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE INDEX server_idx ON `ntbb_servermodlog` (`serverid`, `type`);
-CREATE INDEX user_idx ON `ntbb_servermodlog` (`serverid`, `actorid`);
 CREATE INDEX mixed_search ON `ntbb_servermodlog` (`serverid`, `actorid`, `type`);

--- a/lib/ntbb-session.lib.php
+++ b/lib/ntbb-session.lib.php
@@ -471,7 +471,12 @@ class NTBBSession {
 		if (($user['userid'] === $userid) && !empty($user['loggedin'])) {
 			// already logged in
 			$usertype = '2';
-			if (in_array($userid, $psconfig['sysops'], true)) {
+			$ismain = $serverhostname === 'sim3.psim.us' || $serverhostname === 'smogtours.psim.us';
+			if (
+				in_array($userid, $psconfig['sysops'], true) ||
+				// give admins and leaders sysop on side servers
+				(!$ismain && $users->isLeader())
+			) {
 				$usertype = '3';
 			} else {
 				// check autoconfirmed

--- a/website/servers/index.php
+++ b/website/servers/index.php
@@ -46,7 +46,7 @@ if (@$_POST['act'] === 'addserver') {
 		die("invalid server location");
 	}
 	$email = trim($_POST['email'] ?? '');
-	if (!$email || !strpos($email, '@')) {
+	if (!$email || strpos($email, '@') === false) {
 		die('Invalid email.');
 	}
 	$PokemonServers[$id] = [

--- a/website/servers/index.php
+++ b/website/servers/index.php
@@ -1,7 +1,6 @@
 <?php
 
 include_once 'servers.lib.php';
-include_once __DIR__ . '/../../lib/ntbb-database.lib.php';
 include '../style/wrapper.inc.php';
 
 $timenow = time();

--- a/website/servers/index.php
+++ b/website/servers/index.php
@@ -134,7 +134,7 @@ if ($users->isLeader()) {
 				</div>
 				<div class="buttonrow">
 					<button type="submit"><strong>Add server</strong></button>
-				</div></div>
+				</div>
 			</form>
 <?php
 }

--- a/website/servers/index.php
+++ b/website/servers/index.php
@@ -45,7 +45,7 @@ if (@$_POST['act'] === 'addserver') {
 	if (strpos($server, '.') === false) {
 		die("invalid server location");
 	}
-	$email = isset($_POST['email']) ? trim($_POST['email']) : false;
+	$email = trim($_POST['email'] ?? '');
 	if (!$email || !strpos($email, '@')) {
 		die('Invalid email.');
 	}

--- a/website/servers/index.php
+++ b/website/servers/index.php
@@ -131,6 +131,7 @@ if ($users->isLeader()) {
 				</div>
 				<div class="formrow">
 					<label class="label">Owner's email: <input class="textbox" type="text" name="email" /></label>
+				</div>
 				<div class="buttonrow">
 					<button type="submit"><strong>Add server</strong></button>
 				</div></div>

--- a/website/servers/manage.php
+++ b/website/servers/manage.php
@@ -159,11 +159,11 @@ if (isset($_REQUEST['unbanhosts']) && mb_strlen($_REQUEST['unbanhosts'])) {
 	writeserverinfo();
 	$scount = count($successes);
 	$fcount = count($failures);
-	echo('Removed ' . $scount . " host (s) from the blacklist. (" . implode(', ', $successes) . ")");
+	echo 'Removed ' . $scount . ' host(s) from the blacklist. (' . implode(', ', $successes) . ')<br />';
 	if ($fcount > 0) {
-		echo("Failed to remove " . $fcount . " host (s) from the blacklist. (" . implode(', ', $failures) . ")");
+		echo 'Failed to remove ' . $fcount . ' host(s) from the blacklist. (' . implode(', ', $failures) . ')<br />';
 	}
-	echo('</div>');
+	echo '</div>';
 }
 
 ?>

--- a/website/servers/manage.php
+++ b/website/servers/manage.php
@@ -57,7 +57,7 @@ if (isset($_REQUEST['banowners'])) {
 			$serverinfo['blacklist'] = [];
 		}
 		$failures = [];
-		if (!in_array($userid, $serverinfo['blacklist'])) {
+		if (!in_array($userid, $serverinfo['blacklist'], true)) {
 			$serverinfo['blacklist'][] = $userid;
 			$successes += 1;
 			$psdb->query(
@@ -81,11 +81,11 @@ if (isset($_REQUEST['banowners'])) {
 	}
 	echo "<strong>{$successes} user (s) added to blacklist.</strong><br />";
 	if (count($failures) > 0) {
-		echo ("(" . count($failures) . "user (s) could not be added: " . implode(", ", $failures) . ")<br />");
+		echo "(" . count($failures) . "user (s) could not be added: " . implode(", ", $failures) . ")<br />";
 	}
 }
 
-echo('<br />');
+echo '<br />';
 if (isset($serverinfo['blacklist']) && count($serverinfo['blacklist'])) {
 ?>
 	<hr />
@@ -173,13 +173,10 @@ if (isset($_REQUEST['unbanhosts']) && mb_strlen($_REQUEST['unbanhosts'])) {
 		<input type="text" name="unbanhosts" class="textbox" /><br /><br />
 		<button type="submit">Remove hosts from list</button>
 	</form>
+</td></tr>
+</table></div></div>
+<center>
 <?php
-
-echo('</td></tr>');
-
-echo('</table></div></div>');
-
-echo '<center>';
 
 if (isset($_REQUEST['ownedby']) || isset($_REQUEST['hostedby']) || isset($_REQUEST['lastactive'])) {
 	$owner = isset($_REQUEST['ownedby']) && mb_strlen($_REQUEST['ownedby']) ? $users->userid($_REQUEST['ownedby']) : NULL;

--- a/website/servers/manage.php
+++ b/website/servers/manage.php
@@ -52,7 +52,7 @@ if (isset($_REQUEST['banowners'])) {
 	$successes = 0;
 	foreach ($banned as $user) {
 		$userid = $users->userid($user);
-		if (!mb_strlen($userid)) continue;
+		if (!strlen($userid)) continue;
 		if (!isset($serverinfo['blacklist'])) {
 			$serverinfo['blacklist'] = [];
 		}
@@ -139,13 +139,13 @@ if (isset($_REQUEST['unbanowners']) && isset($serverinfo['blacklist'])) {
 	</div>
 <?php
 
-if (isset($_REQUEST['unbanhosts']) && mb_strlen($_REQUEST['unbanhosts'])) {
+if (isset($_REQUEST['unbanhosts']) && strlen($_REQUEST['unbanhosts'])) {
 	$hosts = explode(',', $_REQUEST['unbanhosts']);
 	$successes = [];
 	$failures = [];
 	foreach ($hosts as $i=>$host) {
 		$host = trim($host);
-		if (!mb_strlen($host)) continue;
+		if (!strlen($host)) continue;
 		if (!isset($serverinfo['bannedhosts'])) {
 			$serverinfo['bannedhosts'] = [];
 		}
@@ -179,9 +179,9 @@ if (isset($_REQUEST['unbanhosts']) && mb_strlen($_REQUEST['unbanhosts'])) {
 <?php
 
 if (isset($_REQUEST['ownedby']) || isset($_REQUEST['hostedby']) || isset($_REQUEST['lastactive'])) {
-	$owner = isset($_REQUEST['ownedby']) && mb_strlen($_REQUEST['ownedby']) ? $users->userid($_REQUEST['ownedby']) : NULL;
-	$host = isset($_REQUEST['hostedby']) && mb_strlen($_REQUEST['hostedby']) ? $_REQUEST['hostedby'] : NULL;
-	$lastactive = isset($_REQUEST['lastactive']) && mb_strlen($_REQUEST['lastactive']) ? strtotime($_REQUEST['lastactive']) : NULL;
+	$owner = isset($_REQUEST['ownedby']) && strlen($_REQUEST['ownedby']) ? $users->userid($_REQUEST['ownedby']) : NULL;
+	$host = isset($_REQUEST['hostedby']) && strlen($_REQUEST['hostedby']) ? $_REQUEST['hostedby'] : NULL;
+	$lastactive = isset($_REQUEST['lastactive']) && strlen($_REQUEST['lastactive']) ? strtotime($_REQUEST['lastactive']) : NULL;
 	$results = [];
 	echo("<br /><div class=\"infobox\" style=\"width:300px\">");
 	if ($lastactive === false) {
@@ -191,7 +191,7 @@ if (isset($_REQUEST['ownedby']) || isset($_REQUEST['hostedby']) || isset($_REQUE
 	$searchMessage = $host ? " the host '" . $host . "'" : "";
 	$searchMessage .= $owner ? ' and ' : '';
 	$searchMessage .= $owner ? " the owner '" . $owner . "'" : "";
-	$searchMessage .= mb_strlen($searchMessage) ? " and" : "";
+	$searchMessage .= strlen($searchMessage) ? " and" : "";
 	$searchMessage .= $lastactive ? " inactivity since before " . date("Y-m-d", $lastactive) : "";
 
 	echo("<details><summary>Servers with " . $searchMessage . ": </summary>");
@@ -234,7 +234,7 @@ if (
 	$params = [];
 	if (isset($_REQUEST['serverid'])) {
 		$serverid = $users->userid($_REQUEST['serverid']);
-		if (mb_strlen($serverid)) {
+		if (strlen($serverid)) {
 			$queryString .= " WHERE serverid = ? ";
 			$hasWhere = true;
 			$params[] = $serverid;
@@ -243,7 +243,7 @@ if (
 
 	if (isset($_REQUEST['action'])) {
 		$action = strtoupper($users->userid($_REQUEST['action']));
-		if (mb_strlen($action)) {
+		if (strlen($action)) {
 			if (!$hasWhere) {
 				$queryString .= " WHERE ";
 				$hasWhere = true;
@@ -257,7 +257,7 @@ if (
 
 	if (isset($_REQUEST['userid'])) {
 		$userid = $users->userid($_REQUEST['userid']);
-		if (mb_strlen($userid)) {
+		if (strlen($userid)) {
 			if (!$hasWhere) {
 				$queryString .= " WHERE ";
 				$hasWhere = true;

--- a/website/servers/manage.php
+++ b/website/servers/manage.php
@@ -1,0 +1,349 @@
+<?php
+
+include_once __DIR__ . '/../../config/config.inc.php';
+include_once __DIR__ . '/../../config/servers.inc.php';
+include_once '../../lib/ntbb-session.lib.php';
+include '../style/wrapper.inc.php';
+include_once __DIR__ . '/../../lib/ntbb-database.lib.php';
+include_once __DIR__ . '/servers.lib.php';
+// todo open servers list in panel?
+
+if (!$users->isLeader()) {
+	die("Access denied.");
+}
+
+$page = 'serveradmin';
+$pageTitle = "Server Administration";
+
+includeHeader();
+
+?>
+	<center><h1>Server Management</h1>
+	<div class="ladder pad"><table>
+	<tr><th>Search servers</th><th>Search server modlog</th>
+	<th>Blacklist users from owning servers</th><th>Ban hosting methods</th>
+	<tr><td style="vertical-align: top; max-width: 300px">
+	<form action="/servers/manage.php" data-target="push">
+		<label for="hostedby">Search by host:</label><br />
+		<input type="text" name="hostedby" class="textbox" /><br /><br />
+		<label for="ownedby">Search by owner:</label><br />
+		<input type="text" name="ownedby" class="textbox" /><br /><br />
+		<label for="lastactive">Search by inactivity since a date:</label><br />
+		<input type="date" name="lastactive" class="textbox" /><br /><br />
+		<button type="submit">Search</button>
+	</form>
+	</div>
+	</td><td style="vertical-align: top; max-width: 300px">
+	<form action="/servers/manage.php" data-target="push">
+		<label for="serverid"> Search on a server:</label><br />
+		<input type="text" name="serverid" class="textbox" /><br /><br />
+		<label for="action">Search an action type:</label><br />
+		<input type="text" name="action" class="textbox" /><br /><br />
+		<label for="userid">Search for actions by a userid:</label><br />
+		<input type="text" name="userid" class="textbox" /><br /><br />
+		<button type="submit">Search</button>
+	</form>
+	</div></td><td style="vertical-align: top; max-width: 300px">
+	<form action="/servers/manage.php" data-target="push">
+		<label>(Separate userids with commas)</label><br />
+		<input type="text" name="banowners" class="textbox" /><br /><br />
+		<button type="submit">Add users to list</button>
+	</form>
+<?php
+
+if (isset($_REQUEST['banowners'])) {
+	echo('<br />');
+	$banned = explode(',', $_REQUEST['banowners']);
+	$successes = 0;
+	foreach ($banned as $user) {
+		$userid = $users->userid($user);
+		if (!mb_strlen($userid)) continue;
+		if (!isset($serverinfo['blacklist'])) {
+			$serverinfo['blacklist'] = [];
+		}
+		$failures = [];
+		if (!in_array($userid, $serverinfo['blacklist'])) {
+			$serverinfo['blacklist'][] = $userid;
+			$successes += 1;
+			$psdb->query(
+				"INSERT INTO `{$psdb->prefix}usermodlog` (`userid`,`actorid`,`date`,`ip`,`entry`) VALUES (?, ?, ?, ?, ?)",
+				[$userid, $curuser['userid'], time(), $users->getIp(), 'banned from owning servers']
+			);
+			foreach ($PokemonServers as $server) {
+				if ($server['owner'] == $userid) {
+					unset($PokemonServers[$server['id']]['owner']);
+				}
+				saveservers();
+				$psdb->query(
+					"INSERT INTO {$psdb->prefix}servermodlog (`serverid`, `actorid`, `date`, `ip`, `type`, `note`) VALUES (?, ?, ?, ?, ?, ?)",
+					[$server['id'], $curuser['id'], time(), $users->getIp(), 'BANOWNER', '']
+				);
+			}
+		} else {
+			$failures[] = $userid;
+		}
+		writeserverinfo();
+	}
+	echo "<strong>{$successes} user (s) added to blacklist.</strong><br />";
+	if (count($failures) > 0) {
+		echo ("(" . count($failures) . "user (s) could not be added: " . implode(", ", $failures) . ")<br />");
+	}
+}
+
+echo('<br />');
+if (isset($serverinfo['blacklist']) && count($serverinfo['blacklist'])) {
+?>
+	<hr />
+	<form action="/servers/manage.php" data-target="push">
+		<label>(Separate userids with commas)</label><br />
+		<input type="text" name="unbanowners" class="textbox" /><br /><br />
+		<button type="submit">Remove users from list</button>
+	</form>
+	<?php
+}
+
+if (isset($_REQUEST['unbanowners']) && isset($serverinfo['blacklist'])) {
+	$unbans = explode(',', $_REQUEST['unbanowners']);
+	if (count($unbans)) {
+		$successes = [];
+		$failures = [];
+		foreach ($unbans as $userid) {
+			$userid = $users->userid($userid);
+			$idx = array_search($userid, $serverinfo['blacklist']);
+			if ($idx) {
+				$successes[] = $userid;
+				array_splice($serverinfo['blacklist'], $idx);
+			} else {
+				$failures[] = $userid;
+			}
+		}
+	}
+	if (count($successes)) {
+		echo(
+			"<strong>" . count($successes) .
+			" user (s) were removed from the blacklist.</strong>" .
+			"<label>(" . implode(", ", $successes) . ")</label><br />"
+		);
+	}
+	if (count($failures)) {
+		echo(
+			"<strong style=\"color:red\">" . count($failures) .
+			"user (s) were not on the blacklist. </strong>" .
+			" <label>(" . implode(', ', $failures) . ")</label><br />"
+		);
+	}
+}
+?>
+	</div>
+	</td> <td style="vertical-align: top; max-width: 300px">
+	<form action="/servers/manage.php" data-target="push">
+		<label>(Separate hosts with commas)</label><br />
+		<input type="text" name="banhosts" class="textbox" /><br /><br />
+		<button type="submit">Add hosts to list</button>
+	</form>
+	</div>
+<?php
+
+if (isset($_REQUEST['unbanhosts']) && mb_strlen($_REQUEST['unbanhosts'])) {
+	$hosts = explode(',', $_REQUEST['unbanhosts']);
+	$successes = [];
+	$failures = [];
+	foreach ($hosts as $i=>$host) {
+		$host = trim($host);
+		if (!mb_strlen($host)) continue;
+		if (!isset($serverinfo['bannedhosts'])) {
+			$serverinfo['bannedhosts'] = [];
+		}
+		if (!in_array($host, $serverinfo['bannedhosts'])) {
+			$failures[] = $host;
+		} else {
+			$successes[] = $host;
+			array_splice($serverinfo['bannedhosts'], $i);
+		}
+	}
+	writeserverinfo();
+	$scount = count($successes);
+	$fcount = count($failures);
+	echo('Removed ' . $scount . " host (s) from the blacklist. (" . implode(', ', $successes) . ")");
+	if ($fcount > 0) {
+		echo("Failed to remove " . $fcount . " host (s) from the blacklist. (" . implode(', ', $failures) . ")");
+	}
+	echo('</div>');
+}
+
+?>
+	<br /><hr />
+	<form action="/servers/manage.php" data-target="push">
+		<label>(Separate hosts with commas)</label><br />
+		<input type="text" name="unbanhosts" class="textbox" /><br /><br />
+		<button type="submit">Remove hosts from list</button>
+	</form>
+<?php
+
+echo('</td></tr>');
+
+echo('</table></div></div>');
+
+echo '<center>';
+
+if (isset($_REQUEST['ownedby']) || isset($_REQUEST['hostedby']) || isset($_REQUEST['lastactive'])) {
+	$owner = isset($_REQUEST['ownedby']) && mb_strlen($_REQUEST['ownedby']) ? $users->userid($_REQUEST['ownedby']) : NULL;
+	$host = isset($_REQUEST['hostedby']) && mb_strlen($_REQUEST['hostedby']) ? $_REQUEST['hostedby'] : NULL;
+	$lastactive = isset($_REQUEST['lastactive']) && mb_strlen($_REQUEST['lastactive']) ? strtotime($_REQUEST['lastactive']) : NULL;
+	$results = [];
+	echo("<br /><div class=\"infobox\" style=\"width:300px\">");
+	if ($lastactive === false) {
+		echo("<strong style=\"color:red\">Invalid time string.</strong><br />");
+	}
+
+	$searchMessage = $host ? " the host '" . $host . "'" : "";
+	$searchMessage .= $owner ? ' and ' : '';
+	$searchMessage .= $owner ? " the owner '" . $owner . "'" : "";
+	$searchMessage .= mb_strlen($searchMessage) ? " and" : "";
+	$searchMessage .= $lastactive ? " inactivity since before " . date("Y-m-d", $lastactive) : "";
+
+	echo("<details><summary>Servers with " . $searchMessage . ": </summary>");
+	foreach ($PokemonServers as $server) {
+		if ($host && strpos($server['server'], $host)) {
+			$results[] = $server;
+		}
+		if ($owner &&
+			(strpos($server['owner'], ',') ? strpos($server['owner'], $owner) : $users->userid($server['owner']) === $owner)
+		) {
+			$results[] = $server;
+		}
+		if ($lastactive && (!isset($server['date']) || $lastactive > $server['date'])) {
+			$results[] = $server;
+		}
+	 }
+
+	if (!count($results)) {
+		echo("No matching servers found.");
+	} else {
+		foreach ($results as $server) {
+			echo('- ' . $server['name']);
+			if ($server['owner']) {
+				echo(" (owned by: " . $server['owner'] . ")");
+			}
+			echo("[" . $server['server'] . "]<br />");
+		}
+	}
+	echo('</details></div>');
+}
+
+if (
+	isset($_REQUEST['serverid']) || isset($_REQUEST['action']) ||
+	isset($_REQUEST['userid'])
+) {
+	echo '<br /><details><summary>';
+	echo 'Modlog search results:</summary>';
+	$queryString = "SELECT * FROM {$psdb->prefix}servermodlog ";
+	$hasWhere = false;
+	$params = [];
+	if (isset($_REQUEST['serverid'])) {
+		$serverid = $users->userid($_REQUEST['serverid']);
+		if (mb_strlen($serverid)) {
+			$queryString .= " WHERE serverid = ? ";
+			$hasWhere = true;
+			$params[] = $serverid;
+		}
+	}
+
+	if (isset($_REQUEST['action'])) {
+		$action = strtoupper($users->userid($_REQUEST['action']));
+		if (mb_strlen($action)) {
+			if (!$hasWhere) {
+				$queryString .= " WHERE ";
+				$hasWhere = true;
+			} else {
+				$queryString .= " AND ";
+			}
+			$queryString .= "type = ? ";
+			$params[] = $action;
+		}
+	}
+
+	if (isset($_REQUEST['userid'])) {
+		$userid = $users->userid($_REQUEST['userid']);
+		if (mb_strlen($userid)) {
+			if (!$hasWhere) {
+				$queryString .= " WHERE ";
+				$hasWhere = true;
+			} else {
+				$queryString .= " AND ";
+			}
+			$queryString .= " actorid = ? ";
+			$params[] = $userid;
+		}
+	}
+
+	$res = $psdb->query($queryString, $params);
+	if ($res === false) {
+		die('Error in DB search query, try again later. (' . $psdb->error() . ')');
+	} else {
+		$rows = $res->fetchAll();
+	}
+	if (count($rows) < 1) {
+		echo('No results found.');
+	} else {
+		foreach ($rows as $row) {
+			echo(
+				"<div>[" . date('F j Y, g:i a', $row['date']) .
+				"] " . strtoupper($row['type']) . ": " . $row['note'] .
+				" (by " . $row['actorid'] . ")</div>"
+			);
+		}
+	}
+	echo '</div>';
+}
+
+if (isset($serverinfo['blacklist']) && count($serverinfo['blacklist']) > 0) {
+	echo('<details><summary><strong>Users blacklisted from owning servers</strong></summary>');
+	foreach ($serverinfo['blacklist'] as $userid) {
+		$owned = [];
+		foreach ($PokemonServers as $server) {
+			if (!isset($server['owner'])) {
+				continue;
+			}
+			$owners = explode(',', $server['owner']);
+			foreach ($owners as $ownerName) {
+				if ($userid === $users->userid($ownerName)) {
+					$owned[] = $server['name'];
+					break;
+				}
+			}
+		}
+		$ownedMessage = count($owned) ?
+			"<small>(owner in " . count($owned) . " servers: " . implode(", ", $owned) . ")</small>" :
+			"";
+
+		echo($userid . " " . $ownedMessage);
+	}
+
+	echo('</details></div><br />');
+}
+
+if (isset($serverinfo['bannedhosts']) && count($serverinfo['bannedhosts']) > 0) {
+	?>
+		<details><summary><strong>Banned server hosting methods:</strong></summary>
+	<?php
+	foreach ($serverinfo['bannedhosts'] as $host) {
+		?>- <?=htmlspecialchars($host)?><?php
+		$using = [];
+		foreach ($PokemonServers as $server) {
+			if (strpos($server['server'], $host) > -1) {
+				$using[] = $server['name'];
+			}
+		}
+		$totalCount = count($using);
+		if ($totalCount > 0) {
+			echo("<label> (" . $totalCount . " server(s) using this host: " . implode(', ', $using) . ")</label>");
+		}
+		echo('<br />');
+	}
+	echo('</details>');
+}
+echo '</center>';
+
+includeFooter();
+?>

--- a/website/servers/manage.php
+++ b/website/servers/manage.php
@@ -1,11 +1,6 @@
 <?php
 
-include_once __DIR__ . '/../../config/config.inc.php';
-include_once __DIR__ . '/../../config/servers.inc.php';
-include_once '../../lib/ntbb-session.lib.php';
-include '../style/wrapper.inc.php';
-include_once __DIR__ . '/../../lib/ntbb-database.lib.php';
-include_once __DIR__ . '/servers.lib.php';
+include_once './servers.lib.php';
 // todo open servers list in panel?
 
 if (!$users->isLeader()) {

--- a/website/servers/server.php
+++ b/website/servers/server.php
@@ -260,7 +260,13 @@ exports.servertoken = '<?= $token ?>';</textarea></p>
 				<h1>Edit server</h1>
 				<div class="formrow">
 					<p><label class="label">Location: <input class="textbox" type="text" name="loc" placeholder="http://<?php echo $entry['server']; if ($entry['port'] != 8000) echo '-',$entry['port']; ?>.psim.us/" size="60" /><em>(you can leave off http:// etc if you want)</em></label></p>
-					<p><label class="label">Owner: <strong><?php echo $entry['owner'] ?? '(none)'; ?></strong></label></p>
+						<p><label class="label">Owner: <?php
+							if ($users->isLeader()) {
+								echo ('<input class="textbox" type="text" name="owner" value="'.$entry['owner'] ?? '(none)' .'" size="60">');
+							} else {
+								echo '<em>' . $entry['owner'] ?? '(none)' . "</em>";
+							}
+					?></label></p>
 					<label class="label">Configuration:</label>
 					<p><label class="label">Email: <input class="textbox" type="text" name="email" placeholder="<?php echo $entry['email'] ?? "(none)"?>" /></label></p>
 					<?php

--- a/website/servers/server.php
+++ b/website/servers/server.php
@@ -91,7 +91,7 @@ if (@$_POST['act'] === 'editserver') {
 				$bannedhost = trim($bannedhost);
 				if ($bannedhost && strpos($server, $bannedhost) !== false) {
 					$cannotUpdate = true;
-					echo "<br /><strong style=\"color:red\">You can't use the host " . htmlspecialchars($server) . " because it is from a blacklisted host.</strong><br />"
+					echo "<br /><strong style=\"color:red\">You can't use the host " . htmlspecialchars($server) . " because it is from a blacklisted host.</strong><br />";
 					break;
 				}
 			}
@@ -114,7 +114,7 @@ if (@$_POST['act'] === 'editserver') {
 			);
 		}
 		if (isset($_POST['email']) && $is_manager) {
-			if (!mb_strlen($_POST['email']) || !strpos($_POST['email'], '@')) {
+			if (!strlen($_POST['email']) || !strpos($_POST['email'], '@')) {
 				die("invalid email");
 			}
 			$oldEmail = $PokemonServers[$id]['email'] ?? "none";
@@ -131,7 +131,7 @@ if (@$_POST['act'] === 'editserver') {
 				if (isset($serverinfo['blacklist']) && in_array($userid, $serverinfo['blacklist'])) {
 					echo '<strong style="color:red">' . $userid . ' is blacklisted from owning a server.</strong><br />';
 				} else {
-					$logMessage = mb_strlen($PokemonServers[$id]['owner']) ?
+					$logMessage = strlen($PokemonServers[$id]['owner']) ?
 						("from " . $PokemonServers[$id]['owner'] . " to " . $userid) :
 						("to " . $userid);
 

--- a/website/servers/server.php
+++ b/website/servers/server.php
@@ -92,7 +92,7 @@ if (@$_POST['act'] === 'editserver') {
 				if ($bannedhost && strpos($server, $bannedhost) > -1) {
 					$cannotUpdate = true;
 					echo(
-						"<br /><strong style=\"color:red\">You cannot use the host " . $server .
+						"<br /><strong style=\"color:red\">You cannot use the host " . htmlspecialchars ($server) .
 						" as it is from a blacklisted host.</strong><br />"
 					);
 					break;

--- a/website/servers/server.php
+++ b/website/servers/server.php
@@ -89,7 +89,7 @@ if (@$_POST['act'] === 'editserver') {
 		if (isset($serverinfo['bannedhosts']) && trim($server) !== trim($oldServer)) {
 			foreach ($serverinfo['bannedhosts'] as $bannedhost) {
 				$bannedhost = trim($bannedhost);
-				if ($bannedhost && strpos($server, $bannedhost) > -1) {
+				if ($bannedhost && strpos($server, $bannedhost) !== false) {
 					$cannotUpdate = true;
 					echo(
 						"<br /><strong style=\"color:red\">You cannot use the host " . htmlspecialchars ($server) .

--- a/website/servers/server.php
+++ b/website/servers/server.php
@@ -260,12 +260,12 @@ exports.servertoken = '<?= $token ?>';</textarea></p>
 				<h1>Edit server</h1>
 				<div class="formrow">
 					<p><label class="label">Location: <input class="textbox" type="text" name="loc" placeholder="http://<?php echo $entry['server']; if ($entry['port'] != 8000) echo '-',$entry['port']; ?>.psim.us/" size="60" /><em>(you can leave off http:// etc if you want)</em></label></p>
-						<p><label class="label">Owner: <?php
-							if ($users->isLeader()) {
-								echo ('<input class="textbox" type="text" name="owner" value="'.$entry['owner'] ?? '(none)' .'" size="60">');
-							} else {
-								echo '<em>' . $entry['owner'] ?? '(none)' . "</em>";
-							}
+					<p><label class="label">Owner: <?php
+						if ($users->isLeader()) {
+							echo ('<input class="textbox" type="text" name="owner" value="'.$entry['owner'] ?? '(none)' .'" size="60">');
+						} else {
+							echo '<em>' . $entry['owner'] ?? '(none)' . "</em>";
+						}
 					?></label></p>
 					<label class="label">Configuration:</label>
 					<p><label class="label">Email: <input class="textbox" type="text" name="email" placeholder="<?php echo $entry['email'] ?? "(none)"?>" /></label></p>

--- a/website/servers/server.php
+++ b/website/servers/server.php
@@ -56,7 +56,7 @@ if (@$_POST['act'] === 'editserver') {
 	if (!$users->csrfCheck()) die('invalid data, please retry');
 
 	$id = $entry['id'];
-	$loc = trim($_POST['loc'] ?? '');
+	$loc = trim(@$_POST['loc']) ?? ($entry ? $entry['server'] : "");
 	if ($loc) {
 
 		if (substr($loc, 0, 7) === 'http://') $loc = substr($loc, 7);
@@ -82,13 +82,77 @@ if (@$_POST['act'] === 'editserver') {
 			die("invalid server location");
 		}
 
-		$PokemonServers[$id]['server'] = $server;
-		$PokemonServers[$id]['port'] = $port;
-	}
+		$oldServer = $PokemonServers[$id]['server'];
+		$oldPort = $PokemonServers[$id]['port'];
 
-	$owners = explode(',', $_POST['owner']);
-	foreach ($owners as $i=>$owner) $owners[$i] = $users->userid($owner);
-	$PokemonServers[$id]['owner'] = implode(',',$owners);
+		$cannotUpdate = false;
+		if (isset($serverinfo['bannedhosts']) && trim($server) !== trim($oldServer)) {
+			foreach ($serverinfo['bannedhosts'] as $bannedhost) {
+				$bannedhost = trim($bannedhost);
+				if ($bannedhost && strpos($server, $bannedhost) > -1) {
+					$cannotUpdate = true;
+					echo(
+						"<br /><strong style=\"color:red\">You cannot use the host " . $server .
+						" as it is from a blacklisted host.</strong><br />"
+					);
+					break;
+				}
+			}
+		}
+
+		foreach ($PokemonServers as $curserver) {
+			if ($curserver['server'] === $server) {
+				$cannotUpdate = true;
+				echo(
+					"<br /><strong style=\"color:red\">You cannot use the host " . $server .
+					" as it is already in use by another server.</strong><br />"
+				);
+				break;
+			}
+		}
+
+		if (!$cannotUpdate) {
+			$PokemonServers[$id]['server'] = $server;
+			$PokemonServers[$id]['port'] = $port;
+			$psdb->query(
+				"INSERT INTO {$psdb->prefix}servermodlog (`serverid`, `actorid`, `date`, `ip`, `type`, `note`) VALUES (?, ?, ?, ?, ?, ?)",
+				[$id, $curuser['userid'], time(), $users->getIp(), 'EDITSERVER', $server . ':' . $port . " (from " . $oldServer . ":" . $oldPort . ")"]
+			);
+		}
+		if (isset($_POST['email']) && $is_manager) {
+			if (!mb_strlen($_POST['email']) || !strpos($_POST['email'], '@')) {
+				die("invalid email");
+			}
+			$oldEmail = $PokemonServers[$id]['email'] ?? "none";
+			$PokemonServers[$id]['email'] = $_POST['email'];
+			$psdb->query(
+				"INSERT INTO {$psdb->prefix}servermodlog (`serverid`, `actorid`, `date`, `ip`, `type`, `note`) VALUES (?, ?, ?, ?, ?, ?)",
+				[$id, $curuser['userid'], time(), $users->getIp(), 'EDITEMAIL', $oldEmail . " to " . $PokemonServers[$id]['email']]
+			);
+		}
+
+		if (isset($_POST['owner']) && $is_manager) {
+			$userid = $users->userid($_POST['owner']);
+			if (strlen($userid) && $PokemonServers[$id]['owner'] !== $userid) {
+				if (isset($serverinfo['blacklist']) && in_array($userid, $serverinfo['blacklist'])) {
+					echo(
+						'<strong style="color:red">' . $userid .
+						" is blacklisted from owning a server.</strong><br />"
+					);
+				} else {
+					$logMessage = mb_strlen($PokemonServers[$id]['owner']) ?
+						("from " . $PokemonServers[$id]['owner'] . " to " . $userid) :
+						("to " . $userid);
+
+					$PokemonServers[$id]['owner'] = $userid;
+					$psdb->query(
+						"INSERT INTO {$psdb->prefix}servermodlog (`serverid`, `actorid`, `date`, `ip`, `type`, `note`) VALUES (?, ?, ?, ?, ?, ?)",
+						[$id, $curuser['userid'], time(), $users->getIp(), 'EDITOWNER', $logMessage]
+					);
+				}
+			}
+		}
+	}
 
 	saveservers();
 	$success = 'editserver';
@@ -100,6 +164,10 @@ if (@$_POST['act'] === 'deleteserver') {
 	$id = $entry['id'];
 
 	unset($PokemonServers[$id]);
+	$psdb->query(
+		"INSERT INTO {$psdb->prefix}servermodlog (`serverid`, `actorid`, `date`, `ip`, `type`, `note`) VALUES (?, ?, ?, ?, ?, ?)",
+		[$id, $curuser['userid'], time(), $users->getIp(), 'DELETESERVER', ""]
+	);
 	saveservers();
 	$success = 'deleteserver';
 	$entry = false;
@@ -112,6 +180,12 @@ if (@$_POST['act'] === 'banserver') {
 	$message = @$_POST['message'];
 	if (!$message) $message = 'banned';
 	$PokemonServers[$id]['banned'] = $_POST['message'];
+
+	$psdb->query(
+		"INSERT INTO {$psdb->prefix}servermodlog (`serverid`, `actorid`, `date`, `ip`, `type`, `note`) VALUES (?, ?, ?, ?, ?, ?)",
+		[$id, $curuser['userid'], time(), $users->getIp(), 'BANSERVER', $_POST['message']]
+	);
+
 	saveservers();
 	$success = 'banserver';
 	$entry = $PokemonServers[$id];
@@ -177,6 +251,7 @@ exports.servertoken = '<?= $token ?>';</textarea></p>
 <?php } ?>
 			</p>
 <?php if (@$entry['owner']) { ?><p>Owner: <?= htmlspecialchars($entry['owner']); ?></p><?php } ?>
+<?php if ($is_manager && isset($entry['email'])) echo("<label>Email: {$entry['email']}</label>") ?><br />
 <?php if ($entry['id'] !== 'showdown' && $is_owner) { ?>
 			<p id="editserverbutton">
 				<button onclick="document.getElementById('editserver').style.display = 'block';document.getElementById('editserverbutton').style.display = 'none';return false">Edit server</button> <button onclick="document.location.href = ('http://<?= $psconfig['routes']['client'] ?>/customcss.php?server=<?= $entry['id'] ?>&amp;invalidate')">Reload custom CSS</button>
@@ -185,8 +260,10 @@ exports.servertoken = '<?= $token ?>';</textarea></p>
 				<h1>Edit server</h1>
 				<div class="formrow">
 					<p><label class="label">Location: <input class="textbox" type="text" name="loc" placeholder="http://<?php echo $entry['server']; if ($entry['port'] != 8000) echo '-',$entry['port']; ?>.psim.us/" size="60" /><em>(you can leave off http:// etc if you want)</em></label></p>
-					<p><label class="label">Owner: <input class="textbox" type="text" name="owner" value="<?php echo $entry['owner'] ?? '(none)'; ?>" size="60" /><em>(separate multiple owners by commas)</em></label></p>
-					<label class="label">Configuration:</label><?php
+					<p><label class="label">Owner: <strong><?php echo $entry['owner'] ?? '(none)'; ?></strong></label></p>
+					<label class="label">Configuration:</label>
+					<p><label class="label">Email: <input class="textbox" type="text" name="email" placeholder="<?php echo $entry['email'] ?? "(none)"?>" /></label></p>
+					<?php
 
 if (@$entry['token']) {
 	echo '<em>(Token exists)</em> <button type="submit" name="act" value="maketoken">Regenerate token</button> <button type="submit" name="act" value="deltoken">Remove</button>';

--- a/website/servers/server.php
+++ b/website/servers/server.php
@@ -91,10 +91,7 @@ if (@$_POST['act'] === 'editserver') {
 				$bannedhost = trim($bannedhost);
 				if ($bannedhost && strpos($server, $bannedhost) !== false) {
 					$cannotUpdate = true;
-					echo(
-						"<br /><strong style=\"color:red\">You cannot use the host " . htmlspecialchars ($server) .
-						" as it is from a blacklisted host.</strong><br />"
-					);
+					echo "<br /><strong style=\"color:red\">You can't use the host " . htmlspecialchars($server) . " because it is from a blacklisted host.</strong><br />"
 					break;
 				}
 			}
@@ -103,10 +100,7 @@ if (@$_POST['act'] === 'editserver') {
 		foreach ($PokemonServers as $curserver) {
 			if ($curserver['server'] === $server) {
 				$cannotUpdate = true;
-				echo(
-					"<br /><strong style=\"color:red\">You cannot use the host " . $server .
-					" as it is already in use by another server.</strong><br />"
-				);
+				echo "<br /><strong style=\"color:red\">You can't use the host " . htmlspecialchars($server) . " because it is already in use by another server.</strong><br />";
 				break;
 			}
 		}
@@ -135,10 +129,7 @@ if (@$_POST['act'] === 'editserver') {
 			$userid = $users->userid($_POST['owner']);
 			if (strlen($userid) && $PokemonServers[$id]['owner'] !== $userid) {
 				if (isset($serverinfo['blacklist']) && in_array($userid, $serverinfo['blacklist'])) {
-					echo(
-						'<strong style="color:red">' . $userid .
-						" is blacklisted from owning a server.</strong><br />"
-					);
+					echo '<strong style="color:red">' . $userid . ' is blacklisted from owning a server.</strong><br />';
 				} else {
 					$logMessage = mb_strlen($PokemonServers[$id]['owner']) ?
 						("from " . $PokemonServers[$id]['owner'] . " to " . $userid) :
@@ -262,7 +253,7 @@ exports.servertoken = '<?= $token ?>';</textarea></p>
 					<p><label class="label">Location: <input class="textbox" type="text" name="loc" placeholder="http://<?php echo $entry['server']; if ($entry['port'] != 8000) echo '-',$entry['port']; ?>.psim.us/" size="60" /><em>(you can leave off http:// etc if you want)</em></label></p>
 					<p><label class="label">Owner: <?php
 						if ($users->isLeader()) {
-							echo ('<input class="textbox" type="text" name="owner" value="'.$entry['owner'] ?? '(none)' .'" size="60">');
+							echo ('<input class="textbox" type="text" name="owner" value="'.$entry['owner'] ?? '' .'" placeholder="(none)" size="60">');
 						} else {
 							echo '<em>' . $entry['owner'] ?? '(none)' . "</em>";
 						}

--- a/website/servers/servers.lib.php
+++ b/website/servers/servers.lib.php
@@ -15,3 +15,19 @@ function saveservers() {
 $PokemonServers = '.var_export($GLOBALS['PokemonServers'], true).';
 ');
 }
+
+
+$serverinfo = json_decode(
+	file_exists(__DIR__ . '/../../config/serverinfo.json') ?
+		file_get_contents(__DIR__ . '/../../config/serverinfo.json') :
+		"{}",
+	true
+);
+
+function writeserverinfo() {
+	global $serverinfo;
+	file_put_contents(
+		__DIR__ . '/../../config/serverinfo.json',
+		json_encode($serverinfo, JSON_FORCE_OBJECT)
+	);
+}

--- a/website/servers/servers.lib.php
+++ b/website/servers/servers.lib.php
@@ -18,9 +18,7 @@ $PokemonServers = '.var_export($GLOBALS['PokemonServers'], true).';
 
 
 $serverinfo = json_decode(
-	file_exists(__DIR__ . '/../../config/serverinfo.json') ?
-		file_get_contents(__DIR__ . '/../../config/serverinfo.json') :
-		"{}",
+	file_get_contents(__DIR__ . '/../../config/serverinfo.json') ?: "{}",
 	true
 );
 

--- a/website/style/main.css
+++ b/website/style/main.css
@@ -370,7 +370,6 @@ table.table, .table td, .table th {
 
 	border: 1px solid #AAAAAA;
 	border-radius: 3px;
-	
 	box-shadow: inset 0px 1px 2px #CCCCCC, 1px 1px 0 rgba(255,255,255,.6);
 	background: #F8FBFD;
 }
@@ -458,4 +457,14 @@ code {
 	font-size: 10pt;
 	display: block;
 	color: #444444;
+}
+
+.infobox {
+	border: 1px solid #6688AA;
+	padding: 2px 4px;
+}
+
+.pad {
+	margin: 0;
+	padding: 5px 15px;
 }


### PR DESCRIPTION
Features requested / approved by policy upperstaff.
This PR adds a few things.
- Makes leaders/admins on the loginserver into sysops on side servers (barring Main and Smogtours)
- Makes it so side servers can only have one owner.
- Adds a required email field for side servers.
- Adds an administration panel. This can do a few things. Namely, ban/unban hosts from being used on a side server, ban/unban users from being owner on side servers, filter servers by different criteria, and reading modlogs for servers (editing, deletion, banning, addition, etc.)