### PR TITLE
Bo3: Add challenge checkbox for VGC formats

### DIFF
--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -896,6 +896,8 @@
 			buf += '<p><label class="label">Format:</label>' + this.renderFormats(format) + '</p>';
 			buf += '<p><label class="label">Team:</label>' + this.renderTeams(format) + '</p>';
 			buf += '<p><label class="checkbox"><input type="checkbox" name="private" ' + (Storage.prefs('disallowspectators') ? 'checked' : '') + ' /> <abbr title="You can still invite spectators by giving them the URL or using the /invite command">Don\'t allow spectators</abbr></label></p>';
+			buf += '<p' + (!(format && format.includes('vgc')) ? ' class="hidden">' : '>');
+			buf += '<label class="checkbox"><input type="checkbox" name="bestof" /> <abbr title="Start a team-locked best-of-3 series">Best-of-3</abbr></label></p>';
 			buf += '<p class="buttonbar"><button name="makeChallenge"><strong>Challenge</strong></button> <button type="button" name="dismissChallenge">Cancel</button></p></form>';
 			$challenge.html(buf);
 		},
@@ -935,6 +937,14 @@
 			var format = $pmWindow.find('button[name=format]').val();
 			var teamIndex = $pmWindow.find('button[name=team]').val();
 			var privacy = this.adjustPrivacy($pmWindow.find('input[name=private]').is(':checked'));
+
+			var bestof = $pmWindow.find('input[name=bestof]').is(':checked');
+			var hasCustomRules = format.includes('@@@');
+			if (bestof) {
+				format += hasCustomRules ? ', ' : '@@@';
+				format += 'Best of = 3';
+			}
+
 			var team = null;
 			if (Storage.teams[teamIndex]) team = Storage.teams[teamIndex];
 
@@ -1272,6 +1282,18 @@
 				app.rooms[''].curTeamIndex = -1;
 				var $teamButton = this.sourceEl.closest('form').find('button[name=team]');
 				if ($teamButton.length) $teamButton.replaceWith(app.rooms[''].renderTeams(format));
+
+				var $bestOfCheckbox = this.sourceEl.closest('form').find('input[name=bestof]');
+				if ($bestOfCheckbox) {
+					var $parentTag = $bestOfCheckbox.parent().parent();
+					if (format.includes('vgc')) {
+						$parentTag.removeClass('hidden');
+					} else {
+						$parentTag.addClass('hidden');
+						$bestOfCheckbox.prop('checked', false);
+					}
+				}
+
 				var $partnerLabels = $('label[name=partner]');
 				$partnerLabels.each(function (i, label) {
 					label.style.display = BattleFormats[format].partner ? '' : 'none';


### PR DESCRIPTION
Adds a best-of-three checkbox to VGC formats (note: depending on how this is received, we may want to generalize with a property server-side on the format itself so other formats can also use it). When this box is checked, it adds Best of = 3 to custom rules sent to the challenge partner. The challenged recipient cannot select to make the format bo3.
![image](https://github.com/smogon/pokemon-showdown-client/assets/23667022/cf92d392-2d8b-4936-8005-81c4b8ec4d9d)
![image](https://github.com/smogon/pokemon-showdown-client/assets/23667022/d01d324c-ee45-4b18-a506-c016fb7518f5)

Unlike privacy, I don't want to store the current state of bo3 being checked, because I can imagine lots of cases where you'd want to regularly switch back and forth. I recommend whenever we add a bo3 ladder that we make ``challengeShow: false`` for that format.

Credit @Karthik99999 for helping to parallel program this change.