### PR TITLE
Fix selecting cosmetic formes in old gens

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -936,7 +936,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 		const nextGenData = Dex.mod(nextGen).data;
 		const overrideSpeciesData = {};
 		BattleTeambuilderTable[gen].overrideSpeciesData = overrideSpeciesData;
-		const overrideSpeciesKeys = ['abilities', 'baseStats', 'requiredItem', 'types'];
+		const overrideSpeciesKeys = ['abilities', 'baseStats', 'cosmeticFormes', 'requiredItem', 'types', 'unreleasedHidden'];
 		for (const id in genData.Pokedex) {
 			const curEntry = genData.Pokedex[id];
 			const nextEntry = nextGenData.Pokedex[id];

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -3358,9 +3358,9 @@
 			this.$el.html(buf).css({'max-width': (4 + spriteSize) * width, 'height': 42 + (4 + spriteSize) * height});
 		},
 		setForm: function (form) {
-			var species = this.room.curTeam.dex.species.get(this.curSet.species);
+			var species = Dex.species.get(this.curSet.species);
 			if (form && form !== species.form) {
-				this.curSet.species = this.room.curTeam.dex.species.get(species.baseSpecies + form).name;
+				this.curSet.species = Dex.species.get(species.baseSpecies + form).name;
 			} else if (!form) {
 				this.curSet.species = species.baseSpecies;
 			}


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-8938391

The issue is that `ModdedDex` doesn't properly handle cosmetic forms. This happens because it checks for battle aliases (and cosmetic forms always redirect to the base species) before getting the base results from the main `Dex` class, which means cosmetic forms never are never returned from `ModdedDex`.

With that being said, I think it's fine to just use the base `Dex` for `setForm`, so it's not an urgent thing to fix. Also note that I didn't change `this.room.curTeam.dex` to `Dex` in the `initialize` function because that part is working fine and there's actually a reason to use the generation dex, since unown doesn't have its `!` and `?` formes in gen 2.