### PR TITLE
Add BDSP Monotype teambuilder support

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -516,6 +516,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 			BattleTeambuilderTable['gen8bdsp'].tiers = tiers;
 			BattleTeambuilderTable['gen8bdsp'].items = items;
 			BattleTeambuilderTable['gen8bdsp'].overrideTier = overrideTier;
+			BattleTeambuilderTable['gen8bdsp'].monotypeBans = monotypeBans;
 			BattleTeambuilderTable['gen8bdsp'].formatSlices = formatSlices;
 		} else if (isVGC) {
 			BattleTeambuilderTable[gen + 'vgc'] = {};

--- a/src/battle-dex-search.ts
+++ b/src/battle-dex-search.ts
@@ -971,7 +971,7 @@ class BattlePokemonSearch extends BattleTypedSearch<'pokemon'> {
 			});
 		}
 
-		if (format === 'monotype' && dex.gen >= 5) {
+		if (format === 'monotype' && dex.gen >= 5 && table.monotypeBans) {
 			tierSet = tierSet.filter(([type, id]) => {
 				if (id in table.monotypeBans) return false;
 				return true;


### PR DESCRIPTION
This is fairly high priority, as a BDSP Monotype format will exist in the next 24 hours, and with the current client, trying to make a team in "gen8bdspmonotype" crashes the client (shows a blank teambuilder); this also fixes future instances.