### PR TITLE
Add more support for undefined effect tags

### DIFF
--- a/src/battle-animations.ts
+++ b/src/battle-animations.ts
@@ -2781,7 +2781,19 @@ export class PokemonSprite extends Sprite {
 		let effect = PokemonSprite.statusTable[id];
 		if (typeof effect === 'string') return effect;
 		if (effect === null) return PokemonSprite.statusTable[id] = '';
-		if (effect === undefined) effect = [`[[${id}]]`, 'neutral'];
+		if (effect === undefined) {
+			let label = `[[${id}]]`;
+			if (Dex.species.get(id).exists) {
+				label = Dex.species.get(id).name;
+			} else if (Dex.items.get(id).exists) {
+				label = Dex.items.get(id).name;
+			} else if (Dex.moves.get(id).exists) {
+				label = Dex.moves.get(id).name;
+			} else if (Dex.abilities.get(id).exists) {
+				label = Dex.abilities.get(id).name;
+			}
+			effect = [label, 'neutral'];
+		}
 		return PokemonSprite.statusTable[id] = `<span class="${effect[1]}">${effect[0].replace(/ /g, '&nbsp;')}</span> `;
 	}
 


### PR DESCRIPTION
This mostly just makes undefined tags less... ugly? If something exists somewhere for them in the main data files. This is mainly only relevant for OMs, but it will make things like Salt Cure prior to its bad effect being implemented on the client look better than just `[[saltcure]]`.

![](https://i.imgur.com/bNXoYej.png)