### PR TITLE
Prevent remote teams from overwriting local teams

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -142,7 +142,7 @@
 		update: function () {
 			teams = Storage.teams;
 			if (this.curTeam) {
-				if (this.curTeam.loaded === false || (this.curTeam.teamid && !this.curTeam.loaded)) {
+				if (this.curTeam.loaded === false) {
 					this.loadTeam();
 					return this.updateTeamView();
 				}


### PR DESCRIPTION
The extra `loaded` check seems to be allowing local teams to be overwritten with remote team data on every refresh, which doesn't seem to be the intended behavior given this comment in `storage.js`.
```
// prioritize locally saved teams over remote
// as so to not overwrite changes
```