### PR TITLE
base stats + toggle

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -1465,6 +1465,7 @@
 			buf += '<p><label class="optlabel"><input type="checkbox" name="ignorespects"' + (this.battle.ignoreSpects ? ' checked' : '') + '/> Ignore spectators</label></p>';
 			buf += '<p><label class="optlabel"><input type="checkbox" name="ignoreopp"' + (this.battle.ignoreOpponent ? ' checked' : '') + '/> Ignore opponent</label></p>';
 			buf += '<p><strong>All battles</strong></p>';
+			buf += '<p><labal class="optlabel"><input type="checkbox" name="showbasestats"' + (Dex.prefs('showbasestats') ? ' checked' : '') + ' /> Show base stats</label></p>'
 			buf += '<p><label class="optlabel"><input type="checkbox" name="ignorenicks"' + (Dex.prefs('ignorenicks') ? ' checked' : '') + ' /> Ignore nicknames</label></p>';
 			buf += '<p><label class="optlabel"><input type="checkbox" name="allignorespects"' + (Dex.prefs('ignorespects') ? ' checked' : '') + '/> Ignore spectators</label></p>';
 			buf += '<p><label class="optlabel"><input type="checkbox" name="allignoreopp"' + (Dex.prefs('ignoreopp') ? ' checked' : '') + '/> Ignore opponent</label></p>';
@@ -1475,6 +1476,7 @@
 		},
 		events: {
 			'change input[name=ignorespects]': 'toggleIgnoreSpects',
+			'change input[name=showbasestats]': 'toggleShowBaseStats',
 			'change input[name=ignorenicks]': 'toggleIgnoreNicks',
 			'change input[name=ignoreopp]': 'toggleIgnoreOpponent',
 			'change input[name=hardcoremode]': 'toggleHardcoreMode',
@@ -1506,6 +1508,10 @@
 			var ignoreSpects = !!e.currentTarget.checked;
 			Storage.prefs('ignorespects', ignoreSpects);
 			if (ignoreSpects && !this.battle.ignoreSpects) this.$el.find('input[name=ignorespects]').click();
+		},
+		toggleShowBaseStats: function (e) {
+			var showbasestats = !!e.currentTarget.checked;
+			Storage.prefs('showbasestats', showbasestats);
 		},
 		toggleIgnoreNicks: function (e) {
 			this.battle.ignoreNicks = !!e.currentTarget.checked;

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -1465,7 +1465,7 @@
 			buf += '<p><label class="optlabel"><input type="checkbox" name="ignorespects"' + (this.battle.ignoreSpects ? ' checked' : '') + '/> Ignore spectators</label></p>';
 			buf += '<p><label class="optlabel"><input type="checkbox" name="ignoreopp"' + (this.battle.ignoreOpponent ? ' checked' : '') + '/> Ignore opponent</label></p>';
 			buf += '<p><strong>All battles</strong></p>';
-			buf += '<p><labal class="optlabel"><input type="checkbox" name="showbasestats"' + (Dex.prefs('showbasestats') ? ' checked' : '') + ' /> Show base stats</label></p>'
+			buf += '<p><labal class="optlabel"><input type="checkbox" name="showbasestats"' + (Dex.prefs('showbasestats') ? ' checked' : '') + ' /> Show base stats</label></p>';
 			buf += '<p><label class="optlabel"><input type="checkbox" name="ignorenicks"' + (Dex.prefs('ignorenicks') ? ' checked' : '') + ' /> Ignore nicknames</label></p>';
 			buf += '<p><label class="optlabel"><input type="checkbox" name="allignorespects"' + (Dex.prefs('ignorespects') ? ' checked' : '') + '/> Ignore spectators</label></p>';
 			buf += '<p><label class="optlabel"><input type="checkbox" name="allignoreopp"' + (Dex.prefs('ignoreopp') ? ' checked' : '') + '/> Ignore opponent</label></p>';

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -441,7 +441,6 @@
 			'change input[name=noanim]': 'setNoanim',
 			'change input[name=nogif]': 'setNogif',
 			'change input[name=bwgfx]': 'setBwgfx',
-			'change input[name=showbasestats]': 'setShowBaseStats',
 			'change input[name=nopastgens]': 'setNopastgens',
 			'change select[name=tournaments]': 'setTournaments',
 			'change select[name=language]': 'setLanguage',
@@ -490,8 +489,6 @@
 			}
 			buf += '<p><label class="optlabel"><input type="checkbox" name="bwgfx"' + (Dex.prefs('bwgfx') ? ' checked' : '') + ' /> Use BW sprites instead of XY models</label></p>';
 			buf += '<p><label class="optlabel"><input type="checkbox" name="nopastgens"' + (Dex.prefs('nopastgens') ? ' checked' : '') + ' /> Use modern sprites for past generations</label></p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="showbasestats"' + (Dex.prefs('showbasestats') ? ' checked' : '') + ' /> Show base stats</label></p>';
-
 			buf += '<hr />';
 			buf += '<p><strong>Chat</strong></p>';
 			if (Object.keys(settings).length) {
@@ -584,10 +581,6 @@
 		setNopastgens: function (e) {
 			var nopastgens = !!e.currentTarget.checked;
 			Storage.prefs('nopastgens', nopastgens);
-		},
-		setShowBaseStats: function (e) {
-			var showbasestats = !!e.currentTarget.checked;
-			Storage.prefs('showbasestats', showbasestats);
 		},
 		setTournaments: function (e) {
 			var tournaments = e.currentTarget.value;

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -441,6 +441,7 @@
 			'change input[name=noanim]': 'setNoanim',
 			'change input[name=nogif]': 'setNogif',
 			'change input[name=bwgfx]': 'setBwgfx',
+			'change input[name=showbasestats]': 'setShowBaseStats',
 			'change input[name=nopastgens]': 'setNopastgens',
 			'change select[name=tournaments]': 'setTournaments',
 			'change select[name=language]': 'setLanguage',
@@ -489,6 +490,7 @@
 			}
 			buf += '<p><label class="optlabel"><input type="checkbox" name="bwgfx"' + (Dex.prefs('bwgfx') ? ' checked' : '') + ' /> Use BW sprites instead of XY models</label></p>';
 			buf += '<p><label class="optlabel"><input type="checkbox" name="nopastgens"' + (Dex.prefs('nopastgens') ? ' checked' : '') + ' /> Use modern sprites for past generations</label></p>';
+			buf += '<p><label class="optlabel"><input type="checkbox" name="showbasestats"' + (Dex.prefs('showbasestats') ? ' checked' : '') + ' /> Show base stats</label></p>';
 
 			buf += '<hr />';
 			buf += '<p><strong>Chat</strong></p>';
@@ -582,6 +584,10 @@
 		setNopastgens: function (e) {
 			var nopastgens = !!e.currentTarget.checked;
 			Storage.prefs('nopastgens', nopastgens);
+		},
+		setShowBaseStats: function (e) {
+			var showbasestats = !!e.currentTarget.checked;
+			Storage.prefs('showbasestats', showbasestats);
 		},
 		setTournaments: function (e) {
 			var tournaments = e.currentTarget.value;

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -768,6 +768,8 @@ class BattleTooltips {
 		if (gender === 'M' || gender === 'F') {
 			genderBuf = ` <img src="${Dex.resourcePrefix}fx/gender-${gender.toLowerCase()}.png" alt="${gender}" width="7" height="10" class="pixelated" /> `;
 		}
+		let weightBuf = '<small>' + ' ' + clientPokemon?.getSpecies().weightkg.toFixed(2) + 'kg' + '</small>';
+		let heightBuf = '<small>' + ' ' + clientPokemon?.getSpecies().heightm + 'm' + '</small>';
 
 		let name = BattleLog.escapeHTML(pokemon.name);
 		if (pokemon.speciesForme !== pokemon.name) {
@@ -776,7 +778,10 @@ class BattleTooltips {
 
 		let levelBuf = (pokemon.level !== 100 ? ` <small>L${pokemon.level}</small>` : ``);
 		if (!illusionIndex || illusionIndex === 1) {
-			text += `<h2>${name}${genderBuf}${illusionIndex ? '' : levelBuf}<br />`;
+			if (Dex.prefs('showbasestats') === true) {
+				text += `<h2>${name}${genderBuf}${illusionIndex ? '' : levelBuf}${heightBuf}${weightBuf}<br />`;
+			} else {
+				text += `<h2>${name}${genderBuf}${illusionIndex ? '' : levelBuf}<br />`;
 
 			if (clientPokemon?.volatiles.formechange) {
 				if (clientPokemon.volatiles.transform) {
@@ -785,6 +790,7 @@ class BattleTooltips {
 					text += `<small>(Changed forme: ${clientPokemon.volatiles.formechange[1]})</small><br />`;
 				}
 			}
+		}
 
 			let types = this.getPokemonTypes(pokemon);
 
@@ -873,6 +879,16 @@ class BattleTooltips {
 
 		text += this.renderStats(clientPokemon, serverPokemon, !isActive);
 
+		let types = this.getPokemonTypes(pokemon);
+		if (Dex.prefs('showbasestats') === true) {
+			text += '<p><small>Base: ';
+			text += 'HP: ' + clientPokemon?.getSpecies().baseStats['hp'] + ' ';
+			text += 'Atk: ' + clientPokemon?.getSpecies().baseStats['atk'] + ' ';
+			text += 'Def: ' + clientPokemon?.getSpecies().baseStats['def'] + ' ';
+			text += 'SpA: ' + clientPokemon?.getSpecies().baseStats['spa'] + ' ';
+			text += 'SpD: ' + clientPokemon?.getSpecies().baseStats['spd'] + ' ';
+			text += 'Spe: ' + clientPokemon?.getSpecies().baseStats['spe'] + '</small>' + '</p>'
+		}
 		if (serverPokemon && !isActive) {
 			// move list
 			text += `<p class="section">`;

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -783,14 +783,14 @@ class BattleTooltips {
 			} else {
 				text += `<h2>${name}${genderBuf}${illusionIndex ? '' : levelBuf}<br />`;
 
-			if (clientPokemon?.volatiles.formechange) {
-				if (clientPokemon.volatiles.transform) {
-					text += `<small>(Transformed into ${clientPokemon.volatiles.formechange[1]})</small><br />`;
-				} else {
-					text += `<small>(Changed forme: ${clientPokemon.volatiles.formechange[1]})</small><br />`;
+				if (clientPokemon?.volatiles.formechange) {
+					if (clientPokemon.volatiles.transform) {
+						text += `<small>(Transformed into ${clientPokemon.volatiles.formechange[1]})</small><br />`;
+					} else {
+						text += `<small>(Changed forme: ${clientPokemon.volatiles.formechange[1]})</small><br />`;
+					}
 				}
 			}
-		}
 
 			let types = this.getPokemonTypes(pokemon);
 
@@ -887,7 +887,7 @@ class BattleTooltips {
 			text += 'Def: ' + clientPokemon?.getSpecies().baseStats['def'] + ' ';
 			text += 'SpA: ' + clientPokemon?.getSpecies().baseStats['spa'] + ' ';
 			text += 'SpD: ' + clientPokemon?.getSpecies().baseStats['spd'] + ' ';
-			text += 'Spe: ' + clientPokemon?.getSpecies().baseStats['spe'] + '</small>' + '</p>'
+			text += 'Spe: ' + clientPokemon?.getSpecies().baseStats['spe'] + '</small>' + '</p>';
 		}
 		if (serverPokemon && !isActive) {
 			// move list


### PR DESCRIPTION
Hello.

This commit allows you toggle if you want to show base stats, weight and height for a pokemons. 
![image](https://user-images.githubusercontent.com/36735685/126631203-dab7bd5f-a33d-4b20-8ad7-e9b99a339b7f.png)



This is how it looks with it enabled for:


<details>
<summary>Friendly pokemon</summary>

![Friendly Mon](https://user-images.githubusercontent.com/36735685/126631467-436922e0-1c7a-406b-9836-5ec6b2b2de63.png)
</details>  

<details>
<summary>Enermy pokemon</summary>

![Enermy pokemon](https://user-images.githubusercontent.com/36735685/126632034-516542a4-ed8a-437a-99d4-957825060632.png)
</details>  

