### PR TITLE
Add a button to allow using the format selector in chat pages

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -877,16 +877,19 @@ function toId() {
 		serializeForm: function (form, checkboxOnOff) {
 			// querySelector dates back to IE8 so we can use it
 			// fortunate, because form serialization is a HUGE MESS in older browsers
-			var elements = form.querySelectorAll('input[name], select[name], textarea[name], keygen[name]');
+			var elements = form.querySelectorAll('input[name], select[name], textarea[name], keygen[name], button[value]');
 			var out = [];
+			window.elements = elements;
 			for (var i = 0; i < elements.length; i++) {
 				var element = elements[i];
+				if ($(element).attr('type') === 'submit') continue;
 				if (element.type === 'checkbox' && !element.value && checkboxOnOff) {
 					out.push([element.name, element.checked ? 'on' : 'off']);
 				} else if (!['checkbox', 'radio'].includes(element.type) || element.checked) {
 					out.push([element.name, element.value]);
 				}
 			}
+			window.out = out;
 			return out;
 		},
 		submitSend: function (e) {
@@ -2110,12 +2113,15 @@ function toId() {
 		},
 		dispatchClickButton: function (e) {
 			var target = e.currentTarget;
-			if (target.name) {
+			var type = $(target).attr('type');
+			if (type === 'submit') type = null;
+			if (target.name || type) {
 				app.dismissingSource = app.dismissPopups();
 				app.dispatchingButton = target;
 				e.preventDefault();
 				e.stopImmediatePropagation();
-				this[target.name](target.value, target);
+				if (target.name && this[target.name]) this[target.name](target.value, target);
+				if (type && this[type]) this[type](target.value, target);
 				delete app.dismissingSource;
 				delete app.dispatchingButton;
 			}
@@ -2141,6 +2147,15 @@ function toId() {
 		 */
 		receive: function (data) {
 			//
+		},
+
+		/**
+		 * Used for <formatselect>, does format popup and caches value in button value
+		 */
+		selectformat: function (value, target) {
+			app.addPopup(FormatPopup, {format: 'gen9randombattle', sourceEl: target, selectType: 'watch', onselect: function (newFormat) {
+				target.value = newFormat;
+			}});
 		},
 
 		// layout

--- a/src/battle-log.ts
+++ b/src/battle-log.ts
@@ -759,6 +759,7 @@ export class BattleLog {
 			username: 0,
 			spotify: 0,
 			youtube: 0,
+			formatselect: 0,
 			twitch: 0,
 		});
 
@@ -780,6 +781,7 @@ export class BattleLog {
 			'psicon::pokemon': 0,
 			'psicon::item': 0,
 			'psicon::type': 0,
+			'selectformat::type': 0,
 			'psicon::category': 0,
 			'username::name': 0,
 			'form::data-submitsend': 0,
@@ -913,6 +915,16 @@ export class BattleLog {
 						'frameborder', '0', 'allow', 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture', 'allowfullscreen', 'allowfullscreen',
 					],
 				};
+			} else if (tagName === 'formatselect') {
+				return {
+					tagName: 'button',
+					attribs: [
+						'type', 'selectformat',
+						'class', "select formatselect",
+						'value', getAttrib('value') || "gen9randombattle",
+						'name', getAttrib('name') || '',
+					],
+				}
 			} else if (tagName === 'psicon') {
 				// <psicon> is a custom element which supports a set of mutually incompatible attributes:
 				// <psicon pokemon> and <psicon item>


### PR DESCRIPTION
Will be useful for teams, /buildformat, etc. 
Adds a `<formatselect>` tag that can be used in `data-submitsend` forms to let users select formats without knowing how format IDs work. 