### PR TITLE
User and active battle counts update on an interval

### DIFF
--- a/js/client-rooms.js
+++ b/js/client-rooms.js
@@ -24,6 +24,12 @@
 			app.send('/cmd rooms');
 			app.user.on('change:named', this.updateUser, this);
 			this.update();
+			this.chatroomInterval = setInterval(() => {
+				if (app.curSideRoom?.id === 'rooms') {
+					app.send('/cmd rooms');
+					this.update()
+				}
+			}, 20000);
 		},
 		initSectionSelection: function () {
 			var buf = ['<option value="">(All rooms)</option>'];
@@ -166,6 +172,8 @@
 		},
 		closeHide: function () {
 			app.sideRoom = app.curSideRoom = null;
+			clearInterval(this.chatroomInterval);
+			this.chatroomInterval = null;
 			this.close();
 		},
 		finduser: function () {

--- a/js/client-rooms.js
+++ b/js/client-rooms.js
@@ -24,10 +24,10 @@
 			app.send('/cmd rooms');
 			app.user.on('change:named', this.updateUser, this);
 			this.update();
-			this.chatroomInterval = setInterval(() => {
-				if (app.curSideRoom?.id === 'rooms') {
+			this.chatroomInterval = setInterval(function () {
+				if (app.curSideRoom && app.curSideRoom.id === 'rooms') {
 					app.send('/cmd rooms');
-					this.update()
+					this.update();
 				}
 			}, 20000);
 		},


### PR DESCRIPTION
I added a feature to allow the user count and active battle counts to automatically update themselves every 20 seconds.

Currently these values only update on refocusing the room window after 60 seconds have passed since last updated.