### PR TITLE
Add CSS class based on field slot (left-center-right)

### DIFF
--- a/src/battle-animations.ts
+++ b/src/battle-animations.ts
@@ -2651,9 +2651,9 @@ export class PokemonSprite extends Sprite {
 		// DOUBLES: Slot0 -> left / Slot1 -> Right
 		// TRIPLES: slot0 -> left / Slot1 -> Center / Slot2 -> Right
 		const position = [
-			' left',
-			this.scene.activeCount === 3 ? ' center' : ' right',
-			' right',
+			' leftstatbar',
+			this.scene.activeCount === 3 ? ' centerstatbar' : ' rightstatbar',
+			' rightstatbar',
 		];
 		return position[slot];
 	}

--- a/src/battle-animations.ts
+++ b/src/battle-animations.ts
@@ -2647,8 +2647,19 @@ export class PokemonSprite extends Sprite {
 	// Statbar
 	/////////////////////////////////////////////////////////////////////
 
+	getClassForPosition(slot: number) {
+		// DOUBLES: Slot0 -> left / Slot1 -> Right
+		// TRIPLES: slot0 -> left / Slot1 -> Center / Slot2 -> Right
+		const position = [
+			' left',
+			this.scene.activeCount === 3 ? ' center' : ' right',
+			' right',
+		];
+		return position[slot];
+	}
+
 	getStatbarHTML(pokemon: Pokemon) {
-		let buf = '<div class="statbar' + (this.isFrontSprite ? ' lstatbar' : ' rstatbar') + '" style="display: none">';
+		let buf = '<div class="statbar' + (this.isFrontSprite ? ' lstatbar' : ' rstatbar') + this.getClassForPosition(pokemon.slot) + '" style="display: none">';
 		const ignoreNick = this.isFrontSprite && (this.scene.battle.ignoreOpponent || this.scene.battle.ignoreNicks);
 		buf += `<strong>${BattleLog.escapeHTML(ignoreNick ? pokemon.speciesForme : pokemon.name)}`;
 		const gender = pokemon.gender;


### PR DESCRIPTION
While I was working on a custom theme, I noticed that it was not possible to tell which pokemon was positioned to the right or left during a double battle. This made it impossible to properly edit the "statbar" via css.