### PR TITLE
Fix `showteam` in replays

### DIFF
--- a/src/battle-log.ts
+++ b/src/battle-log.ts
@@ -259,6 +259,30 @@ export class BattleLog {
 			app.rooms[roomid].notifyOnce(title, body, 'highlight');
 			break;
 
+		case 'showteam': {
+			// @ts-ignore
+			if (!window.Storage?.unpackTeam || !window.Storage?.exportTeam) return;
+			// @ts-ignore
+			const team: PokemonSet[] = Storage.unpackTeam(args[2]);
+			const side = this.scene?.battle.getSide(args[1]);
+			if (!team || !side) return;
+			const exportedTeam = team.map(set => {
+				// @ts-ignore
+				let buf = Storage.exportTeam([set], this.gen).replace(/\n/g, '<br />');
+				if (set.name && set.name !== set.species) {
+					buf = buf.replace(set.name, BattleLog.sanitizeHTML(`<span class="picon" style="${Dex.getPokemonIcon(set.species)}"></span><br />${set.name}`));
+				} else {
+					buf = buf.replace(set.species, `<span class="picon" style="${Dex.getPokemonIcon(set.species)}"></span><br />${set.species}`);
+				}
+				if (set.item) {
+					buf = buf.replace(set.item, `${set.item} <span class="itemicon" style="${Dex.getItemIcon(set.item)}"></span>`);
+				}
+				return buf;
+			}).join('');
+			divHTML = `<div class="infobox"><details><summary>Open Team Sheet for ${side.name}</summary>${exportedTeam}</details></div>`;
+			break;
+		}
+
 		case 'seed': case 'choice': case ':': case 'timer': case 't:':
 		case 'J': case 'L': case 'N': case 'spectator': case 'spectatorleave':
 		case 'initdone':

--- a/src/battle-log.ts
+++ b/src/battle-log.ts
@@ -260,7 +260,7 @@ export class BattleLog {
 
 		case 'showteam': {
 			if (!battle) return;
-			const team: PokemonSet[] = battle.unpackTeam(args[2]);
+			const team = battle.unpackTeam(args[2]);
 			if (!team.length) return;
 			const side = battle.getSide(args[1]);
 			const exportedTeam = team.map(set => {

--- a/src/battle-log.ts
+++ b/src/battle-log.ts
@@ -99,8 +99,8 @@ export class BattleLog {
 	}
 	add(args: Args, kwArgs?: KWArgs, preempt?: boolean) {
 		if (kwArgs?.silent) return;
-		if (this.scene?.battle.seeking) {
-			const battle = this.scene.battle;
+		const battle = this.scene?.battle;
+		if (battle?.seeking) {
 			if (battle.stepQueue.length > 2000) {
 				// adding elements gets slower and slower the more there are
 				// (so showing 100 turns takes around 2 seconds, and 1000 turns takes around a minute)
@@ -122,7 +122,6 @@ export class BattleLog {
 		if (!['name', 'n'].includes(args[0])) this.lastRename = null;
 		switch (args[0]) {
 		case 'chat': case 'c': case 'c:':
-			let battle = this.scene?.battle;
 			let name;
 			let message;
 			if (args[0] === 'c:') {
@@ -260,15 +259,12 @@ export class BattleLog {
 			break;
 
 		case 'showteam': {
-			// @ts-ignore
-			if (!window.Storage?.unpackTeam || !window.Storage?.exportTeam) return;
-			// @ts-ignore
-			const team: PokemonSet[] = Storage.unpackTeam(args[2]);
-			const side = this.scene?.battle.getSide(args[1]);
-			if (!team || !side) return;
+			if (!battle) return;
+			const team: PokemonSet[] = battle.unpackTeam(args[2]);
+			if (!team.length) return;
+			const side = battle.getSide(args[1]);
 			const exportedTeam = team.map(set => {
-				// @ts-ignore
-				let buf = Storage.exportTeam([set], this.gen).replace(/\n/g, '<br />');
+				let buf = battle.exportTeam([set]).replace(/\n/g, '<br />');
 				if (set.name && set.name !== set.species) {
 					buf = buf.replace(set.name, BattleLog.sanitizeHTML(`<span class="picon" style="${Dex.getPokemonIcon(set.species)}"></span><br />${set.name}`));
 				} else {

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -3827,7 +3827,7 @@ export class Battle {
 			break;
 		}
 		case 'showteam': {
-			const team: PokemonSet[] = this.unpackTeam(args[2]);
+			const team = this.unpackTeam(args[2]);
 			if (!team.length) return;
 			const side = this.getSide(args[1]);
 			side.clearPokemon();
@@ -3842,7 +3842,7 @@ export class Battle {
 				}
 				if (set.teraType) pokemon.teraType = set.teraType;
 			}
-			this.log(args);
+			this.log(args, kwArgs);
 			break;
 		}
 		case 'switch': case 'drag': case 'replace': {

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -3579,7 +3579,7 @@ export class Battle {
 		case 'showteam': {
 			if (this.turn !== 0) return;
 			// @ts-ignore
-			if (!window.Storage?.unpackTeam || !window.Storage?.exportTeam) return;
+			if (!window.Storage?.unpackTeam) return;
 			// @ts-ignore
 			const team: PokemonSet[] = Storage.unpackTeam(args[2]);
 			if (!team) return;
@@ -3596,20 +3596,7 @@ export class Battle {
 				}
 				if (set.teraType) pokemon.teraType = set.teraType;
 			}
-			const exportedTeam = team.map(set => {
-				// @ts-ignore
-				let buf = Storage.exportTeam([set], this.gen).replace(/\n/g, '<br />');
-				if (set.name && set.name !== set.species) {
-					buf = buf.replace(set.name, BattleLog.sanitizeHTML(`<psicon pokemon="${set.species}" /> <br />${set.name}`));
-				} else {
-					buf = buf.replace(set.species, `<psicon pokemon="${set.species}" /> <br />${set.species}`);
-				}
-				if (set.item) {
-					buf = buf.replace(set.item, `${set.item} <psicon item="${set.item}" />`);
-				}
-				return buf;
-			}).join('');
-			this.add(`|raw|<div class="infobox"><details><summary>Open Team Sheet for ${side.name}</summary>${exportedTeam}</details></div>`);
+			this.log(args);
 			break;
 		}
 		case 'switch': case 'drag': case 'replace': {

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -3334,7 +3334,7 @@ export class Battle {
 		let j = 0;
 
 		while (true) {
-			const set: PokemonSet = {} as any as PokemonSet;
+			const set: PokemonSet = {} as any;
 			team.push(set);
 
 			// name


### PR DESCRIPTION
- Moves the HTML generation to `BattleLog`
- Creates functions for `unpackTeam` and `exportTeam` under `Battle` as replays do not have access to the `Storage` functions.