### PR TITLE
Battle-log: Whitelist a data- attribute for server-side divs

### DIFF
--- a/src/battle-log.ts
+++ b/src/battle-log.ts
@@ -750,6 +750,7 @@ export class BattleLog {
 			'psicon::category': 0,
 			'username::name': 0,
 			'form::data-submitsend': 0,
+			'div::data-server': 0,
 			'button::data-send': 0,
 			'form::data-delimiter': 0,
 			'button::data-delimiter': 0,


### PR DESCRIPTION
This is necessary for a custom identifier for the |scroll| message type. I originally wanted data-time to sort out timestamps, but I figured this would be a better all-use attribute that other server pages could use to identify divs for scrolling to / other selector stuff (Caja sanitizes out data-* attribs otherwise)