### PR TITLE
Make popups scrollable internally instead of adding scrollbar to body

### DIFF
--- a/style/client.css
+++ b/style/client.css
@@ -706,7 +706,9 @@ span.header-username:hover {
 	z-index: 20;
 }
 .ps-popup {
-	position: absolute;
+	position: fixed;
+	max-height: 99vh;
+	overflow-y: auto;
 	top: auto; right: auto; left: auto; bottom: auto;
 	text-align: left;
 	background: #E1E8E8;


### PR DESCRIPTION
- Changed some CSS so that popups with an overflowing content can be scrollable internally, instead of adding a scrollbar to the body, so that the layout of the page is kept and does not seem broken.
- Browser compatibility is not altered by the changes in this PR.

Before:

![Peek 2023-10-20 09-26](https://github.com/smogon/pokemon-showdown-client/assets/56583786/cb46e215-d8cb-4ea1-9375-2bd8d9b3b62c)

After:

![Peek 2023-10-20 09-27](https://github.com/smogon/pokemon-showdown-client/assets/56583786/65b6b656-d7b8-40e0-b501-4638baed8ac1)