### PR TITLE
Support new Commander activation message

### DIFF
--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -856,6 +856,9 @@ class BattleTextParser {
 			}
 
 			if (id === 'commander') {
+				// Commander didn't have a message prior to v1.2.0 of SV
+				// so this is for old replays
+				if (target === pokemon) return line1;
 				const template = this.template('activate', id);
 				return line1 + template.replace('[POKEMON]', this.pokemon(pokemon)).replace(/\[TARGET\]/g, this.pokemon(target));
 			}

--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -857,7 +857,7 @@ class BattleTextParser {
 
 			if (id === 'commander') {
 				// Commander didn't have a message prior to v1.2.0 of SV
-				// so this is for old replays
+				// so this is for backwards compatibility
 				if (target === pokemon) return line1;
 				const template = this.template('activate', id);
 				return line1 + template.replace('[POKEMON]', this.pokemon(pokemon)).replace(/\[TARGET\]/g, this.pokemon(target));

--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -856,9 +856,9 @@ class BattleTextParser {
 			}
 
 			if (id === 'commander') {
-                const template = this.template('activate', id);
-                return line1 + template.replace('[POKEMON]', this.pokemon(pokemon)).replace(/\[TARGET\]/g, this.pokemon(target));
-            }
+				const template = this.template('activate', id);
+				return line1 + template.replace('[POKEMON]', this.pokemon(pokemon)).replace(/\[TARGET\]/g, this.pokemon(target));
+			}
 
 			let templateId = 'activate';
 			if (id === 'forewarn' && pokemon === target) {

--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -855,6 +855,11 @@ class BattleTextParser {
 				return line1 + template.replace('[TARGET]', this.pokemon(target));
 			}
 
+			if (id === 'commander') {
+                const template = this.template('activate', id);
+                return line1 + template.replace('[POKEMON]', this.pokemon(pokemon)).replace(/\[TARGET\]/g, this.pokemon(target));
+            }
+
 			let templateId = 'activate';
 			if (id === 'forewarn' && pokemon === target) {
 				templateId = 'activateNoTarget';


### PR DESCRIPTION
For smogon/pokemon-showdown#9473

This is needed because we only replace things like `[TARGET]` once but Commander uses `[TARGET]` twice.