### PR TITLE
Gen I-II: Fix speed stat displayed when paralysed

### DIFF
--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -1204,6 +1204,10 @@ class BattleTooltips {
 			}
 		}
 
+		if (pokemon.status === 'par' && this.battle.gen < 3) {
+			stats.spe = Math.floor(stats.spe * 0.25)
+		}
+
 		return stats;
 	}
 

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -997,6 +997,8 @@ class BattleTooltips {
 
 			if (this.battle.gen > 2 && ability === 'quickfeet') {
 				stats.spe = Math.floor(stats.spe * 1.5);
+			} else if (this.battle.gen > 2 && pokemon.status === 'par') {
+				stats.spe = Math.floor(stats.spe * 0.25);
 			}
 		}
 
@@ -1202,10 +1204,6 @@ class BattleTooltips {
 			} else {
 				stats.spe = Math.floor(stats.spe * 0.25);
 			}
-		}
-
-		if (pokemon.status === 'par' && this.battle.gen < 3) {
-			stats.spe = Math.floor(stats.spe * 0.25)
 		}
 
 		return stats;

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -997,7 +997,7 @@ class BattleTooltips {
 
 			if (this.battle.gen > 2 && ability === 'quickfeet') {
 				stats.spe = Math.floor(stats.spe * 1.5);
-			} else if (this.battle.gen > 2 && pokemon.status === 'par') {
+			} else if (this.battle.gen < 2 && pokemon.status === 'par') {
 				stats.spe = Math.floor(stats.spe * 0.25);
 			}
 		}


### PR DESCRIPTION
Fixing an issue with speed not being seen as lowered when paralyzed in gen 1 and 2.
Issue was up because of " if (pokemon.status === 'par' && ability !== 'quickfeet') {" and abilities were inexistant in the first two gens. My guess is that ability is at an undefined value at this moment but I'm not sure. 