### PR TITLE
Ensure Revival Blessing only heals fainted Pokemon

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1733,7 +1733,7 @@ export class Battle {
 			break;
 		}
 		case '-heal': {
-			let poke = this.getPokemon(args[1])!;
+			let poke = this.getPokemon(args[1], Dex.getEffect(kwArgs.from).id === 'revivalblessing')!;
 			let damage = poke.healthParse(args[2], true, true);
 			if (damage === null) break;
 			let range = poke.getDamageRange(damage);
@@ -3279,7 +3279,7 @@ export class Battle {
 		}
 		return null;
 	}
-	getPokemon(pokemonid: string | undefined) {
+	getPokemon(pokemonid: string | undefined, faintedOnly = false) {
 		if (!pokemonid || pokemonid === '??' || pokemonid === 'null' || pokemonid === 'false') {
 			return null;
 		}
@@ -3295,6 +3295,7 @@ export class Battle {
 
 		for (const pokemon of side.pokemon) {
 			if (isInactive && side.active.includes(pokemon)) continue;
+			if (faintedOnly && pokemon.hp) continue;
 			if (pokemon.ident === pokemonid) { // name matched, good enough
 				if (slot >= 0) pokemon.slot = slot;
 				return pokemon;


### PR DESCRIPTION
Bug report: https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-9751369

Currently, if multiple Pokemon have the same nickname, Revival Blessing will always heal the first, even if it's not fainted.

Test replay: https://replay.pokemonshowdown.com/gen9purehackmons-1928803548