### PR TITLE
Fix uploading replays

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -1368,8 +1368,10 @@ function toId() {
 			var serverid = Config.server.id && toID(Config.server.id.split(':')[0]);
 			var silent = data.silent;
 			if (serverid && serverid !== 'showdown') id = serverid + '-' + id;
-			$.post(app.user.getActionPHP() + '?act=uploadreplay', {
+			$.post(app.user.getActionPHP(), {
+				serverid: 'showdown',
 				log: data.log,
+				serverid: serverid,
 				password: data.password || '',
 				id: id
 			}, function (data) {

--- a/js/client.js
+++ b/js/client.js
@@ -1369,7 +1369,6 @@ function toId() {
 			var silent = data.silent;
 			if (serverid && serverid !== 'showdown') id = serverid + '-' + id;
 			$.post(app.user.getActionPHP(), {
-				serverid: 'showdown',
 				log: data.log,
 				serverid: serverid,
 				password: data.password || '',


### PR DESCRIPTION
the `?act=uploadreplay` breaks when removing the /~~serverid/action.php magic.
It would be ideal if this could be merged and patched asap - rn replays aren't working for people on new clients.