### PR TITLE
Fixed IV defaults for generations with hypertraining

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -1247,11 +1247,13 @@ Storage.importTeam = function (buffer, teams) {
 			if (line.substr(0, 14) === 'Hidden Power [') {
 				var hptype = line.substr(14, line.length - 15);
 				line = 'Hidden Power ' + hptype;
-				var type = Dex.types.get(hptype);
-				if (!curSet.ivs && type) {
-					curSet.ivs = {};
-					for (var stat in type.HPivs) {
-						curSet.ivs[stat] = type.HPivs[stat];
+				if ((parseInt(format[3], 10) || 6) < 7) { // update IVs to match hidden power if format is gen 6 or earlier
+					var type = Dex.types.get(hptype);
+					if (!curSet.ivs && type) {
+						curSet.ivs = {};
+						for (var stat in type.HPivs) {
+							curSet.ivs[stat] = type.HPivs[stat];
+						}
 					}
 				}
 			}

--- a/src/panel-teamdropdown.tsx
+++ b/src/panel-teamdropdown.tsx
@@ -398,13 +398,6 @@ class PSTeambuilder {
 			if (line.startsWith('Hidden Power [')) {
 				const hpType = line.slice(14, -1) as TypeName;
 				line = 'Hidden Power ' + hpType;
-				if (!set.ivs && Dex.types.isName(hpType)) {
-					set.ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
-					const hpIVs = Dex.types.get(hpType).HPivs || {};
-					for (let stat in hpIVs) {
-						set.ivs[stat as StatName] = hpIVs[stat as StatName]!;
-					}
-				}
 			}
 			if (line === 'Frustration' && set.happiness === undefined) {
 				set.happiness = 0;


### PR DESCRIPTION
addresses my issue here: https://github.com/smogon/pokemon-showdown-client/issues/2091
Also addressing this issue here: https://www.smogon.com/forums/threads/default-to-31-ivs-on-pokemon-with-hidden-power-in-generations-with-hyper-training.3692969/

I wanted to see if I could make it depend on the format of the team it was being imported to but it doesn't appear that the areas of code responsible for this issue have access to that information. Only the storage import can use it so I went ahead and implemented it there. This is the best fix I could find.

Here are the reasons I made this PR:
1) The way this was implemented ended up being very insidious. Players are having their teams nerfed without their knowledge and have lost battles they would have one without it. Due to how sneaky this effect is, many users have no idea that that teambuilder is actively nerfing their pokemon due to a mechanic that doesn't apply to them.
2) Past-gen players would have already created their teams on the proper gen of showdown and won't need the extra correction. IVs that deviate from 31s are always specified and modifications for hidden power are no exception.
3) Validation will catch the issue and re-adding the hidden power type will fix the stats which means generations without hyper training will be left largely unaffected. Worst case they change the move and change it back to force the ivs to recalculate.
4) you have always been able to import illegal sets so this change won't catch anyone off-guard. If people even realize it is gone. 

What if the previous generations rely on this?
 - IVs that deviate from 31 are always specified. before and after this change. Any team that would have made use of this change, once exported, would have the differing IVs noted anyway.
 
What if they, knowing this was a thing, removed the noted ivs?
 - The validator will catch this and it will not be hard to fix. Whether they remove and re-add the hidden power move or manually fix the ivs, this will be at most a minor annoyance. As opposed to the game-losing plague that is IVs being forced away from their optimal state due to the teambuilder attempting to account for mechanics that no longer apply without the user being aware it is doing so.

Why didn't you modify this so it always knows what gen the pokemon is being important for?
 - Sadly we cannot always know what format a team is for as the parameter isn't required. Thus why only one of the functions could take the generation into account

TLDR:
Possible harm caused by this change:
 - a minor annoyance.
Possible harm prevented by this change:
 - Users will no longer have their teams nerfed without their consent or knowledge
 - The import button will now be consistent