### PR TITLE
Fix phantom move bugs in teambuilder

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2851,8 +2851,8 @@
 						this.unChooseMove(curVal);
 						$inputEl.val('');
 						delete this.search.cur[toID(val)];
-						this.curSet.moves.splice(i - 1, 1);
-
+						// Remove all instances of the duplicate move from the moves array.
+						this.curSet.moves = this.curSet.moves.filter(e => e != curVal);
 					} else if (curVal) {
 						moves.push(curVal);
 					}

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2835,7 +2835,7 @@
 		},
 		chartClick: function (e) {
 			if (this.search.addFilter(e.currentTarget)) {
-				this.$('input[name=' + this.curChartName + ']').val('').select();
+				this.$('input[name=' + this.curChartName + ']').select();
 				this.search.find('');
 				return;
 			}
@@ -2851,6 +2851,8 @@
 						this.unChooseMove(curVal);
 						$inputEl.val('');
 						delete this.search.cur[toID(val)];
+						this.curSet.moves.splice(i - 1, 1);
+
 					} else if (curVal) {
 						moves.push(curVal);
 					}

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2852,7 +2852,7 @@
 						$inputEl.val('');
 						delete this.search.cur[toID(val)];
 						// Remove all instances of the duplicate move from the moves array.
-						this.curSet.moves = this.curSet.moves.filter(e => e != curVal);
+						this.curSet.moves = this.curSet.moves.filter(move => move != curVal);
 					} else if (curVal) {
 						moves.push(curVal);
 					}


### PR DESCRIPTION
There are currently two annoying bugs in the teambuilder for moves.

1. Replacing an already used move with itself doesn't actually remove it and instead overwrites another move after saving.
2. Moves that are overwritten by changing the filter create phantom moves with similar behavior after saving if we try to re add them.

Bug examples:

https://github.com/smogon/pokemon-showdown-client/assets/88553777/63aa4bd6-704c-4643-8eca-2644def98034
https://user-images.githubusercontent.com/59275598/187088226-dcee32e4-3de1-4dc8-99d4-0a42027b7cb7.mp4


This PR fixes both issues with an elegant two lines solution.
The array containing the moves should be updated after overwriting and moves should be selected and not overwritten when changing filters (this also makes more sense imo).

This PR would fix/close issue  #1991 .


After the patch:

https://github.com/smogon/pokemon-showdown-client/assets/88553777/b7db47ed-64eb-4052-8e2d-88943215f7aa

Thanks to anyone who tests this PR so i can be sure i didn't mess anything up.