### PR TITLE
Teambuilder: Add team format to Pokepaste export

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -827,6 +827,7 @@
 			document.getElementById("pasteData").value = team;
 			document.getElementById("pasteTitle").value = this.curTeam.name;
 			document.getElementById("pasteAuthor").value = app.user.get('name');
+			if (this.curTeam.format !== 'gen8') document.getElementById("pasteNotes").value = "Format: " + this.curTeam.format;
 			document.getElementById("pokepasteForm").submit();
 		},
 


### PR DESCRIPTION
Currently the only piece of information about the team which isn't visible in the export from clicking Export; thought this might as well be added

Even if the field is to be saved for the planned 'Notes' section in the teambuilder, there's nothing stopping _both_ of them from being there, ex:
```
Format: gen71v1
Blacephalon is bulked for Band Adamant Aegislash with Shadow Sneak
```