### PR TITLE
Fix Eviolite with PLA evolutions

### DIFF
--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -1133,7 +1133,8 @@ class BattleTooltips {
 		}
 		const isNFE = Dex.species.get(serverPokemon.speciesForme).evos?.some(evo => {
 			const evoSpecies = Dex.species.get(evo);
-			return !evoSpecies.isNonstandard || evoSpecies.isNonstandard === Dex.species.get(serverPokemon.speciesForme)?.isNonstandard;
+			return !evoSpecies.isNonstandard ||
+					evoSpecies.isNonstandard === Dex.species.get(serverPokemon.speciesForme)?.isNonstandard;
 		});
 		if (item === 'eviolite' && isNFE) {
 			stats.def = Math.floor(stats.def * 1.5);

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -1131,7 +1131,11 @@ class BattleTooltips {
 		if (ability === 'marvelscale' && pokemon.status) {
 			stats.def = Math.floor(stats.def * 1.5);
 		}
-		if (item === 'eviolite' && Dex.species.get(pokemon.speciesForme).evos) {
+		const isNFE = Dex.species.get(serverPokemon.speciesForme).evos?.some(evo => {
+			const evoSpecies = Dex.species.get(evo);
+			return !evoSpecies.isNonstandard || evoSpecies.isNonstandard === Dex.species.get(serverPokemon.speciesForme)?.isNonstandard;
+		});
+		if (item === 'eviolite' && isNFE) {
 			stats.def = Math.floor(stats.def * 1.5);
 			stats.spd = Math.floor(stats.spd * 1.5);
 		}


### PR DESCRIPTION
Fixes https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-9187239. This bug extends beyond Custom Game; currently Eviolite Ursaring will show the boost in Gen 7 and National Dex formats as well which is definitely a bug.

Uses the server-side implementation for Eviolite from @pyuk-bot: https://github.com/smogon/pokemon-showdown/pull/8650

![image](https://user-images.githubusercontent.com/23667022/163693291-7eed8b77-61f1-4e72-a5ea-9e949a26f565.png)
![image](https://user-images.githubusercontent.com/23667022/163693295-b52b6b0c-531c-42cf-880f-fa9db52eba9e.png)
![image](https://user-images.githubusercontent.com/23667022/163693297-1b2f144f-35b7-4273-9f0c-18d60cdb7a59.png)
