### PR TITLE
Tooltips: Trying to fix the name of the ability when changed and suppressed

### DIFF
--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -505,10 +505,16 @@ class BattleTextParser {
 		}
 
 		case 'switchout': {
-			const [, pokemon] = args;
-			const side = pokemon.slice(0, 2);
+			const [, pokemon, details] = args;
+			const [side, fullname] = this.pokemonFull(pokemon, details);
 			const template = this.template('switchOut', kwArgs.from, this.own(side));
-			return template.replace('[TRAINER]', this.trainer(side)).replace('[NICKNAME]', this.pokemonName(pokemon)).replace('[POKEMON]', this.pokemon(pokemon));
+			let pokemonName;
+			if (BattleLog.prefs('ignorenick') === "true") {
+				pokemonName = fullname;
+			} else {
+				pokemonName = this.pokemonName(pokemon)
+			}
+			return template.replace('[TRAINER]', this.trainer(side)).replace('[NICKNAME]', pokemonName).replace('[POKEMON]', this.pokemon(pokemon));
 		}
 
 		case 'faint': {

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -772,8 +772,10 @@ class BattleTooltips {
 		}
 
 		let name = BattleLog.escapeHTML(pokemon.name);
-		if (pokemon.speciesForme !== pokemon.name) {
+		if (pokemon.speciesForme !== pokemon.name && BattleLog.prefs('ignorenicks') === "false") {
 			name += ' <small>(' + BattleLog.escapeHTML(pokemon.speciesForme) + ')</small>';
+		} else {
+			name = BattleLog.escapeHTML(pokemon.speciesForme);
 		}
 
 		let levelBuf = (pokemon.level !== 100 ? ` <small>L${pokemon.level}</small>` : ``);

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -2824,7 +2824,7 @@ export class Battle {
 				}
 				break;
 			case 'mummy':
-				if (!kwArgs.ability) break; // if Mummy activated but failed, no ability will have been sent
+				if (!kwArgs.ability || target?.ability === '(suppressed)') break; // if Mummy activated but failed, no ability will have been sent
 				let ability = Dex.abilities.get(kwArgs.ability);
 				this.activateAbility(target, ability.name);
 				this.activateAbility(poke, "Mummy");


### PR DESCRIPTION
This is not a final version but a first draft of what I think should be done, basically what I understand from the architecture of the code is when you have to trigger an ability it goes from the switch in battle.ts and calls the server for changing the abilty and the name. But as of now the normal behavior is to normally not change the name of the ability as it is still just (suppressed), so for the moment I put a condition where if the ability name is '(suppressed)' it shouldn't switch to Mummy(base: "baseAbility"). I don't think it should be the final solution but I want to report what's the problem at its core.

Should be hard to tackle, might need some ideas for it