### PR TITLE
Improve Team Preview decision text

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -906,11 +906,11 @@
 				for (var i = 0; i < leadCount; i++) {
 					leads.push(myPokemon[this.choice.teamPreview[i] - 1].speciesForme);
 				}
-				buf += this.createOxfordCommaList(leads) + ' will be sent out first';
+				buf += this.createCommaSeparatedList(leads) + ' will be sent out first';
 				for (var i = leadCount; i < this.choice.count; i++) {
 					back.push(myPokemon[this.choice.teamPreview[i] - 1].speciesForme);
 				}
-				if (back) buf += ', with ' + this.createOxfordCommaList(back) + ' in the back';
+				if (back.length) buf += ', with ' + this.createCommaSeparatedList(back) + ' in the back';
 				buf += '. <br />';
 			} else if (this.choice.choices && this.request && this.battle.myPokemon) {
 				var myPokemon = this.battle.myPokemon;
@@ -980,8 +980,8 @@
 			return buf;
 		},
 
-		createOxfordCommaList: function (list) {
-			return list.slice(0, -2).join(', ') + (list.slice(0, -2).length ? ', ' : '') + list.slice(-2).join(', and ');
+		createCommaSeparatedList: function (list) {
+			return list.slice(0, -2).join(', ') + (list.slice(0, -2).length ? ', ' : '') + list.slice(-2).join(' and ');
 		},
 
 		/**

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -906,12 +906,11 @@
 				for (var i = 0; i < leadCount; i++) {
 					leads.push(myPokemon[this.choice.teamPreview[i] - 1].speciesForme);
 				}
-				buf += this.createCommaSeparatedList(leads) + ' will be sent out first';
+				buf += leads.join(', ') + ' will be sent out first.<br />';
 				for (var i = leadCount; i < this.choice.count; i++) {
 					back.push(myPokemon[this.choice.teamPreview[i] - 1].speciesForme);
 				}
-				if (back.length) buf += ', with ' + this.createCommaSeparatedList(back) + ' in the back';
-				buf += '. <br />';
+				if (back.length) buf += back.join(', ') + ' are in the back.<br />';
 			} else if (this.choice.choices && this.request && this.battle.myPokemon) {
 				var myPokemon = this.battle.myPokemon;
 				for (var i = 0; i < this.choice.choices.length; i++) {
@@ -978,10 +977,6 @@
 				buf += '<p><small><em>Waiting for opponent...</em></small> <button class="button" name="undoChoice">Cancel</button></p>';
 			}
 			return buf;
-		},
-
-		createCommaSeparatedList: function (list) {
-			return list.slice(0, -2).join(', ') + (list.slice(0, -2).length ? ', ' : '') + list.slice(-2).join(' and ');
 		},
 
 		/**

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -901,10 +901,17 @@
 			if (this.choice.teamPreview) {
 				var myPokemon = this.battle.mySide.pokemon;
 				var leads = [];
-				for (var i = 0; i < this.choice.count; i++) {
+				var back = [];
+				var leadCount = this.battle.gameType === 'doubles' ? 2 : (this.battle.gameType === 'triples' ? 3 : 1);
+				for (var i = 0; i < leadCount; i++) {
 					leads.push(myPokemon[this.choice.teamPreview[i] - 1].speciesForme);
 				}
-				buf += leads.join(', ') + ' will be sent out first.<br />';
+				buf += this.createOxfordCommaList(leads) + ' will be sent out first';
+				for (var i = leadCount; i < this.choice.count; i++) {
+					back.push(myPokemon[this.choice.teamPreview[i] - 1].speciesForme);
+				}
+				if (back) buf += ', with ' + this.createOxfordCommaList(back) + ' in the back';
+				buf += '. <br />';
 			} else if (this.choice.choices && this.request && this.battle.myPokemon) {
 				var myPokemon = this.battle.myPokemon;
 				for (var i = 0; i < this.choice.choices.length; i++) {
@@ -971,6 +978,10 @@
 				buf += '<p><small><em>Waiting for opponent...</em></small> <button class="button" name="undoChoice">Cancel</button></p>';
 			}
 			return buf;
+		},
+
+		createOxfordCommaList: function (list) {
+			return list.slice(0, -2).join(', ') + (list.slice(0, -2).length ? ', ' : '') + list.slice(-2).join(', and ');
 		},
 
 		/**


### PR DESCRIPTION
In formats where you decide to bring more than just leads, currently it says you're sending out your 4-6 Pokemon "first". You can see this most clearly when choosing team slots for Zoroark or in VGC. This PR modifies the text to indicate more clearly which Pokemon are being led, and which Pokemon are in the back. It's a minor QOL improvement.
Before:
![image](https://user-images.githubusercontent.com/23667022/140252821-96722148-f164-48d8-909f-1603aacbde11.png)
![image](https://user-images.githubusercontent.com/23667022/140252939-192db23d-d2e3-4f5a-a7ac-92eba658e63f.png)
After:
![image](https://user-images.githubusercontent.com/23667022/140253339-af0a4150-ae64-4bf0-9b01-24424c31c79f.png)
![image](https://user-images.githubusercontent.com/23667022/140253270-f5ec5ec6-0686-438a-9bc5-25b6c95cdfd8.png)