### PR TITLE
Prevent setting timer after a game has ended

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -1002,7 +1002,7 @@
 				return;
 			}
 
-			if (!this.autoTimerActivated && Storage.prefs('autotimer')) {
+			if (!this.autoTimerActivated && Storage.prefs('autotimer') && !this.battle.ended) {
 				this.setTimer('on');
 				this.autoTimerActivated = true;
 			}


### PR DESCRIPTION
Client-side for https://github.com/smogon/pokemon-showdown/pull/8640

When the "Automatically start timer" box is ticked, now it will no longer send a start timer request if the game has ended.

<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/23667022/151100274-7f3e1a16-179b-446c-bc50-74e316454ae0.png">
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/23667022/151100169-e13c74ac-e7d5-473c-9c02-f6c33500ebbf.png">
</details>