### PR TITLE
Battle: Check whether ability is (suppressed) in rememberAbility

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -352,7 +352,7 @@ export class Pokemon implements PokemonDetails, PokemonHealth {
 	}
 	rememberAbility(ability: string, isNotBase?: boolean) {
 		ability = Dex.abilities.get(ability).name;
-		if (!(this.ability === '(suppressed)')) {
+		if (this.ability !== '(suppressed)') {
 			this.ability = ability;
 		}
 		if (!this.baseAbility && !isNotBase) {

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -352,7 +352,9 @@ export class Pokemon implements PokemonDetails, PokemonHealth {
 	}
 	rememberAbility(ability: string, isNotBase?: boolean) {
 		ability = Dex.abilities.get(ability).name;
-		this.ability = ability;
+		if (!(this.ability === '(suppressed)')) {
+			this.ability = ability;
+		}
 		if (!this.baseAbility && !isNotBase) {
 			this.baseAbility = ability;
 		}

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -2798,11 +2798,9 @@ export class Battle {
 				let pokeability = Dex.sanitizeName(kwArgs.ability) || target!.ability;
 				let targetability = Dex.sanitizeName(kwArgs.ability2) || poke.ability;
 				if (pokeability) {
-					poke.ability = pokeability;
 					if (!target!.baseAbility) target!.baseAbility = pokeability;
 				}
 				if (targetability) {
-					target!.ability = targetability;
 					if (!poke.baseAbility) poke.baseAbility = targetability;
 				}
 				if (poke.side !== target!.side) {


### PR DESCRIPTION
I mainly fix the issue in https://github.com/smogon/pokemon-showdown/projects/3#card-61196750. The ability should still be (suppressed) after a pokemon gain a new ability, so I just add a check in rememberAbility to prevent ability change if the current ability is suppressed.