### PR TITLE
Allow Costar to copy crit volatiles

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1867,13 +1867,12 @@ export class Battle {
 		case '-copyboost': {
 			let poke = this.getPokemon(args[1])!;
 			let frompoke = this.getPokemon(args[2])!;
-			let effect = Dex.getEffect(kwArgs.from);
 			let stats = args[3] ? args[3].split(', ') : ['atk', 'def', 'spa', 'spd', 'spe', 'accuracy', 'evasion'];
 			for (const stat of stats) {
 				poke.boosts[stat] = frompoke.boosts[stat];
 				if (!poke.boosts[stat]) delete poke.boosts[stat];
 			}
-			if (this.gen >= 6 && effect.id === 'psychup') {
+			if (this.gen >= 6) {
 				const volatilesToCopy = ['focusenergy', 'gmaxchistrike', 'laserfocus'];
 				for (const volatile of volatilesToCopy) {
 					if (frompoke.volatiles[volatile]) {


### PR DESCRIPTION
Turns out that Costar actually does copy the crit volatiles, so I am fixing my mistake from #2020