### PR TITLE
Fix client commands on certain Android devices

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -449,7 +449,7 @@
 				}
 			}
 
-			switch (cmd.toLowerCase()) {
+			switch (toID(cmd)) {
 			case 'chal':
 			case 'chall':
 			case 'challenge':


### PR DESCRIPTION
On certain Android devices (at least mine and [this guy's](https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-8697490)), a hidden UTF-8 character (that I cannot identify) is sent alongside a command that causes it to completely skip the cases outlined in the switch statement that would let the command get processed. Here's a video of the strange behavior:
https://user-images.githubusercontent.com/23667022/133870646-1c8a6623-6847-4214-a70a-27568235be4e.mp4

The first time, I send my command through the desktop interface of Chrome devtools (the string is in fact being sent through my phone), which succeeds. The second time, I send it natively through my Android device. The third time is again natively through my Android device, after making the change dynamically in devtools.

I think this should fix a number of other occasional bug reports we get as well that claim to be custom client errors when they are not using a custom client, in addition to /rank.