### PR TITLE
Add a Friends button to the main menu

### DIFF
--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -51,7 +51,8 @@
 			buf += '<p><button class="button mainmenu3" name="joinRoom" value="ladder">Ladder</button></p></div>';
 
 			buf += '<div class="menugroup"><p><button class="button mainmenu4 onlineonly disabled" name="joinRoom" value="battles">Watch a battle</button></p>';
-			buf += '<p><button class="button mainmenu5 onlineonly disabled" name="finduser">Find a user</button></p></div>';
+			buf += '<p><button class="button mainmenu5 onlineonly disabled" name="finduser">Find a user</button></p>';
+			buf += '<p><button class="button mainmenu6 onlineonly disabled" name="joinRoom" value="view-friends-all">Friends</button></p></div>';
 
 			this.$('.mainmenu').html(buf);
 

--- a/src/panel-mainmenu.tsx
+++ b/src/panel-mainmenu.tsx
@@ -372,6 +372,7 @@ class MainMenuPanel extends PSRoomPanel<MainMenuRoom> {
 						<div class="menugroup">
 							<p><button class={"mainmenu4" + onlineButton} name="joinRoom" value="battles">Watch a battle</button></p>
 							<p><button class={"mainmenu5" + onlineButton} name="finduser">Find a user</button></p>
+							<p><button class={"mainmenu6" + onlineButton} name="joinRoom" value="view-friends-all">Friends</button></p>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
Currently, the only way to access the Friends list is by using a `/command`. This requires that the user be in a room. It would be more convenient for users who do not normally join any chat rooms to be able to pull up their friends list from the main menu. To that end, this change adds a convenient "Friends" button, allowing the user to instantly check their friends list with a single click.