### PR TITLE
Fix Hospitality activation message

### DIFF
--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -930,7 +930,7 @@ class BattleTextParser {
 		case '-heal': {
 			let [, pokemon] = args;
 			let template = this.template('heal', kwArgs.from, 'NODEFAULT');
-			const line1 = this.maybeAbility(kwArgs.from, pokemon);
+			const line1 = this.maybeAbility(kwArgs.from, BattleTextParser.effectId(kwArgs.from) === 'hospitality' ? kwArgs.of : pokemon);
 			if (template) {
 				return line1 + template.replace('[POKEMON]', this.pokemon(pokemon)).replace('[SOURCE]', this.pokemon(kwArgs.of)).replace('[NICKNAME]', kwArgs.wisher);
 			}

--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -183,6 +183,13 @@ class BattleTextParser {
 			break;
 		}
 
+		case '-heal': {
+			let [, pokemon] = args;
+			const id = BattleTextParser.effectId(kwArgs.from);
+			if (['dryskin', 'eartheater', 'voltabsorb', 'waterabsorb'].includes(id)) kwArgs.of = '';
+			break;
+		}
+
 		case '-nothing':
 			// OLD: |-nothing
 			// NEW: |-activate||move:Splash
@@ -930,7 +937,7 @@ class BattleTextParser {
 		case '-heal': {
 			let [, pokemon] = args;
 			let template = this.template('heal', kwArgs.from, 'NODEFAULT');
-			const line1 = this.maybeAbility(kwArgs.from, BattleTextParser.effectId(kwArgs.from) === 'hospitality' ? kwArgs.of : pokemon);
+			const line1 = this.maybeAbility(kwArgs.from, kwArgs.of || pokemon);
 			if (template) {
 				return line1 + template.replace('[POKEMON]', this.pokemon(pokemon)).replace('[SOURCE]', this.pokemon(kwArgs.of)).replace('[NICKNAME]', kwArgs.wisher);
 			}

--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -184,7 +184,6 @@ class BattleTextParser {
 		}
 
 		case '-heal': {
-			let [, pokemon] = args;
 			const id = BattleTextParser.effectId(kwArgs.from);
 			if (['dryskin', 'eartheater', 'voltabsorb', 'waterabsorb'].includes(id)) kwArgs.of = '';
 			break;

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1741,7 +1741,7 @@ export class Battle {
 			if (kwArgs.from) {
 				let effect = Dex.getEffect(kwArgs.from);
 				let ofpoke = this.getPokemon(kwArgs.of);
-				this.activateAbility(effect.id === 'hospitality' ? ofpoke : poke, effect);
+				this.activateAbility(ofpoke || poke, effect);
 				if (effect.effectType === 'Item' && !CONSUMED.includes(poke.prevItemEffect)) {
 					if (poke.prevItem !== effect.name) {
 						poke.item = effect.name;

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1740,7 +1740,8 @@ export class Battle {
 
 			if (kwArgs.from) {
 				let effect = Dex.getEffect(kwArgs.from);
-				this.activateAbility(poke, effect);
+				let ofpoke = this.getPokemon(kwArgs.of);
+				this.activateAbility(effect.id === 'hospitality' ? ofpoke : poke, effect);
 				if (effect.effectType === 'Item' && !CONSUMED.includes(poke.prevItemEffect)) {
 					if (poke.prevItem !== effect.name) {
 						poke.item = effect.name;


### PR DESCRIPTION
I didn't want to hardcode this, but it seems like absorb abilities like volt absorb and dry skin depend on the client not using the pokemon from `[of]` to properly show their activation message. That feels like something that should be fixed server side (the source of healing for those abilities should be the same as the ability holder), but if I did fix that old replays would have incorrect activations unless I hardcoded removing `[of]` from said absorption abilities (which is what used to be done).