### PR TITLE
Gen 1: Update Useful/Useless Moves

### DIFF
--- a/src/battle-dex-search.ts
+++ b/src/battle-dex-search.ts
@@ -1218,14 +1218,14 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 		if (dex.gen === 1) {
 			// Usually not useless for Gen 1
 			if ([
-				'acidarmor', 'amnesia', 'barrier', 'bind', 'blizzard', 'clamp', 'confuseray', 'counter', 'firespin', 'hyperbeam', 'mirrormove', 'pinmissile', 'razorleaf', 'sing', 'slash', 'sludge', 'twineedle', 'wrap',
+				'acidarmor', 'amnesia', 'barrier', 'bind', 'blizzard', 'clamp', 'confuseray', 'counter', 'firespin', 'growth', 'headbutt', 'hyperbeam', 'mirrormove', 'pinmissile', 'razorleaf', 'sing', 'slash', 'sludge', 'twineedle', 'wrap',
 			].includes(id)) {
 				return true;
 			}
 
 			// Usually useless for Gen 1
 			if ([
-				'disable', 'firepunch', 'icepunch', 'leechseed', 'quickattack', 'roar', 'thunderpunch', 'toxic', 'triattack', 'whirlwind',
+				'disable', 'haze', 'leechseed', 'quickattack', 'roar', 'toxic', 'triattack', 'whirlwind',
 			].includes(id)) {
 				return false;
 			}
@@ -1235,10 +1235,24 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 			case 'bubblebeam': return (!moves.includes('surf') && !moves.includes('blizzard'));
 			case 'doubleedge': return !moves.includes('bodyslam');
 			case 'doublekick': return !moves.includes('submission');
+			case "firepunch": return !moves.includes ('fireblast');
 			case 'megadrain': return !moves.includes('razorleaf') && !moves.includes('surf');
 			case 'megakick': return !moves.includes('hyperbeam');
 			case 'reflect': return !moves.includes('barrier') && !moves.includes('acidarmor');
+			case "stomp": return !moves.includes ('headbutt');
 			case 'submission': return !moves.includes('highjumpkick');
+			case "thunderpunch": return !moves.includes ('thunderbolt');
+			case "triattack": return !moves.includes ('bodyslam'); //This makes it useful on Porygon specifically, it has a few edge cases
+			}
+			
+			//Useful and Useless moves for Stadium OU specifically, which changes many game mechanics.
+			if (this.formatType === 'stadiumou') {
+				if (['doubleedge', 'focusenergy', 'haze'].includes(id)) return true;
+				if (['hyperbeam', 'sing', 'hypnosis'].includes(id)) return false;
+				switch (id) {
+					case 'fly': return !moves.includes('drillpeck');
+					case 'dig': return !moves.includes('earthquake');
+				}
 			}
 		}
 

--- a/src/battle-dex-search.ts
+++ b/src/battle-dex-search.ts
@@ -1242,10 +1242,9 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 			case "stomp": return !moves.includes ('headbutt');
 			case 'submission': return !moves.includes('highjumpkick');
 			case "thunderpunch": return !moves.includes ('thunderbolt');
-			case "triattack": return !moves.includes ('bodyslam'); //This makes it useful on Porygon specifically, it has a few edge cases
+			case "triattack": return !moves.includes ('bodyslam');
 			}
-			
-			//Useful and Useless moves for Stadium OU specifically, which changes many game mechanics.
+			// Useful and Useless moves for Stadium OU, which changes many game mechanics.
 			if (this.formatType === 'stadiumou') {
 				if (['doubleedge', 'focusenergy', 'haze'].includes(id)) return true;
 				if (['hyperbeam', 'sing', 'hypnosis'].includes(id)) return false;

--- a/src/battle-dex-search.ts
+++ b/src/battle-dex-search.ts
@@ -1235,22 +1235,22 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 			case 'bubblebeam': return (!moves.includes('surf') && !moves.includes('blizzard'));
 			case 'doubleedge': return !moves.includes('bodyslam');
 			case 'doublekick': return !moves.includes('submission');
-			case "firepunch": return !moves.includes ('fireblast');
+			case 'firepunch': return !moves.includes('fireblast');
 			case 'megadrain': return !moves.includes('razorleaf') && !moves.includes('surf');
 			case 'megakick': return !moves.includes('hyperbeam');
 			case 'reflect': return !moves.includes('barrier') && !moves.includes('acidarmor');
-			case "stomp": return !moves.includes ('headbutt');
+			case 'stomp': return !moves.includes('headbutt');
 			case 'submission': return !moves.includes('highjumpkick');
-			case "thunderpunch": return !moves.includes ('thunderbolt');
-			case "triattack": return !moves.includes ('bodyslam');
+			case 'thunderpunch': return !moves.includes('thunderbolt');
+			case 'triattack': return !moves.includes('bodyslam');
 			}
 			// Useful and Useless moves for Stadium OU, which changes many game mechanics.
 			if (this.formatType === 'stadium') {
 				if (['doubleedge', 'focusenergy', 'haze'].includes(id)) return true;
 				if (['hyperbeam', 'sing', 'hypnosis'].includes(id)) return false;
 				switch (id) {
-					case 'fly': return !moves.includes('drillpeck');
-					case 'dig': return !moves.includes('earthquake');
+				case 'fly': return !moves.includes('drillpeck');
+				case 'dig': return !moves.includes('earthquake');
 				}
 			}
 		}

--- a/src/battle-dex-search.ts
+++ b/src/battle-dex-search.ts
@@ -1245,7 +1245,7 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 			case "triattack": return !moves.includes ('bodyslam');
 			}
 			// Useful and Useless moves for Stadium OU, which changes many game mechanics.
-			if (this.formatType === 'stadiumou') {
+			if (this.formatType === 'stadium') {
 				if (['doubleedge', 'focusenergy', 'haze'].includes(id)) return true;
 				if (['hyperbeam', 'sing', 'hypnosis'].includes(id)) return false;
 				switch (id) {


### PR DESCRIPTION
This implements some old suggestions from;
https://www.smogon.com/forums/threads/move-category-suggestions.3671530/page-3#post-8981161
https://www.smogon.com/forums/threads/move-category-suggestions.3671530/post-8653106
As well as a few others.

Moves like Growth and Headbutt are generally useful in RBY given the environment. Tangela uses Growth quite a bit in UU and, well, y'know, Special is good. Headbutt is frequently used in Tradebacks and has a few niche uses on UU Dewgong for paraflinching. 

Haze is terrible and should always be useless. In the Tradebacks teambuilder this clogs up stuff a lot. I cut Ice Punch from the useless area because it has legitimate freeze fishing uses due to having more PP than Ice Beam. In Tradebacks this is important on a few Snorlax sets, and I think Jynx can get away with it in OU if you're drunk enough. 

I also added edge cases for Fire Punch, Stomp (which Tauros uses sometimes in OU, very important), Thunder Punch, and Tri Attack. Fire and Thunder Punch are both useful in Tradebacks and change how the game is played dramatically. The way I've done Tri Attack should make it come up for Porygon specifically, which occasionally uses it to not suffer Double-Edge recoil. I could technically do this for Strength too but the best user of that is Exeggutor and it hasn't seen any high-level success. 

I added some cases for Stadium OU where a few moves become extremely relevant. PS currently doesn't represent these very well. Double-Edge replaces Hyper Beam on quite a few movesets, Focus Energy functions (Jolteon uses this, v important), and Haze is a pseudo-Refresh. Haze is only really relevant for Vaporeon which is never really used but if someone uses it they may as well have it suggested to them. Sleep moves become pretty terrible all things considered, so I put the *bad ones* in useless; I think Sleep Powder and Lovely Kiss are ok, and Parasect is gonna be using Spore in the blue moon someone uses it. Fly and Dig are unbanned and some Pokemon will use them if they lack other coverage moves (eg. Aerodactyl, Arcanine) so they may as well get given edge cases.

I wanted to have Toxic be useful in UU which is actually insanely good and used on a myriad of top threats for Dragonite specifically, but I wasn't sure how to do it. It's usable in NU too, you see. I'm probably just stupid. It's terrible in OU and I don't want to disrupt that.

Sorry if I did anything wrong here, I'm not entirely educated on how this area works. 