### PR TITLE
Support syncing YouTube videos

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,9 @@ module.exports = {
 		// Rooms
 		"Room": false, "BattleRoom": false, "ChatRoom": false, "ConsoleRoom": false, "HTMLRoom": false, "LadderRoom": false, "MainMenuRoom": false, "RoomsRoom": false, "BattlesRoom": false, "TeambuilderRoom": false,
 
+		// meant to handle games for non-battles (ie yt groupwatches)
+		"BattleGame": false,
+
 		// Tons of popups
 		"Popup": false, "ForfeitPopup": false, "BracketPopup": false, "LoginPasswordPopup": false, "UserPopup": false, "UserOptionsPopup": false, "UserOptions": false, "TeamPopup": false,
 		"AvatarsPopup": false, "CreditsPopup": false, "FormatPopup": false, "FormattingPopup": false, "LoginPopup": false,

--- a/index.template.html
+++ b/index.template.html
@@ -109,6 +109,7 @@ https://psim.us/dev
 <script src="//play.pokemonshowdown.com/js/client-battle.js?"></script>
 <script src="//play.pokemonshowdown.com/js/client-rooms.js?"></script>
 <script src="//play.pokemonshowdown.com/data/graphics.js?"></script>
+<script src="//play.pokemonshowdown.com/js/client-game.js?"></script>
 
 <script>
 	var app = new App();

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -50,6 +50,7 @@
 			this.$chat = this.$chatFrame.find('.inner');
 
 			this.$options = this.battle.scene.$options.html('<div style="padding-top: 3px; padding-right: 3px; text-align: right"><button class="icon button" name="openBattleOptions" title="Options">Battle Options</button></div>');
+			this.game = new BattleGame(this);
 		},
 		events: {
 			'click .replayDownloadButton': 'clickReplayDownloadButton',

--- a/js/client-game.js
+++ b/js/client-game.js
@@ -50,7 +50,7 @@
 					return;
 				}
 				if (this.player.getPlayerState() !== YT.PlayerState.PLAYING) {
-					this.player.startVideo();
+					this.player.playVideo();
 				}
 				var time = this.player.getCurrentTime();
 				// time is kept in ms on server (Date.now() - startTime)

--- a/js/client-game.js
+++ b/js/client-game.js
@@ -1,0 +1,83 @@
+/**
+ * Handles game-room plugin communication.
+ * @author mia-pi-git
+ */
+
+(function ($) {
+	this.BattleGame = Backbone.View.extend({
+		initialize: function (room) {
+			this.room = room;
+			this.$el = room.$el;
+			// battle window
+			this.$window = this.$el.find('div.battle').first();
+			this.listen();
+		},
+		listen: function () {
+			app.on('response:youtube', this.handleYouTube, this);
+		},
+		handleYouTube: function (data) {
+			if (data.room !== this.room.id) return;
+			if (!this.player) { // should usually exist, but just in case
+				var self = this;
+				// load API then
+				if (!window.YT) {
+					return this.loadYouTubeAPI(function () {
+						setTimeout(function () { // fsr Player isn't there immediately
+							self.handleYouTube(data);
+						}, 100);
+					});
+				}
+				this.player = new YT.Player(this.$window.find('iframe').first()[0], {
+					events: {
+						onReady: function () {
+							self.handleYouTube(data);
+						},
+					},
+				});
+				return;
+			}
+			switch (data.type) {
+			case 'play':
+				this.player.playVideo();
+				break;
+			case 'pause':
+				this.player.pauseVideo();
+				break;
+			case 'at':
+				if (!this.player.getCurrentTime) {
+					// weird thing that happens when the video ends
+					// it's possibly intentional (?), so we can just ignore it
+					return;
+				}
+				if (this.player.getPlayerState() !== YT.PlayerState.PLAYING) {
+					this.player.startVideo();
+				}
+				var time = this.player.getCurrentTime();
+				// time is kept in ms on server (Date.now() - startTime)
+				var sentTime = data.time / 1000;
+				if (Math.abs(time - sentTime) >= 2) {
+					this.player.seekTo(sentTime);
+				}
+				break;
+			}
+		},
+		loadYouTubeAPI: function (callback) {
+			if (window.YT) return callback();
+			if (window.ytLoading) { // already loading
+				window.ytLoading.push(callback);
+				return;
+			}
+			window.ytLoading = [];
+			window.ytLoading.push(callback);
+			var tag = document.createElement('script');
+			tag.src = "https://www.youtube.com/iframe_api";
+			tag.onload = function () {
+				for (let i = 0; i < window.ytLoading.length; i++) {
+					window.ytLoading[i]();
+				}
+				delete window.ytLoading;
+			}
+			document.body.appendChild(tag);
+		},
+	});
+}).call(this, jQuery);

--- a/src/battle-log.ts
+++ b/src/battle-log.ts
@@ -872,7 +872,7 @@ export class BattleLog {
 					tagName: 'iframe',
 					attribs: [
 						'width', width, 'height', height,
-						'src', `https://www.youtube.com/embed/${videoId}${time ? `?start=${time}` : ''}`,
+						'src', `https://www.youtube.com/embed/${videoId}?enablejsapi=1${time ? `&time=${time}` : ""}`,
 						'frameborder', '0', 'allow', 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture', 'allowfullscreen', 'allowfullscreen',
 					],
 				};

--- a/testclient.html
+++ b/testclient.html
@@ -109,6 +109,7 @@
 		<script src="js/battle-tooltips.js"></script>
 		<script src="js/client-battle.js"></script>
 		<script src="js/client-rooms.js"></script>
+		<script src="js/client-game.js"></script>
 		<script src="js/storage.js"></script>
 		<script src="data/graphics.js" onerror="loadRemoteData(this.src)"></script>
 


### PR DESCRIPTION
This makes it so the server can control <youtube> tags created in game room fields - it's meant for the group watch feature. 
I abstracted the code into a BattleGame class (in client-game.js) because GameRooms use BattleRoom, and putting game code in battle code seemed messy. This way, other users of GameRoom (or this user) can add more support as needed.

The BattleGame for youtube sets a listener for `|queryresponse|youtube` (which I used since it's easily supported and listened to within existing infrastructure), loads the YouTube IFrame API (necessary to control the video), creates a player object, and executes the commands sent by the server in the JSON blob. Currently supported: `at` (tells the client where the server is and syncs it if they're >2s apart), `pause` (pauses the video), and lastly `play` (starts the video). 
