### PR TITLE
Teambuilder: Use Gen 7 VGC tier slices for all VGC/BS formats

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -413,7 +413,6 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 					return tier;
 				}
 				if (isLetsGo) {
-					let baseSpecies = Dex.mod(gen).species.get(species.baseSpecies);
 					let validNum = (baseSpecies.num <= 151 && species.num >= 1) || [808, 809].includes(baseSpecies.num);
 					if (!validNum) return 'Illegal';
 					if (species.forme && !['Alola', 'Mega', 'Mega-X', 'Mega-Y', 'Starter'].includes(species.forme)) return 'Illegal';

--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -420,18 +420,14 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 					return species.tier;
 				}
 				if (isVGC) {
-					if (species.tier === 'NFE') return 'NFE';
-					if (species.tier === 'LC') return 'NFE';
 					if (
 						species.tier === 'Illegal' || species.tier === 'Unreleased' ||
 						species.tier === 'CAP' || species.tier === 'CAP NFE' || species.tier === 'CAP LC'
 					) return 'Illegal';
-					if (baseSpecies.tags.includes('Restricted Legendary')) {
-						return 'Restricted Legendary';
-					}
-					if (baseSpecies.tags.includes('Mythical')) {
-						return 'Mythical';
-					}
+					if (baseSpecies.tags.includes('Mythical')) return 'Mythical';
+					if (baseSpecies.tags.includes('Restricted Legendary')) return 'Restricted Legendary';
+					if (species.tier === 'NFE') return 'NFE';
+					if (species.tier === 'LC') return 'LC';
 					return 'Regular';
 				}
 				if (species.tier === 'CAP' || species.tier === 'CAP NFE' || species.tier === 'CAP LC') {

--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -419,10 +419,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 					return species.tier;
 				}
 				if (isVGC) {
-					if (
-						species.tier === 'Illegal' || species.tier === 'Unreleased' ||
-						species.tier === 'CAP' || species.tier === 'CAP NFE' || species.tier === 'CAP LC'
-					) return 'Illegal';
+					if (species.isNonstandard && species.isNonstandard !== 'Gigantamax') return 'Illegal';
 					if (baseSpecies.tags.includes('Mythical')) return 'Mythical';
 					if (baseSpecies.tags.includes('Restricted Legendary')) return 'Restricted Legendary';
 					if (species.tier === 'NFE') return 'NFE';

--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -310,9 +310,6 @@ console.log("DONE");
  * Build teambuilder-tables.js
  *********************************************************/
 
-const restrictedLegends = ['Mewtwo', 'Lugia', 'Ho-Oh', 'Kyogre', 'Groudon', 'Rayquaza', 'Dialga', 'Palkia', 'Giratina', 'Reshiram', 'Zekrom', 'Kyurem', 'Xerneas', 'Yveltal', 'Zygarde', 'Cosmog', 'Cosmoem', 'Solgaleo', 'Lunala', 'Necrozma'];
-const mythicals = ['Mew', 'Celebi', 'Jirachi', 'Deoxys', 'Phione', 'Manaphy', 'Darkrai', 'Shaymin', 'Arceus', 'Victini', 'Keldeo', 'Meloetta', 'Genesect', 'Diancie', 'Hoopa', 'Volcanion', 'Greninja-Ash', 'Magearna', 'Marshadow', 'Zeraora'];
-
 process.stdout.write("Building `data/teambuilder-tables.js`... ");
 
 {
@@ -321,20 +318,21 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 	let buf = '// DO NOT EDIT - automatically built with build-tools/build-indexes\n\n';
 	const GENS = [8, 7, 6, 5, 4, 3, 2, 1];
 	const DOUBLES = GENS.filter(x => x > 2).map(num => -num);
+	const VGC = GENS.filter(x => x > 3).map(num => -num - 0.5);
 	const NFE = GENS.map(num => num + 0.3);
 	const STADIUM = [2.04, 1.04];
-	const OTHER = [8.4, 8.2, 8.1, -8.4, 7.1, -7.5];
+	const OTHER = [8.4, 8.2, 8.1, -8.4, 7.1];
 
 	// process.stdout.write("\n  ");
-	for (const genIdent of [...GENS, ...DOUBLES, ...NFE, ...STADIUM, ...OTHER]) {
+	for (const genIdent of [...GENS, ...DOUBLES, ...VGC, ...NFE, ...STADIUM, ...OTHER]) {
 		const isLetsGo = (genIdent === 7.1);
 		const isMetBattle = (genIdent === 8.2);
-		const isNFE = (('' + genIdent).endsWith('.3'));
+		const isNFE = ('' + genIdent).endsWith('.3');
 		const isDLC1 = (genIdent === 8.4 || genIdent === -8.4);
 		const isNatDex = (genIdent === 8.1);
 		const isStadium = ('' + genIdent).endsWith('.04');
 		const isDoubles = (genIdent < 0);
-		const isVGC = (genIdent === -7.5);
+		const isVGC = ('' + genIdent).endsWith('.5');
 		const genNum = Math.floor(isDoubles ? -genIdent : genIdent);
 		const gen = (() => {
 			let genStr = 'gen' + genNum;
@@ -353,6 +351,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 		const nonstandardMoves = [];
 		for (const id of pokemon) {
 			const species = Dex.mod(gen).species.get(id);
+			const baseSpecies = Dex.mod(gen).species.get(species.baseSpecies);
 			if (species.gen > genNum) continue;
 			const tier = (() => {
 				if (isNatDex) {
@@ -423,11 +422,14 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 				if (isVGC) {
 					if (species.tier === 'NFE') return 'NFE';
 					if (species.tier === 'LC') return 'NFE';
-					if (species.tier === 'Illegal' || species.tier === 'Unreleased') return 'Illegal';
-					if (restrictedLegends.includes(species.name) || restrictedLegends.includes(species.baseSpecies)) {
+					if (
+						species.tier === 'Illegal' || species.tier === 'Unreleased' ||
+						species.tier === 'CAP' || species.tier === 'CAP NFE' || species.tier === 'CAP LC'
+					) return 'Illegal';
+					if (baseSpecies.tags.includes('Restricted Legendary')) {
 						return 'Restricted Legendary';
 					}
-					if (mythicals.includes(species.name) || mythicals.includes(species.baseSpecies)) {
+					if (baseSpecies.tags.includes('Mythical')) {
 						return 'Mythical';
 					}
 					return 'Regular';

--- a/src/battle-dex-search.ts
+++ b/src/battle-dex-search.ts
@@ -891,7 +891,7 @@ class BattlePokemonSearch extends BattleTypedSearch<'pokemon'> {
 		if (format === 'ubers' || format === 'uber') tierSet = tierSet.slice(slices.Uber);
 		else if (isVGCOrBS) {
 			if (
-				format === 'vgc2016' || format.startsWith('vgc2019') ||
+				format === 'vgc2010' || format === 'vgc2016' || format.startsWith('vgc2019') ||
 				format.endsWith('series8') || format.endsWith('series10')
 			) {
 				tierSet = tierSet.slice(slices["Restricted Legendary"]);

--- a/src/battle-dex-search.ts
+++ b/src/battle-dex-search.ts
@@ -840,8 +840,8 @@ class BattlePokemonSearch extends BattleTypedSearch<'pokemon'> {
 	getBaseResults(): SearchRow[] {
 		const format = this.format;
 		if (!format) return this.getDefaultResults();
-		const requirePentagon = format === 'battlespotsingles' || format === 'battledoubles' || format.startsWith('vgc');
-		let isDoublesOrBS = this.formatType === 'doubles';
+		const isVGCOrBS = format.startsWith('battlespot') || format.startsWith('battlestadium') || format.startsWith('vgc');
+		let isDoublesOrBS = isVGCOrBS || this.formatType === 'doubles';
 		const dex = this.dex;
 
 		let table = BattleTeambuilderTable;
@@ -850,13 +850,12 @@ class BattlePokemonSearch extends BattleTypedSearch<'pokemon'> {
 			if (dex.gen < 8) {
 				table = table['gen' + dex.gen];
 			}
-		} else if (dex.gen === 7 && requirePentagon) {
+		} else if (isVGCOrBS) {
 			table = table['gen' + dex.gen + 'vgc'];
-			isDoublesOrBS = true;
 		} else if (table['gen' + dex.gen + 'doubles'] && dex.gen > 4 && this.formatType !== 'letsgo' && this.formatType !== 'dlc1doubles' &&
 			(
-			format.includes('doubles') || format.includes('vgc') || format.includes('triples') ||
-			format.endsWith('lc') || format.endsWith('lcuu') || format === 'freeforall' || format.startsWith('ffa')
+			format.includes('doubles') || format.includes('triples') || format.endsWith('lc') ||
+			format.endsWith('lcuu') || format === 'freeforall' || format.startsWith('ffa')
 		)) {
 			table = table['gen' + dex.gen + 'doubles'];
 			isDoublesOrBS = true;
@@ -890,11 +889,16 @@ class BattlePokemonSearch extends BattleTypedSearch<'pokemon'> {
 		let tierSet: SearchRow[] = table.tierSet;
 		let slices: {[k: string]: number} = table.formatSlices;
 		if (format === 'ubers' || format === 'uber') tierSet = tierSet.slice(slices.Uber);
-		else if (format === 'vgc2017') tierSet = tierSet.slice(slices.Regular);
-		else if (format === 'vgc2018') tierSet = tierSet.slice(slices.Regular);
-		else if (format.startsWith('vgc2019')) tierSet = tierSet.slice(slices["Restricted Legendary"]);
-		else if (format === 'battlespotsingles') tierSet = tierSet.slice(slices.Regular);
-		else if (format === 'battlespotdoubles') tierSet = tierSet.slice(slices.Regular);
+		else if (isVGCOrBS) {
+			if (
+				format === 'vgc2016' || format.startsWith('vgc2019') ||
+				format.endsWith('series8') || format.endsWith('series10')
+			) {
+				tierSet = tierSet.slice(slices["Restricted Legendary"]);
+			} else {
+				tierSet = tierSet.slice(slices.Regular);
+			}
+		}
 		else if (format === 'ou') tierSet = tierSet.slice(slices.OU);
 		else if (format === 'uu') tierSet = tierSet.slice(slices.UU);
 		else if (format === 'ru') tierSet = tierSet.slice(slices.RU || slices.UU);
@@ -940,14 +944,6 @@ class BattlePokemonSearch extends BattleTypedSearch<'pokemon'> {
 			tierSet = tierSet.filter(([type, id]) => {
 				if (id in table.monotypeBans) return false;
 				return true;
-			});
-		}
-
-		if (/^(battlespot|battlestadium|vgc)/g.test(format)) {
-			tierSet = tierSet.filter(([type, id]) => {
-				const species = dex.species.get(id);
-				const baseSpecies = dex.species.get(species.baseSpecies);
-				return !baseSpecies.tags.includes('Mythical');
 			});
 		}
 

--- a/src/battle-dex-search.ts
+++ b/src/battle-dex-search.ts
@@ -588,6 +588,7 @@ abstract class BattleTypedSearch<T extends SearchType> {
 			format = format.slice(7) as ID;
 			if (!format) format = 'ou' as ID;
 		}
+		if (format.startsWith('vgc')) this.formatType = 'doubles';
 		if (format === 'vgc2020') this.formatType = 'dlc1doubles';
 		if (format.includes('doubles') && this.dex.gen > 4 && !this.formatType) this.formatType = 'doubles';
 		if (format.startsWith('ffa') || format === 'freeforall') this.formatType = 'doubles';

--- a/src/battle-dex-search.ts
+++ b/src/battle-dex-search.ts
@@ -898,8 +898,7 @@ class BattlePokemonSearch extends BattleTypedSearch<'pokemon'> {
 			} else {
 				tierSet = tierSet.slice(slices.Regular);
 			}
-		}
-		else if (format === 'ou') tierSet = tierSet.slice(slices.OU);
+		} else if (format === 'ou') tierSet = tierSet.slice(slices.OU);
 		else if (format === 'uu') tierSet = tierSet.slice(slices.UU);
 		else if (format === 'ru') tierSet = tierSet.slice(slices.RU || slices.UU);
 		else if (format === 'nu') tierSet = tierSet.slice(slices.NU || slices.UU);


### PR DESCRIPTION
I just found it a bit weird that only gen 7 VGC/BS formats got the special filtering of Restricted Legendary/Regular mons.

Also I don't know what to do about the current Battle Stadium Singles format, since it's series 10 and should show restricteds, but it doesn't have 'Series 10' in the format name like VGC does, so I can't only show restricteds for s10 BSS but not s9 BSS.