### PR TITLE
Encore/Taunt counters

### DIFF
--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -854,6 +854,26 @@ class BattleTooltips {
 			text += '</p>';
 		}
 
+		if(pokemon.volatiles['encore']) {
+			if(this.battle.gen >= 5){
+				text += '<p><small>Encore turns remaining:</small> ' + (3 - clientPokemon.volatilesData.encoreTurns);
+			}
+			else{
+				text += '<p><small>Turns encored:</small> ' + clientPokemon.volatilesData.encoreTurns;
+			}
+			text += '</p>'
+		}
+
+		if(pokemon.volatiles['taunt']) {
+			if(this.battle.gen >= 5){
+				text += '<p><small>Taunt turns remaining:</small> ' + (3 - clientPokemon.volatilesData.tauntTurns);
+			}
+			else{
+				text += '<p><small>Turns taunted:</small> ' + clientPokemon.volatilesData.tauntTurns;
+			}
+			text += '</p>'
+		}
+
 		const supportsAbilities = this.battle.gen > 2 && !this.battle.tier.includes("Let's Go");
 
 		let abilityText = '';

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -104,6 +104,7 @@ export class Pokemon implements PokemonDetails, PokemonHealth {
 	/** [[moveName, ppUsed]] */
 	moveTrack: [string, number][] = [];
 	statusData = {sleepTurns: 0, toxicTurns: 0};
+	volatilesData = {encoreTurns: 0, tauntTurns: 0};
 	timesAttacked = 0;
 
 	sprite: PokemonSprite;
@@ -277,6 +278,8 @@ export class Pokemon implements PokemonDetails, PokemonHealth {
 	removeVolatile(volatile: ID) {
 		this.side.battle.scene.removeEffect(this, volatile);
 		if (!this.hasVolatile(volatile)) return;
+		if(volatile == 'encore') this.volatilesData.encoreTurns = 0;
+		if(volatile == 'taunt') this.volatilesData.tauntTurns = 0;
 		delete this.volatiles[volatile];
 	}
 	addVolatile(volatile: ID, ...args: any[]) {
@@ -1527,6 +1530,12 @@ export class Battle {
 			} else {
 				pokemon.rememberMove(callerMoveForPressure.name, pp - 1); // 1 pp was already deducted from using the move itself
 			}
+			if(pokemon.volatiles['encore']) {
+				pokemon.volatilesData.encoreTurns++;
+			}
+			if(pokemon.volatiles['taunt']) {
+				pokemon.volatilesData.tauntTurns++;
+			}
 		}
 		pokemon.lastMove = move.id;
 		this.lastMove = move.id;
@@ -1616,6 +1625,8 @@ export class Battle {
 		case 'attract':
 			this.scene.resultAnim(pokemon, 'Immobilized', 'neutral');
 			break;
+		case 'taunt':
+			pokemon.volatilesData.tauntTurns++;
 		}
 		this.scene.animReset(pokemon);
 	}
@@ -1759,6 +1770,8 @@ export class Battle {
 					poke.side.wisher = null;
 					poke.statusData.sleepTurns = 0;
 					poke.statusData.toxicTurns = 0;
+					poke.volatilesData.encoreTurns = 0;
+					poke.volatilesData.tauntTurns = 0;
 					break;
 				case 'wish':
 					this.scene.runResidualAnim('wish' as ID, poke);
@@ -2726,6 +2739,7 @@ export class Battle {
 					break;
 				case 'taunt':
 					this.scene.resultAnim(poke, 'Taunt&nbsp;ended', 'good');
+					poke.volatilesData.tauntTurns = 0;
 					break;
 				case 'disable':
 					this.scene.resultAnim(poke, 'Disable&nbsp;ended', 'good');
@@ -2738,6 +2752,7 @@ export class Battle {
 					break;
 				case 'encore':
 					this.scene.resultAnim(poke, 'Encore&nbsp;ended', 'good');
+					poke.volatilesData.encoreTurns = 0;
 					break;
 				case 'bide':
 					this.scene.runOtherAnim('bideunleash' as ID, [poke]);

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1625,9 +1625,13 @@ export class Battle {
 		case 'attract':
 			this.scene.resultAnim(pokemon, 'Immobilized', 'neutral');
 			break;
-		case 'taunt':
-			pokemon.volatilesData.tauntTurns++;
 		}
+		if(pokemon.volatiles['encore']) {
+				pokemon.volatilesData.encoreTurns++;
+			}
+			if(pokemon.volatiles['taunt']) {
+				pokemon.volatilesData.tauntTurns++;
+			}
 		this.scene.animReset(pokemon);
 	}
 


### PR DESCRIPTION
[Approved feature suggestion from this thread](https://www.smogon.com/forums/threads/visual-countdown-for-moves-encore-and-taunt.3720092/)

Adds a new counter for Taunt/Encore similar to Sleep/Toxic, and displays as a tooltip. Appears differently in gens 2-4 than in 5+ due to those gens not having a set amount of turns.

![image](https://github.com/smogon/pokemon-showdown-client/assets/146598906/678d6a0c-bc7a-488a-b4e6-72ba9d38e279)
