### PR TITLE
Fix Smogon Analysis links in teambuilder

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -1998,8 +1998,8 @@
 				var number = parseInt(format.charAt(3), 10);
 				if (1 <= number && number <= 7) {
 					generationNumber = number;
-					format = format.substr(4);
 				}
+				format = format.substr(4);
 			}
 			var generation = ['rb', 'gs', 'rs', 'dp', 'bw', 'xy', 'sm', 'ss'][generationNumber - 1];
 			if (format === 'battlespotdoubles') {
@@ -2009,9 +2009,11 @@
 			} else if (format === 'ou' || format === 'uu' || format === 'ru' || format === 'nu' || format === 'pu' || format === 'lc' || format === 'monotype' || format === 'mixandmega' || format === 'nfe' || format === 'nationaldex' || format === 'stabmons' || format === '1v1' || format === 'almostanyability') {
 				smogdexid += '/' + format;
 			} else if (format === 'balancedhackmons') {
-				smogdexid += 'bh';
-			} else if (format === 'nationaldexag' || format === 'anythinggoes') {
-				smogdexid += 'ag';
+				smogdexid += '/bh';
+			} else if (format === 'anythinggoes') {
+				smogdexid += '/ag';
+			} else if (format === 'nationaldexag') {
+				smogdexid += '/national-dex-ag';
 			}
 			return 'http://smogon.com/dex/' + generation + '/pokemon/' + smogdexid + '/';
 		},


### PR DESCRIPTION
- Make the link redirect to the current tier for Gen 8 formats (was previously only doing it for Gen 7 and below)
- Fixes bh/ag getting appended to the species name without a forward slash (check this [bug report](https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-8903859))
- Uses the proper link for National Dex AG (previously was just using `ag` when it should be `national-dex-ag`)