### PR TITLE
Teambuilder: Don't show Pokemon that don't learn moves in Gen 9

### DIFF
--- a/src/battle-dex-search.ts
+++ b/src/battle-dex-search.ts
@@ -755,7 +755,8 @@ abstract class BattleTypedSearch<T extends SearchType> {
 			this.format.startsWith('vgc') ||
 			this.format.startsWith('battlespot') ||
 			this.format.startsWith('battlestadium') ||
-			this.format.startsWith('battlefestival')
+			this.format.startsWith('battlefestival') ||
+			(this.dex.gen === 9 && this.formatType !== 'natdex')
 		) {
 			if (gen === 9) {
 				genChar = 'a';


### PR DESCRIPTION
Prevents Pokemon who only learn moves in previous generations while searching, i.e. knock off shows bisharp right now