### PR TITLE
Add Open Team Sheet PokePaste button to VGC formats

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -830,8 +830,8 @@
 			this.exportMode = true;
 			this.update();
 		},
-		pokepasteExport: function () {
-			var team = Storage.exportTeam(this.curSetList);
+		pokepasteExport: function (type) {
+			var team = Storage.exportTeam(this.curSetList, this.curTeam.gen, type === 'openteamsheet');
 			if (!team) return app.addPopupMessage("Add a Pokémon to your team before uploading it!");
 			document.getElementById("pasteData").value = team;
 			document.getElementById("pasteTitle").value = this.curTeam.name;
@@ -867,7 +867,7 @@
 				// Chrome is dumb and doesn't support data URLs in HTTPS
 				urlprefix = "https://" + Config.routes.client + "/action.php?act=dlteam&team=";
 			}
-			var contents = Storage.exportTeam(team.team).replace(/\n/g, '\r\n');
+			var contents = Storage.exportTeam(team.team, team.gen).replace(/\n/g, '\r\n');
 			var downloadurl = "text/plain:" + filename + ":" + urlprefix + encodeURIComponent(window.btoa(unescape(encodeURIComponent(contents))));
 			console.log(downloadurl);
 			dataTransfer.setData("DownloadURL", downloadurl);
@@ -1109,7 +1109,7 @@
 			var buf = '';
 			if (this.exportMode) {
 				buf = '<div class="pad"><button name="back"><i class="fa fa-chevron-left"></i> List</button> <input class="textbox teamnameedit" type="text" class="teamnameedit" size="30" value="' + BattleLog.escapeHTML(this.curTeam.name) + '" /> <button name="saveImport"><i class="fa fa-upload"></i> Import/Export</button> <button name="saveImport" class="savebutton"><i class="fa fa-floppy-o"></i> Save</button></div>';
-				buf += '<div class="teamedit"><textarea class="textbox" rows="17">' + BattleLog.escapeHTML(Storage.exportTeam(this.curSetList)) + '</textarea></div>';
+				buf += '<div class="teamedit"><textarea class="textbox" rows="17">' + BattleLog.escapeHTML(Storage.exportTeam(this.curSetList, this.curTeam.gen)) + '</textarea></div>';
 			} else {
 				buf = '<div class="pad"><button name="back"><i class="fa fa-chevron-left"></i> List</button> ';
 				buf += '<input class="textbox teamnameedit" type="text" class="teamnameedit" size="30" value="' + BattleLog.escapeHTML(this.curTeam.name) + '" /> ';
@@ -1158,6 +1158,9 @@
 				buf += '<input type="hidden" name="author" id="pasteAuthor">';
 				buf += '<input type="hidden" name="notes" id="pasteNotes">';
 				buf += '<button name="pokepasteExport" type="submit" class="button exportbutton"><i class="fa fa-upload"></i> Upload to PokePaste</button></form>';
+				if (this.curTeam.format.includes('vgc')) {
+					buf += '<button name="pokepasteExport" value="openteamsheet" type="submit" class="button exportbutton"><i class="fa fa-upload"></i> Upload to PokePaste (Open Team Sheet)</button></form>';
+				}
 				buf += '</div>';
 			}
 			this.$el.html('<div class="teamwrapper">' + buf + '</div>');
@@ -1634,7 +1637,7 @@
 			this.$('.teambuilder-pokemon-import')
 				.show()
 				.find('textarea')
-				.val(Storage.exportTeam([this.curSet]).trim())
+				.val(Storage.exportTeam([this.curSet], this.curTeam.gen).trim())
 				.focus()
 				.select();
 
@@ -1692,7 +1695,7 @@
 			var smogonSet = formatSets['dex'][species][setName] || formatSets['stats'][species][setName];
 			var curSet = $.extend({}, this.curSet, smogonSet);
 
-			var text = Storage.exportTeam([curSet]);
+			var text = Storage.exportTeam([curSet], this.curTeam.gen);
 			this.$('.teambuilder-pokemon-import .pokemonedit').val(text);
 		},
 		closePokemonImport: function (force) {

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -835,8 +835,13 @@
 			if (!team) return app.addPopupMessage("Add a Pokémon to your team before uploading it!");
 			document.getElementById("pasteData").value = team;
 			document.getElementById("pasteTitle").value = this.curTeam.name;
+			if (type === 'openteamsheet') {
+				document.getElementById("pasteTitle").value += " (OTS)";
+			}
 			document.getElementById("pasteAuthor").value = app.user.get('name');
-			if (this.curTeam.format !== 'gen9') document.getElementById("pasteNotes").value = "Format: " + this.curTeam.format;
+			if (this.curTeam.format !== 'gen9') {
+				document.getElementById("pasteNotes").value = "Format: " + this.curTeam.format;
+			}
 			document.getElementById("pokepasteForm").submit();
 		},
 

--- a/js/storage.js
+++ b/js/storage.js
@@ -1268,7 +1268,7 @@ Storage.exportAllTeams = function () {
 	for (var i = 0, len = Storage.teams.length; i < len; i++) {
 		var team = Storage.teams[i];
 		buf += '=== ' + (team.format ? '[' + team.format + (team.capacity === 24 ? '-box] ' : '] ') : '') + (team.folder ? '' + team.folder + '/' : '') + team.name + ' ===\n\n';
-		buf += Storage.exportTeam(team.team);
+		buf += Storage.exportTeam(team.team, team.gen);
 		buf += '\n';
 	}
 	return buf;
@@ -1279,13 +1279,13 @@ Storage.exportFolder = function (folder) {
 		var team = Storage.teams[i];
 		if (team.folder + "/" === folder || team.format === folder) {
 			buf += '=== ' + (team.format ? '[' + team.format + (team.capacity === 24 ? '-box] ' : '] ') : '') + (team.folder ? '' + team.folder + '/' : '') + team.name + ' ===\n\n';
-			buf += Storage.exportTeam(team.team);
+			buf += Storage.exportTeam(team.team, team.gen);
 			buf += '\n';
 		}
 	}
 	return buf;
 };
-Storage.exportTeam = function (team) {
+Storage.exportTeam = function (team, gen, hidestats) {
 	if (!team) return "";
 	if (typeof team === 'string') {
 		if (team.indexOf('\n') >= 0) return team;
@@ -1329,71 +1329,73 @@ Storage.exportTeam = function (team) {
 		if (curSet.gigantamax) {
 			text += 'Gigantamax: Yes  \n';
 		}
-		if (curSet.teraType) {
-			text += 'Tera Type: ' + curSet.teraType + "  \n";
+		if (gen === 9) {
+			text += 'Tera Type: ' + (curSet.teraType || Dex.species.get(curSet.species).types[0]) + "  \n";
 		}
-		var first = true;
-		if (curSet.evs) {
-			for (var j in BattleStatNames) {
-				if (!curSet.evs[j]) continue;
-				if (first) {
-					text += 'EVs: ';
-					first = false;
-				} else {
-					text += ' / ';
-				}
-				text += '' + curSet.evs[j] + ' ' + BattleStatNames[j];
-			}
-		}
-		if (!first) {
-			text += "  \n";
-		}
-		if (curSet.nature) {
-			text += '' + curSet.nature + ' Nature' + "  \n";
-		}
-		var first = true;
-		if (curSet.ivs) {
-			var defaultIvs = true;
-			var hpType = false;
-			for (var j = 0; j < curSet.moves.length; j++) {
-				var move = curSet.moves[j];
-				if (move.substr(0, 13) === 'Hidden Power ' && move.substr(0, 14) !== 'Hidden Power [') {
-					hpType = move.substr(13);
-					if (!Dex.types.isName(hpType)) {
-						alert(move + " is not a valid Hidden Power type.");
-						continue;
+		if (!hidestats) {
+			var first = true;
+			if (curSet.evs) {
+				for (var j in BattleStatNames) {
+					if (!curSet.evs[j]) continue;
+					if (first) {
+						text += 'EVs: ';
+						first = false;
+					} else {
+						text += ' / ';
 					}
+					text += '' + curSet.evs[j] + ' ' + BattleStatNames[j];
+				}
+			}
+			if (!first) {
+				text += "  \n";
+			}
+			if (curSet.nature) {
+				text += '' + curSet.nature + ' Nature' + "  \n";
+			}
+			var first = true;
+			if (curSet.ivs) {
+				var defaultIvs = true;
+				var hpType = false;
+				for (var j = 0; j < curSet.moves.length; j++) {
+					var move = curSet.moves[j];
+					if (move.substr(0, 13) === 'Hidden Power ' && move.substr(0, 14) !== 'Hidden Power [') {
+						hpType = move.substr(13);
+						if (!Dex.types.isName(hpType)) {
+							alert(move + " is not a valid Hidden Power type.");
+							continue;
+						}
+						for (var stat in BattleStatNames) {
+							if ((curSet.ivs[stat] === undefined ? 31 : curSet.ivs[stat]) !== (Dex.types.get(hpType).HPivs[stat] || 31)) {
+								defaultIvs = false;
+								break;
+							}
+						}
+					}
+				}
+				if (defaultIvs && !hpType) {
 					for (var stat in BattleStatNames) {
-						if ((curSet.ivs[stat] === undefined ? 31 : curSet.ivs[stat]) !== (Dex.types.get(hpType).HPivs[stat] || 31)) {
+						if (curSet.ivs[stat] !== 31 && curSet.ivs[stat] !== undefined) {
 							defaultIvs = false;
 							break;
 						}
 					}
 				}
-			}
-			if (defaultIvs && !hpType) {
-				for (var stat in BattleStatNames) {
-					if (curSet.ivs[stat] !== 31 && curSet.ivs[stat] !== undefined) {
-						defaultIvs = false;
-						break;
+				if (!defaultIvs) {
+					for (var stat in BattleStatNames) {
+						if (typeof curSet.ivs[stat] === 'undefined' || isNaN(curSet.ivs[stat]) || curSet.ivs[stat] == 31) continue;
+						if (first) {
+							text += 'IVs: ';
+							first = false;
+						} else {
+							text += ' / ';
+						}
+						text += '' + curSet.ivs[stat] + ' ' + BattleStatNames[stat];
 					}
 				}
 			}
-			if (!defaultIvs) {
-				for (var stat in BattleStatNames) {
-					if (typeof curSet.ivs[stat] === 'undefined' || isNaN(curSet.ivs[stat]) || curSet.ivs[stat] == 31) continue;
-					if (first) {
-						text += 'IVs: ';
-						first = false;
-					} else {
-						text += ' / ';
-					}
-					text += '' + curSet.ivs[stat] + ' ' + BattleStatNames[stat];
-				}
+			if (!first) {
+				text += "  \n";
 			}
-		}
-		if (!first) {
-			text += "  \n";
 		}
 		if (curSet.moves) for (var j = 0; j < curSet.moves.length; j++) {
 			var move = curSet.moves[j];
@@ -1671,7 +1673,7 @@ Storage.nwSaveTeam = function (team) {
 		this.nwDeleteTeam(team);
 	}
 	team.filename = filename;
-	fs.writeFile(this.dir + 'Teams/' + filename, Storage.exportTeam(team.team).replace(/\n/g, '\r\n'), function () {});
+	fs.writeFile(this.dir + 'Teams/' + filename, Storage.exportTeam(team.team, team.gen).replace(/\n/g, '\r\n'), function () {});
 };
 
 Storage.nwSaveTeams = function () {
@@ -1707,7 +1709,7 @@ Storage.nwDoSaveAllTeams = function () {
 		filename = $.trim(filename).replace(/[\\\/]+/g, '');
 
 		team.filename = filename;
-		fs.writeFile(this.dir + 'Teams/' + filename, Storage.exportTeam(team.team).replace(/\n/g, '\r\n'), function () {});
+		fs.writeFile(this.dir + 'Teams/' + filename, Storage.exportTeam(team.team, team.gen).replace(/\n/g, '\r\n'), function () {});
 	}
 };
 


### PR DESCRIPTION
Now that Open Team Sheets are a more "official" thing, it would be greatly beneficial for there to be an option to upload your current team without anything related to stats, as currently you need to make a copy of your team and manually remove the stats before uploading. This button will only be displayed in VGC formats.

In addition, Tera Types will now always be shown when exporting a set/team, even if it is the primary type of the Pokemon.

![image](https://user-images.githubusercontent.com/32044378/208003710-9dfa55c1-befa-4535-a3c6-df2147a8d4c8.png)
![image](https://user-images.githubusercontent.com/32044378/208003722-7f9188c7-2a1d-49b3-afa5-308812bc7e31.png)
