### PR TITLE
Support best-of-n room titles

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -1256,6 +1256,9 @@ function toId() {
 			var columnChanged = false;
 
 			window.NonBattleGames = {rps: 'Rock Paper Scissors'};
+			for (var i = 3; i <= 9; i = i + 2) {
+				window.NonBattleGames['bestof' + i] = 'Best-of-' + i;
+			}
 			window.BattleFormats = {};
 			for (var j = 1; j < formatsList.length; j++) {
 				if (isSection) {

--- a/src/panel-mainmenu.tsx
+++ b/src/panel-mainmenu.tsx
@@ -97,6 +97,9 @@ class MainMenuRoom extends PSRoom {
 		let column = 0;
 
 		window.NonBattleGames = {rps: 'Rock Paper Scissors'};
+		for (let i = 3; i <= 9; i = i + 2) {
+			window.NonBattleGames['bestof' + i] = 'Best-of-' + i;
+		}
 		window.BattleFormats = {};
 		for (let j = 1; j < formatsList.length; j++) {
 			const entry = formatsList[j];


### PR DESCRIPTION
Goes from this
![image](https://github.com/smogon/pokemon-showdown-client/assets/23667022/d6ce07d8-3139-4ab3-9f2a-3c3e4f163b9f)

To this
![image](https://github.com/smogon/pokemon-showdown-client/assets/23667022/d915917b-3044-4b82-b39c-d78931cd0315)

Originally we were going to include the format in the room title, but that leads to longer tab names than is probably necessary.