### PR TITLE
Fix more client commands on some Android devices

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -441,7 +441,7 @@
 				var spaceIndex = text.indexOf(' ');
 				if (spaceIndex > 0) {
 					cmd = text.substr(1, spaceIndex - 1);
-					target = text.substr(spaceIndex + 1);
+					target = text.substr(spaceIndex + 1).trim();
 				} else {
 					cmd = text.substr(1);
 					target = '';


### PR DESCRIPTION
Basically [this PR](https://github.com/smogon/pokemon-showdown-client/pull/1863) but for the command target; same bug basically. See [sample bug report of behavior with the /highlight command](https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-9330339).