### PR TITLE
Bypass https on localhost

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -758,7 +758,7 @@ function toId() {
 						// We need to bypass the port as well because on most modern browsers, http gets forced
 						// to https, which means a ws connection is made to port 443 instead of wherever it's actually running,
 						// thus ensuring a failed connection.
-						var port = possiblePort ? possiblePort[1] : Config.server.port;
+						var port = possiblePort || Config.server.port;
 						console.log("Bypassing SockJS for localhost");
 						var url = 'ws://' + Config.server.host + ':' + port + Config.sockjsprefix + '/websocket';
 						console.log(url);

--- a/js/client.js
+++ b/js/client.js
@@ -393,6 +393,7 @@ function toId() {
 		},
 		focused: true,
 		initialize: function () {
+			this.query = window.location.search;
 			window.app = this;
 			this.initializeRooms();
 			this.initializePopups();
@@ -753,11 +754,15 @@ function toId() {
 						// anyway, this affects SockJS because it makes HTTP requests to localhost
 						// but it turns out that making direct WebSocket connections to localhost is
 						// still supported, so we'll just bypass SockJS and use WebSocket directly.
+						var possiblePort = /port=([0-9]+)/.exec(self.query || "");
+						// We need to bypass the port as well because on most modern browsers, http gets forced
+						// to https, which means a ws connection is made to port 443 instead of wherever it's actually running,
+						// thus ensuring a failed connection.
+						var port = possiblePort ? possiblePort[1] : Config.server.port;
 						console.log("Bypassing SockJS for localhost");
-						console.log('ws' + protocol.slice('4') + '://' + Config.server.host + ':' + Config.server.port + Config.sockjsprefix + '/websocket');
-						return new WebSocket(
-							'ws' + protocol.slice('4') + '://' + Config.server.host + ':' + Config.server.port + Config.sockjsprefix + '/websocket'
-						);
+						var url = 'ws://' + Config.server.host + ':' + port + Config.sockjsprefix + '/websocket';
+						console.log(url);
+						return new WebSocket(url);
 					}
 					return new SockJS(
 						protocol + '://' + Config.server.host + ':' + Config.server.port + Config.sockjsprefix,

--- a/js/client.js
+++ b/js/client.js
@@ -393,6 +393,7 @@ function toId() {
 		},
 		focused: true,
 		initialize: function () {
+			// Gotta cache this since backbone removes it
 			this.query = window.location.search;
 			window.app = this;
 			this.initializeRooms();

--- a/js/client.js
+++ b/js/client.js
@@ -754,7 +754,7 @@ function toId() {
 						// anyway, this affects SockJS because it makes HTTP requests to localhost
 						// but it turns out that making direct WebSocket connections to localhost is
 						// still supported, so we'll just bypass SockJS and use WebSocket directly.
-						var possiblePort = /port=([0-9]+)/.exec(self.query || "");
+						var possiblePort = new URL(document.location + self.query).searchParams.get('port');
 						// We need to bypass the port as well because on most modern browsers, http gets forced
 						// to https, which means a ws connection is made to port 443 instead of wherever it's actually running,
 						// thus ensuring a failed connection.


### PR DESCRIPTION
This fixes accessing localhost. Previously, browsers forced http to https, meaning the WebSocket connection was made to port 443 on https instead of the correct http connection to whatever port. This ensures localhost is always connecting to http and on the correct port, which is added to the querystring by the redirect in `ps/server/static/index.html`.