### PR TITLE
Fix leaveroom confirm when the room no longer exists 

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -1511,8 +1511,8 @@
 			this.close();
 		},
 		leaveRoom: function (data) {
-			this.room.send('/noreply /leave');
 			this.close();
+			return app.removeRoom(this.room.id);
 		}
 	});
 


### PR DESCRIPTION
When using the setting `Confirmation before leaving a room`, there's a bug that prevents you from leaving if you have this setting turned on. I haven't found any regression, let me know if you want me to test a specific use case

Example on how to replicate the bug:
- Toggle the setting `Confirmation before leaving a room` to true 
- Create groupchat with ``/mgc``
- Destroy it with ``/dgc``
- Try to leave