### PR TITLE
Gen-II: Roll over display issue

### DIFF
--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -1025,16 +1025,32 @@ class BattleTooltips {
 
 		let speedModifiers = [];
 
+		// clamp stats for gen 2
+		if (this.battle.gen === 2) {
+			for (const statName of Dex.statNamesExceptHP) {
+				if (stats[statName] > 999) stats[statName] = 999;
+				if (stats[statName] < 1) stats[statName] = 1;
+			}
+		}
+
 		// check for light ball, thick club, metal/quick powder
 		// the only stat modifying items in gen 2 were light ball, thick club, metal powder
 		if (item === 'lightball' && speciesName === 'Pikachu' && this.battle.gen !== 4) {
 			if (this.battle.gen > 4) stats.atk *= 2;
 			stats.spa *= 2;
+			// apply the stat roll over 
+			if (this.battle.gen === 2 && stats.spa >= 1024) {
+				stats.spa = Math.max(Math.floor(stats.spa / 4) % 256, 1) * 4
+			}
 		}
 
 		if (item === 'thickclub') {
 			if (speciesName === 'Marowak' || speciesName === 'Cubone') {
 				stats.atk *= 2;
+				// apply the stat roll over 
+				if (this.battle.gen === 2 && stats.atk >= 1024) {
+					stats.atk = Math.max(Math.floor(stats.atk / 4) % 256, 1) * 4
+				}
 			}
 		}
 
@@ -1046,6 +1062,13 @@ class BattleTooltips {
 				if (this.battle.gen === 2) {
 					stats.def = Math.floor(stats.def * 1.5);
 					stats.spd = Math.floor(stats.spd * 1.5);
+					// apply the stat roll over 
+					if (stats.def >= 1024) {
+						stats.def = Math.max(Math.floor(stats.def / 4) % 256, 1) * 4
+					}
+					if (stats.def >= 1024) {
+						stats.def = Math.max(Math.floor(stats.def / 4) % 256, 1) * 4
+					}
 				} else {
 					stats.def *= 2;
 				}


### PR DESCRIPTION
I tried to solve the bug reported here, https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-9149100 

I mainly add the clamp stats for gen 2, this allows the stats display to be in range [1, 999]. Maybe this should be added into line 1004, because both gen1 and gen2 have a stats cap which is 999. But currently gen 2's clamp is missing.

Also, for the three item that will affect stats, I add a over roll check like this,
if (this.battle.gen === 2 && stats.xxx >= 1024) {
	stats.xxx = Math.max(Math.floor(stats.xxx / 4) % 256, 1) * 4
}
Here, the logic is to follow how stats is calculated, if anyone's stats is greater than 256, it will be first divide by 4 than mod by 256. This means whoes stats is greater or equal to 1024 will become a small number. I add a *4 in the end of the equation because the opponent's stats is also divide by 4. So the actual value which needs to be shown to the user should be *4. 

(I'm a CS student working on a course homework to make a contribution to a repo, if my code anything that not satisfying the repo's requirment, I'm willing to hear from you and making changes.)