### PR TITLE
Teambuilder: Don't modify IVs for Hidden Power on import

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -1246,13 +1246,6 @@ Storage.importTeam = function (buffer, teams) {
 			if (line.substr(0, 14) === 'Hidden Power [') {
 				var hptype = line.substr(14, line.length - 15);
 				line = 'Hidden Power ' + hptype;
-				var type = Dex.types.get(hptype);
-				if (!curSet.ivs && type) {
-					curSet.ivs = {};
-					for (var stat in type.HPivs) {
-						curSet.ivs[stat] = type.HPivs[stat];
-					}
-				}
 			}
 			if (line === 'Frustration' && curSet.happiness === undefined) {
 				curSet.happiness = 0;

--- a/src/panel-teamdropdown.tsx
+++ b/src/panel-teamdropdown.tsx
@@ -398,13 +398,6 @@ class PSTeambuilder {
 			if (line.startsWith('Hidden Power [')) {
 				const hpType = line.slice(14, -1) as TypeName;
 				line = 'Hidden Power ' + hpType;
-				if (!set.ivs && Dex.types.isName(hpType)) {
-					set.ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
-					const hpIVs = Dex.types.get(hpType).HPivs || {};
-					for (let stat in hpIVs) {
-						set.ivs[stat as StatName] = hpIVs[stat as StatName]!;
-					}
-				}
 			}
 			if (line === 'Frustration' && set.happiness === undefined) {
 				set.happiness = 0;


### PR DESCRIPTION
addresses my issue here: https://github.com/smogon/pokemon-showdown-client/issues/2091

I wanted to see if I could make it depend on the format of the team it was being imported to but it doesn't appear that the areas of code responsible for this issue have access to that information. This seems like the best fix I could find. This shouldn't pose a huge issue to those using earlier formats for the following reasons:
1) Teams they are importing were probably already created in the proper gen of showdown and won't need the extra correction
2) validation will catch the issue and re-adding the hidden power type will fix the stats.
3) you have always been able to import illegal sets so this change won't catch anyone off-guard. If people even realize it is gone.