### PR TITLE
Allow Replace Player to work with Player 3 and Player 4

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -1143,6 +1143,8 @@
 
 			filename += '-' + toID(this.battle.p1.name);
 			filename += '-' + toID(this.battle.p2.name);
+			filename += '-' + toID(this.battle.p3.name);
+			filename += '-' + toID(this.battle.p4.name);
 
 			e.currentTarget.href = BattleLog.createReplayFileHref(this);
 			e.currentTarget.download = filename + '.html';
@@ -1496,7 +1498,7 @@
 			var self = this;
 			app.addPopupPrompt("Replacement player's username", "Replace player", function (target) {
 				if (!target) return;
-				var side = (room.battle.mySide.id === room.battle.p1.id ? 'p1' : 'p2');
+				var side = (room.battle.mySide.id === room.battle.p1.id ? 'p1' : (room.battle.mySide.id === room.battle.p2.id ? 'p2' : (room.battle.mySide.id === room.battle.p3.id ? 'p3' : 'p4')));
 				room.leaveBattle();
 				room.send('/addplayer ' + target + ', ' + side);
 				self.close();


### PR DESCRIPTION
In Free-For-Alls and Multi-Battles, the "replace player" feature doesn't work if you're Player 3 or Player 4. This is because replace player was only coded for P1 and P2. So, I added P3 and P4 to make the feature work for Players 3 and 4.

Proof-of-concept replay: https://sheeplol.neocities.org/ffareplaceplayer/

I tested this in my own client and local server. One Free-For-All battle and one Singles Random Battle. From my testing, this is the correct implementation and doesn't break anything.

There could be a way to write this in a better way, but this seems to be sufficient at least.