### PR TITLE
Teambuilder: Fix bugs and implement new policy for STABmons

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -950,7 +950,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 
 		const overrideMoveData = {};
 		BattleTeambuilderTable[gen].overrideMoveData = overrideMoveData;
-		const overrideMoveKeys = ['accuracy', 'basePower', 'category', 'desc', 'flags', 'pp', 'shortDesc', 'target', 'type'];
+		const overrideMoveKeys = ['accuracy', 'basePower', 'category', 'desc', 'flags', 'isNonstandard', 'pp', 'shortDesc', 'target', 'type'];
 		for (const id in genData.Moves) {
 			const curEntry = Dex.mod(gen).moves.get(id);
 			const nextEntry = Dex.mod(nextGen).moves.get(id);

--- a/src/battle-dex-search.ts
+++ b/src/battle-dex-search.ts
@@ -1416,13 +1416,13 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 				if (sketch) {
 					if (move.isMax || move.isZ) continue;
 					if (move.isNonstandard && move.isNonstandard !== 'Past') continue;
-					if (move.isNonstandard === 'Past' && this.formatType !== 'natdex' && dex.gen === 8) continue;
+					if (move.isNonstandard === 'Past' && this.formatType !== 'natdex') continue;
 					sketchMoves.push(move.id);
 				} else {
 					if (!(dex.gen < 8 || this.formatType === 'natdex') && move.isZ) continue;
 					if (typeof move.isMax === 'string') continue;
 					if (move.isNonstandard === 'LGPE' && this.formatType !== 'letsgo') continue;
-					if (move.isNonstandard === 'Past' && this.formatType !== 'natdex' && dex.gen === 8) continue;
+					if (move.isNonstandard === 'Past' && this.formatType !== 'natdex') continue;
 					moves.push(move.id);
 				}
 			}
@@ -1439,7 +1439,13 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 					types.push(...prevoSpecies.types);
 					prevo = prevoSpecies.prevo;
 				}
-				if (species.battleOnly) species = baseSpecies;
+				if (species.battleOnly) {
+					if (typeof species.battleOnly === 'string' && species.battleOnly !== species.baseSpecies) {
+						species = dex.species.get(species.battleOnly);
+					} else {
+						species = dex.species.get(species.baseSpecies);
+					}
+				}
 				const excludedForme = (s: Species) => ['Alola', 'Alola-Totem', 'Galar', 'Galar-Zen'].includes(s.forme);
 				if (baseSpecies.otherFormes && !['Wormadam', 'Urshifu'].includes(baseSpecies.baseSpecies)) {
 					if (!excludedForme(species)) types.push(...baseSpecies.types);
@@ -1448,7 +1454,7 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 						if (!forme.battleOnly && !excludedForme(forme)) types.push(...forme.types);
 					}
 				}
-				const move = Dex.moves.get(id);
+				const move = dex.moves.get(id);
 				if (!types.includes(move.type)) continue;
 				if (moves.includes(move.id)) continue;
 				if (move.gen > dex.gen) continue;

--- a/src/battle-dex-search.ts
+++ b/src/battle-dex-search.ts
@@ -715,7 +715,7 @@ abstract class BattleTypedSearch<T extends SearchType> {
 		return '' as ID;
 	}
 	protected canLearn(speciesid: ID, moveid: ID) {
-		if (this.dex.gen >= 8 && this.dex.moves.get(moveid).isNonstandard === 'Past' && this.formatType !== 'natdex') {
+		if (this.dex.moves.get(moveid).isNonstandard === 'Past' && this.formatType !== 'natdex') {
 			return false;
 		}
 		let genChar = `${this.dex.gen}`;
@@ -1439,12 +1439,8 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 					types.push(...prevoSpecies.types);
 					prevo = prevoSpecies.prevo;
 				}
-				if (species.battleOnly) {
-					if (typeof species.battleOnly === 'string' && species.battleOnly !== species.baseSpecies) {
-						species = dex.species.get(species.battleOnly);
-					} else {
-						species = dex.species.get(species.baseSpecies);
-					}
+				if (species.battleOnly && typeof species.battleOnly === 'string') {
+					species = dex.species.get(species.battleOnly);
 				}
 				const excludedForme = (s: Species) => ['Alola', 'Alola-Totem', 'Galar', 'Galar-Zen'].includes(s.forme);
 				if (baseSpecies.otherFormes && !['Wormadam', 'Urshifu'].includes(baseSpecies.baseSpecies)) {


### PR DESCRIPTION
https://www.smogon.com/forums/threads/stabmons.3656429/page-8#post-8931262
https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-8930934

- Implements new STABmons policy of accounting for past gen move and species typings
- Fixes Mega formes not showing all the moves they should have access to
- Fixes 'Past' moves showing up as illegal in Gen 7 (the way I did this is by adding `isNonstandard` to the list of properties to override for moves, which is why I removed the `dex.gen === 8` checks when checking for "Past" moves since they are unnecessary now)