### PR TITLE
Gen 1: Add Thunder and Waterfall to usually useless

### DIFF
--- a/src/battle-dex-search.ts
+++ b/src/battle-dex-search.ts
@@ -1225,7 +1225,7 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 
 			// Usually useless for Gen 1
 			if ([
-				'disable', 'haze', 'leechseed', 'quickattack', 'roar', 'toxic', 'triattack', 'whirlwind',
+				'disable', 'haze', 'leechseed', 'quickattack', 'roar', 'thunder', 'toxic', 'triattack', 'waterfall', 'whirlwind',
 			].includes(id)) {
 				return false;
 			}


### PR DESCRIPTION
So I had these updated in another pull request (#1972), but a few RBYers brought up some more candidates I probably missed.

Thunder has one use-case, and it's on Zapdos in Ubers specifically, and even there it's pretty niche. Unlike in later gens, it rarely has game-defining calcs (GSC) and doesn't have rain to support it (Drizzle gens), so it's just kind of awful. It doesn't even have a 30% paralysis chance, it's just 10.1%, so even that reason to run it doesn't exist. With less turn-by-turn average damage than Thunderbolt, it's at least worse than Toxic.

Waterfall doesn't flinch in this generation, which makes it a worse Surf in literally every scenario. It's Seaking's signature move, and it doesn't use it because, well, it has Surf. In Tradebacks, it's just teambuilder clutter a la Haze.

Sorry to be doing this again so soon! This should pretty much cover everything.