### PR TITLE
Ladder: Set current gen to 9 for decay purposes

### DIFF
--- a/lib/ntbb-ladder.lib.php
+++ b/lib/ntbb-ladder.lib.php
@@ -316,8 +316,8 @@ class NTBBLadder {
 						$decay = 1 + intval(($elo-1400)/50);
 					}
 					switch ($this->formatid) {
-					case 'gen8randombattle':
-					case 'gen8ou':
+					case 'gen9randombattle':
+					case 'gen9ou':
 						break;
 					default:
 						$decay -= 2;


### PR DESCRIPTION
Truthfully I'm not sure what this code does: why does the client require the Elo decay rules? Regardless, rules have changed in the loginserver so they should probably change here too.

loginserver commit: https://github.com/smogon/pokemon-showdown-loginserver/commit/1186bcfb4ab5839fc0d3dcf6a92b3377665f0011