### PR TITLE
Teambuilder: Fix bugs from #1889

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -1072,7 +1072,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 			if (modEntry.isNonstandard !== parentEntry.isNonstandard) {
 				overrideMoveData[id] = {
 					isNonstandard: modEntry.isNonstandard,
-				};
+				}
 			}
 		}
 	}

--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -517,8 +517,6 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 			BattleTeambuilderTable['gen8bdsp'].items = items;
 			BattleTeambuilderTable['gen8bdsp'].overrideTier = overrideTier;
 			BattleTeambuilderTable['gen8bdsp'].formatSlices = formatSlices;
-			BattleTeambuilderTable['gen8bdsp'].nonstandardMoves = Dex.mod('gen8bdsp').moves.all()
-				.filter(x => x.isNonstandard).map(x => x.id);
 		} else if (isVGC) {
 			BattleTeambuilderTable[gen + 'vgc'] = {};
 			BattleTeambuilderTable[gen + 'vgc'].tiers = tiers;
@@ -1054,6 +1052,27 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 					if (!overrideMoveData[id]) overrideMoveData[id] = {};
 					overrideMoveData[id][key] = modEntry[key];
 				}
+			}
+		}
+	}
+
+	//
+	// BDSP
+	//
+
+	{
+		const BDSPDex = Dex.mod('gen8bdsp');
+		const BDSPData = BDSPDex.data;
+
+		const overrideMoveData = {};
+		BattleTeambuilderTable['gen8bdsp'].overrideMoveData = overrideMoveData;
+		for (const id in BDSPData.Moves) {
+			const modEntry = BDSPDex.moves.get(id);
+			const parentEntry = Dex.mod('gen8').moves.get(id);
+			if (modEntry.isNonstandard !== parentEntry.isNonstandard) {
+				overrideMoveData[id] = {
+					isNonstandard: modEntry.isNonstandard,
+				};
 			}
 		}
 	}

--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -1072,7 +1072,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 			if (modEntry.isNonstandard !== parentEntry.isNonstandard) {
 				overrideMoveData[id] = {
 					isNonstandard: modEntry.isNonstandard,
-				}
+				};
 			}
 		}
 	}

--- a/src/battle-dex.ts
+++ b/src/battle-dex.ts
@@ -860,8 +860,10 @@ class ModdedDex {
 			if (this.gen <= 3 && data.category !== 'Status') {
 				data.category = Dex.getGen3Category(data.type);
 			}
+
+			// For LGPE/BDSP
 			const table = window.BattleTeambuilderTable[this.modid];
-			if (this.modid === 'gen7letsgo' && id in table.overrideMoveData) {
+			if (id in table.overrideMoveData) {
 				Object.assign(data, table.overrideMoveData[id]);
 			}
 


### PR DESCRIPTION
- Fixes moves that were disabled in gen 8 from not showing pre gen 8
- Fixes doubles bdsp formats from showing nonstandard items