### PR TITLE
Prevent data loss when importing backed up teams

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -1128,6 +1128,7 @@ Storage.importTeam = function (buffer, teams) {
 				}
 				line = $.trim(line.substr(bracketIndex + 1));
 			}
+			var gen = parseInt(format[3], 10) || 6;
 			if (teams.length && typeof teams[teams.length - 1].team !== 'string') {
 				teams[teams.length - 1].team = Storage.packTeam(teams[teams.length - 1].team);
 			}
@@ -1140,6 +1141,7 @@ Storage.importTeam = function (buffer, teams) {
 			teams.push({
 				name: line,
 				format: format,
+				gen: gen,
 				team: team,
 				capacity: capacity,
 				folder: folder,


### PR DESCRIPTION
I got a report about tera types being lost when using the "Backup and Restore all Teams" option in teambuilder. It occurs if you import teams with a valid importable (and save), and then go back to the same location and hit save again.

The issue can be seen here (video from the reporter): https://youtu.be/yXxBpPW9jaw 

The issue was that when importing via the backup option (many teams), the generation of the team was not saved. This is in comparison to editing a specific team which handles that. One the second save, the tera type information is not presented in the exportable backup (which is saved) because the generation for the team is not recorded in `Storage.teams` due to tera types being skipped if `team.gen` is not `9`. This results in data loss if the teams are saved again.