### PR TITLE
TOOLTIPS/TEXT PARSER: Fix Nickname in tooltips and in Battle Log

### DIFF
--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -505,10 +505,16 @@ class BattleTextParser {
 		}
 
 		case 'switchout': {
-			const [, pokemon] = args;
-			const side = pokemon.slice(0, 2);
+			const [, pokemon, details] = args;
+			const [side, fullname] = this.pokemonFull(pokemon, details);
 			const template = this.template('switchOut', kwArgs.from, this.own(side));
-			return template.replace('[TRAINER]', this.trainer(side)).replace('[NICKNAME]', this.pokemonName(pokemon)).replace('[POKEMON]', this.pokemon(pokemon));
+			let pokemonName;
+			if (BattleLog.prefs('ignorenick') === "true") {
+				pokemonName = fullname;
+			} else {
+				pokemonName = this.pokemonName(pokemon)
+			}
+			return template.replace('[TRAINER]', this.trainer(side)).replace('[NICKNAME]', pokemonName).replace('[POKEMON]', this.pokemon(pokemon));
 		}
 
 		case 'faint': {

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -772,8 +772,10 @@ class BattleTooltips {
 		}
 
 		let name = BattleLog.escapeHTML(pokemon.name);
-		if (pokemon.speciesForme !== pokemon.name) {
+		if (pokemon.speciesForme !== pokemon.name && BattleLog.prefs('ignorenicks') === "false") {
 			name += ' <small>(' + BattleLog.escapeHTML(pokemon.speciesForme) + ')</small>';
+		} else {
+			name = BattleLog.escapeHTML(pokemon.speciesForme);
 		}
 
 		let levelBuf = (pokemon.level !== 100 ? ` <small>L${pokemon.level}</small>` : ``);


### PR DESCRIPTION
Fixed a "bug" (I think it wasn't just programmed just a feature not completely implemented).
For both of these fixes I just added conditions to take into account the "Ignore Nicknames" Option.