### PR TITLE
Support loading teams from server, add button to upload teams

### DIFF
--- a/js/client-chat-tournament.js
+++ b/js/client-chat-tournament.js
@@ -167,19 +167,22 @@
 				self.room.send('/tournament leave');
 			});
 			this.$challengeChallenge.on('click', function () {
-				app.sendTeam(Storage.teams[self.$teamSelect.children().val()]);
-				self.room.send('/tournament challenge ' + self.$challengeUserMenu.children().val());
+				app.sendTeam(Storage.teams[self.$teamSelect.children().val()], function () {
+					self.room.send('/tournament challenge ' + self.$challengeUserMenu.children().val());
+				});
 			});
 			this.$challengeAccept.on('click', function () {
-				app.sendTeam(Storage.teams[self.$teamSelect.children().val()]);
-				self.room.send('/tournament acceptchallenge');
+				app.sendTeam(Storage.teams[self.$teamSelect.children().val()], function () {
+					self.room.send('/tournament acceptchallenge');
+				});
 			});
 			this.$challengeCancel.on('click', function () {
 				self.room.send('/tournament cancelchallenge');
 			});
 			this.$validate.on('click', function () {
-				app.sendTeam(Storage.teams[self.$teamSelect.children().val()]);
-				self.room.send('/tournament vtm');
+				app.sendTeam(Storage.teams[self.$teamSelect.children().val()], function () {
+					self.room.send('/tournament vtm');
+				});
 			});
 
 			app.user.on('saveteams', this.updateTeams, this);

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -916,10 +916,14 @@
 					app.addPopupMessage("You need to go into the Teambuilder and build a team for this format.");
 					return;
 				}
-				app.sendTeam(team);
+				app.sendTeam(team, function () {
+					target.disabled = true;
+					app.send(privacy + '/accept ' + userid);
+				});
+			} else {
+				target.disabled = true;
+				app.send(privacy + '/accept ' + userid);
 			}
-			target.disabled = true;
-			app.send(privacy + '/accept ' + userid);
 		},
 		rejectChallenge: function (i, target) {
 			var userid = $(target).closest('.pm-window').data('userid');
@@ -949,8 +953,9 @@
 			buf += '<p class="buttonbar"><button name="cancelChallenge">Cancel</button></p></form>';
 
 			$(target).closest('.challenge').html(buf);
-			app.sendTeam(team);
-			app.send(privacy + '/challenge ' + userid + ', ' + format);
+			app.sendTeam(team, function () {
+				app.send(privacy + '/challenge ' + userid + ', ' + format);
+			});
 		},
 		cancelChallenge: function (i, target) {
 			var userid = $(target).closest('.pm-window').data('userid');
@@ -1090,11 +1095,12 @@
 			$searchForm.find('button.big').html('<strong><i class="fa fa-refresh fa-spin"></i> Connecting...</strong>').addClass('disabled');
 			$searchForm.append('<p class="cancel buttonbar"><button name="cancelSearch">Cancel</button></p>');
 
-			app.sendTeam(team);
 			var self = this;
-			this.searchDelay = setTimeout(function () {
-				app.send(self.adjustPrivacy($privacyCheckbox.is(':checked')) + '/search ' + format);
-			}, 3000);
+			app.sendTeam(team, function () {
+				self.searchDelay = setTimeout(function () {
+					app.send(self.adjustPrivacy($privacyCheckbox.is(':checked')) + '/search ' + format);
+				}, 3000);
+			});
 		},
 		cancelSearch: function () {
 			clearTimeout(this.searchDelay);
@@ -1379,6 +1385,7 @@
 							count++;
 							if (count % bufBoundary === 0 && count != 0 && curBuf < 4) curBuf++;
 						}
+						console.log(teamFormat);
 						if (!isNoFolder) {
 							for (var i = 0; i < teams.length; i++) {
 								if ((!teams[i].format && !teamFormat) || teams[i].format === teamFormat) {

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -863,6 +863,7 @@
 			app.send(cmd + " " + buf.join(', '));
 			this.exported = true;
 			$('button[name=psExport]').addClass('disabled');
+			$('button[name=psExport]')[0].disabled = true;
 		},
 		pokepasteExport: function (type) {
 			var team = Storage.exportTeam(this.curSetList, this.curTeam.gen, type === 'openteamsheet');
@@ -984,6 +985,7 @@
 				app.user.trigger('saveteams');
 				this.exported = false;
 				$('button[name=psExport]').removeClass('disabled');
+				$('button[name=psExport]')[0].disabled = false;
 			}
 
 			// We're going to try to animate the team settling into its new position

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -1179,7 +1179,7 @@
 					return false;
 				};
 				if (this.loadingTeam) buf += '<div style="message-error">Downloading team from server...</strong><br />';
-				buf += '<label name="editMessage" style="display: none">'
+				buf += '<label name="editMessage" style="display: none">';
 				buf += 'Remember to click the upload button below to sync your changes to the server!</label><br />';
 				if (exports.BattleFormats) {
 					buf += '<li class="format-select">';

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -859,7 +859,9 @@
 			buf.push(this.curTeam.name);
 			buf.push(this.curTeam.format);
 			buf.push(this.curTeam.privacy ? 1 : 0);
-			buf.push(Storage.exportTeam(this.curSetList, this.curTeam.gen, false));
+			var team = Storage.exportTeam(this.curSetList, this.curTeam.gen, false);
+			if (!team) return app.addPopupMessage("Add a Pokémon to your team before uploading it!");
+			buf.push(team);
 			app.send(cmd + " " + buf.join(', '));
 			this.exported = true;
 			$('button[name=psExport]').addClass('disabled');

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -478,17 +478,21 @@
 				}
 			}
 
-			buf += '</ul>';
+			buf += '</ul><p>';
 			if (atLeastOne) {
-				buf += '<p><button name="new" value="team" class="button"><i class="fa fa-plus-circle"></i> ' + newTeamButtonText + '</button> <button name="new" value="box" class="button"><i class="fa fa-archive"></i> New Box</button></p>';
+				buf += '<button name="new" value="team" class="button"><i class="fa fa-plus-circle"></i> ' + newTeamButtonText + '</button> <button name="new" value="box" class="button"><i class="fa fa-archive"></i> New Box</button> ';
 			}
+			buf += '<button class="button" name="send" value="/teams">View teams uploaded to server</button>';
+			buf += '</p>';
 
 			if (window.nodewebkit) {
 				buf += '<button name="revealFolder" class="button"><i class="fa fa-folder-open"></i> Reveal teams folder</button> <button name="reloadTeamsFolder" class="button"><i class="fa fa-refresh"></i> Reload teams files</button> <button name="backup" class="button"><i class="fa fa-upload"></i> Backup/Restore all teams</button>';
 			} else if (this.curFolder) {
 				buf += '<button name="backup" class="button"><i class="fa fa-upload"></i> Backup all teams from this folder</button>';
 			} else if (atLeastOne) {
-				buf += '<p><strong>Clearing your cookies (specifically, <code>localStorage</code>) will delete your teams.</strong> <span class="storage-warning">Browsers sometimes randomly clear cookies - you should back up your teams or use the desktop client if you want to make sure you don\'t lose them.</span></p>';
+				buf += '<p><strong>Clearing your cookies (specifically, <code>localStorage</code>) will delete your teams.</strong> ';
+				buf += '<span class="storage-warning">Browsers sometimes randomly clear cookies - you should upload your teams to the Showdown database ';
+				buf += 'or make a backup yourself if you want to make sure you don\'t lose them.</span></p>';
 				buf += '<button name="backup" class="button"><i class="fa fa-upload"></i> Backup/Restore all teams</button>';
 				buf += '<p>If you want to clear your cookies or <code>localStorage</code>, you can use the Backup/Restore feature to save your teams as text first.</p>';
 				var self = this;
@@ -866,6 +870,7 @@
 			this.exported = true;
 			$('button[name=psExport]').addClass('disabled');
 			$('button[name=psExport]')[0].disabled = true;
+			$('label[name=editMessage]').hide();
 		},
 		pokepasteExport: function (type) {
 			var team = Storage.exportTeam(this.curSetList, this.curTeam.gen, type === 'openteamsheet');
@@ -988,6 +993,7 @@
 				this.exported = false;
 				$('button[name=psExport]').removeClass('disabled');
 				$('button[name=psExport]')[0].disabled = false;
+				$('label[name=editMessage]').show();
 			}
 
 			// We're going to try to animate the team settling into its new position
@@ -1173,6 +1179,8 @@
 					return false;
 				};
 				if (this.loadingTeam) buf += '<div style="message-error">Downloading team from server...</strong><br />';
+				buf += '<label name="editMessage" style="display: none">'
+				buf += 'Remember to click the upload button below to sync your changes to the server!</label><br />';
 				if (exports.BattleFormats) {
 					buf += '<li class="format-select">';
 					buf += '<label class="label">Format:</label><button class="select formatselect teambuilderformatselect" name="format" value="' + this.curTeam.format + '">' + (isGenericFormat(this.curTeam.format) ? '<em>Select a format</em>' : BattleLog.escapeFormat(this.curTeam.format)) + '</button>';

--- a/js/client.js
+++ b/js/client.js
@@ -555,7 +555,12 @@ function toId() {
 			});
 
 			this.on('loggedin', function () {
-				Storage.loadRemoteTeams();
+				Storage.loadRemoteTeams(function () {
+					if (app.rooms.teambuilder) {
+						// if they have it open, be sure to update so it doesn't show 'no teams'
+						app.rooms.teambuilder.update();
+					}
+				});
 			});
 
 			this.on('response:savereplay', this.uploadReplay, this);

--- a/js/storage.js
+++ b/js/storage.js
@@ -715,7 +715,7 @@ Storage.unpackLine = function (line) {
 	var format = bracketIndex > 0 ? line.slice((leftBracketIndex ? leftBracketIndex + 1 : 0), isBox ? bracketIndex - 4 : bracketIndex) : 'gen9';
 	if (format && format.slice(0, 3) !== 'gen') format = 'gen6' + format;
 	return {
-		teamid: leftBracketIndex > 0 ? line.slice(0, leftBracketIndex) : undefined,
+		teamid: leftBracketIndex > 0 ? Number(line.slice(0, leftBracketIndex)) : undefined,
 		name: line.slice(slashIndex + 1, pipeIndex),
 		format: format,
 		gen: parseInt(format[3], 10) || 6,

--- a/js/storage.js
+++ b/js/storage.js
@@ -612,7 +612,7 @@ Storage.loadRemoteTeams = function (after) {
 					return {species: mon};
 				});
 				team.team = Storage.packTeam(mons);
-				Storage.teams.push(team);
+				Storage.teams.unshift(team);
 			}
 		}
 		if (typeof after === 'function') after();

--- a/js/storage.js
+++ b/js/storage.js
@@ -585,6 +585,39 @@ Storage.loadTeams = function () {
 	} catch (e) {}
 };
 
+Storage.loadRemoteTeams = function () {
+	$.get(app.user.getActionPHP(), {act: 'getteams'}, Storage.safeJSON(function (data) {
+		if (data.actionerror) {
+			return app.addPopupMessage('Error loading uploaded teams: ' + data.actionerror);
+		}
+		for (var i = 0; i < data.teams.length; i++) {
+			var team = data.teams[i];
+			var matched = false;
+			for (var j = 0; j < Storage.teams.length; j++) {
+				var curTeam = Storage.teams[j];
+				if (curTeam.teamid === team.teamid) {
+					// prioritize locally saved teams over remote
+					// as so to not overwrite changes
+					matched = true;
+					break;
+				}
+			}
+			team.loaded = false;
+			if (!matched) {
+				// hack so that it shows up in the format selector list
+				team.folder = '';
+				// team comes down from loginserver as comma-separated list of mons
+				// to save bandwidth
+				var mons = team.team.split(',').map(function (mon) {
+					return {species: mon};
+				});
+				team.team = Storage.packTeam(mons);
+				Storage.teams.push(team);
+			}
+		}
+	}));
+};
+
 Storage.loadPackedTeams = function (buffer) {
 	try {
 		this.teams = Storage.unpackAllTeams(buffer);
@@ -669,16 +702,20 @@ Storage.unpackAllTeams = function (buffer) {
 };
 
 Storage.unpackLine = function (line) {
+	var leftBracketIndex = line.indexOf('[');
+	if (leftBracketIndex < 0) leftBracketIndex = 0;
 	var pipeIndex = line.indexOf('|');
 	if (pipeIndex < 0) return null;
+	if (leftBracketIndex > pipeIndex) leftBracketIndex = 0;
 	var bracketIndex = line.indexOf(']');
 	if (bracketIndex > pipeIndex) bracketIndex = -1;
 	var isBox = line.slice(0, bracketIndex).endsWith('-box');
 	var slashIndex = line.lastIndexOf('/', pipeIndex);
 	if (slashIndex < 0) slashIndex = bracketIndex; // line.slice(slashIndex + 1, pipeIndex) will be ''
-	var format = bracketIndex > 0 ? line.slice(0, isBox ? bracketIndex - 4 : bracketIndex) : 'gen9';
+	var format = bracketIndex > 0 ? line.slice((leftBracketIndex ? leftBracketIndex + 1 : 0), isBox ? bracketIndex - 4 : bracketIndex) : 'gen9';
 	if (format && format.slice(0, 3) !== 'gen') format = 'gen6' + format;
 	return {
+		teamid: leftBracketIndex > 0 ? line.slice(0, leftBracketIndex) : undefined,
 		name: line.slice(slashIndex + 1, pipeIndex),
 		format: format,
 		gen: parseInt(format[3], 10) || 6,
@@ -691,7 +728,12 @@ Storage.unpackLine = function (line) {
 
 Storage.packAllTeams = function (teams) {
 	return teams.map(function (team) {
-		return (team.format ? '' + team.format + (team.capacity === 24 ? '-box]' : ']') : '') + (team.folder ? '' + team.folder + '/' : '') + team.name + '|' + Storage.getPackedTeam(team);
+		return (
+			(team.teamid ? '' + team.teamid + '[' : '') +
+			(team.format ? '' + team.format + (team.capacity === 24 ? '-box]' : ']') : '') +
+			(team.folder ? '' + team.folder + '/' : '') + team.name + '|' +
+			Storage.getPackedTeam(team)
+		);
 	}).join('\n');
 };
 

--- a/js/storage.js
+++ b/js/storage.js
@@ -585,7 +585,7 @@ Storage.loadTeams = function () {
 	} catch (e) {}
 };
 
-Storage.loadRemoteTeams = function () {
+Storage.loadRemoteTeams = function (after) {
 	$.get(app.user.getActionPHP(), {act: 'getteams'}, Storage.safeJSON(function (data) {
 		if (data.actionerror) {
 			return app.addPopupMessage('Error loading uploaded teams: ' + data.actionerror);
@@ -615,6 +615,7 @@ Storage.loadRemoteTeams = function () {
 				Storage.teams.push(team);
 			}
 		}
+		if (typeof after === 'function') after();
 	}));
 };
 


### PR DESCRIPTION
Client-side integration for the teams database.
This PR: 
- Adds a button to upload a team next to the pokepaste button.
- Supports pulling teams from the external DB via the loginserver. This is split into two levels: on startup, the client requests a list of teams from the loginserver, which responds with a list of teamIDs, mon IDs from that team, format, and team name. This leaves out the majority of the data. When the user opens the team in teambuilder, or tries to do anything with it, the app loads it from loginserver, caches it, then uses it. 

I dislike having to add a callback parameter to sendTeam, but unfortunately we do not support async/await at the moment. Will take suggestions to improve that though. 