### PR TITLE
Add queued action feature

### DIFF
--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -1079,7 +1079,7 @@
 			}
 
 			if (!app.user.get('named')) {
-				app.addPopup(LoginPopup);
+				app.addPopup(LoginPopup, {nextAction: 'battle'});
 				return;
 			}
 

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -42,6 +42,16 @@
 			}
 			buf += ' <button class="icon button" name="openSounds" title="Sound" aria-label="Sound"><i class="' + (Dex.prefs('mute') ? 'fa fa-volume-off' : 'fa fa-volume-up') + '"></i></button> <button class="icon button" name="openOptions" title="Options" aria-label="Options"><i class="fa fa-cog"></i></button>';
 			this.$userbar.html(buf);
+
+			// after userbar update, execute any queued action
+			switch (app.nextAction) {
+				case 'battle':
+					$('button[name=search]').click();
+					break;
+				default:
+					break;
+			}
+			app.nextAction = undefined;
 		},
 		login: function () {
 			app.addPopup(LoginPopup);
@@ -915,7 +925,7 @@
 
 			var name = (data.name || '');
 			if (!name && app.user.get('named')) name = app.user.get('name');
-			buf += '<p><label class="label">Username: <small class="preview" style="' + BattleLog.hashColor(toUserid(name)) + '">(color)</small><input class="textbox autofocus" type="text" name="username" value="' + BattleLog.escapeHTML(name) + '" autocomplete="username"></label></p>';
+			buf += '<p><label class="label">Username: <small class="preview" style="' + BattleLog.hashColor(toUserid(name)) + '">(color)</small><input class="textbox autofocus" type="text" name="username" value="' + BattleLog.escapeHTML(name) + '" autocomplete="username"></label>' + (data.nextAction ? '<input style="display:none" name="nextAction" value="' + data.nextAction + '">' : '') + '</p>';
 			if (name) {
 				buf += '<p><small>(Others will be able to see your name change. To change name privately, use "Log out")</small></p>';
 			}
@@ -944,8 +954,7 @@
 		},
 		submit: function (data) {
 			this.close();
-			if (!$.trim(data.username)) return;
-			app.user.rename(data.username);
+			app.user.rename(data.username, data.nextAction);
 		}
 	});
 
@@ -1067,7 +1076,7 @@
 			}
 
 			buf += '<p>If this is your account:</p>';
-			buf += '<p><label class="label">Username: <strong><input type="text" name="username" value="' + BattleLog.escapeHTML(data.username) + '" style="color:inherit;background:transparent;border:0;font:inherit;font-size:inherit;display:block" readonly autocomplete="username" /></strong></label></p>';
+			buf += '<p><label class="label">Username: <strong><input type="text" name="username" value="' + BattleLog.escapeHTML(data.username) + '" style="color:inherit;background:transparent;border:0;font:inherit;font-size:inherit;display:block" readonly autocomplete="username" /></strong></label>' + (data.nextAction ? '<input style="display:none" name="nextAction" value="' + data.nextAction + '">' : '') + '</p>';
 			if (data.special === '@gmail') {
 				buf += '<div id="gapi-custom-signin" style="width:240px;margin:0 auto">[loading Google log-in button]</div>';
 				buf += '<p class="buttonbar"><button name="close">Cancel</button></p>';
@@ -1113,12 +1122,13 @@
 			}
 		},
 		login: function () {
+			var nextAction = this.$('input[name=nextAction]').val();
 			this.close();
-			app.addPopup(LoginPopup);
+			app.addPopup(LoginPopup, {nextAction: nextAction});
 		},
 		submit: function (data) {
 			this.close();
-			app.user.passwordRename(data.username, data.password);
+			app.user.passwordRename(data.username, data.password, '', data.nextAction);
 		}
 	});
 

--- a/js/client.js
+++ b/js/client.js
@@ -237,7 +237,7 @@ function toId() {
 		 *   `login:noresponse`
 		 *     triggered if the login server did not return a response
 		 */
-		finishRename: function (name, assertion) {
+		finishRename: function (name, assertion, nextAction) {
 			if (assertion.slice(0, 14).toLowerCase() === '<!doctype html') {
 				// some sort of MitM proxy; ignore it
 				var endIndex = assertion.indexOf('>');
@@ -250,14 +250,16 @@ function toId() {
 				return;
 			}
 			if (assertion === ';') {
-				this.trigger('login:authrequired', name);
+				this.trigger('login:authrequired', name, '', nextAction);
 			} else if (assertion === ';;@gmail') {
-				this.trigger('login:authrequired', name, '@gmail');
+				this.trigger('login:authrequired', name, '@gmail', nextAction);
 			} else if (assertion.substr(0, 2) === ';;') {
-				this.trigger('login:invalidname', name, assertion.substr(2));
+				this.trigger('login:invalidname', name, assertion.substr(2), nextAction);
 			} else if (assertion.indexOf('\n') >= 0 || !assertion) {
 				app.addPopupMessage("Something is interfering with our connection to the login server.");
 			} else {
+				// login completed, transfer any queued action to app scope
+				app.nextAction = nextAction;
 				app.trigger('loggedin');
 				app.send('/trn ' + name + ',0,' + assertion);
 			}
@@ -270,7 +272,7 @@ function toId() {
 		 *
 		 * See `finishRename` above for a list of events this can emit.
 		 */
-		rename: function (name) {
+		rename: function (name, nextAction) {
 			// | , ; are not valid characters in names
 			name = name.replace(/[\|,;]+/g, '');
 			for (var i in this.replaceList) {
@@ -279,7 +281,7 @@ function toId() {
 			for (var i in this.normalizeList) {
 				name = name.replace(this.normalizeList[i], i);
 			}
-			var userid = toUserid(name);
+			var userid = $.trim(toUserid(name));
 			if (!userid) {
 				app.addPopupMessage("Usernames must contain at least one letter.");
 				return;
@@ -292,13 +294,13 @@ function toId() {
 					userid: userid,
 					challstr: this.challstr
 				}, function (data) {
-					self.finishRename(name, data);
+					self.finishRename(name, data, nextAction);
 				});
 			} else {
 				app.send('/trn ' + name);
 			}
 		},
-		passwordRename: function (name, password, special) {
+		passwordRename: function (name, password, special, nextAction) {
 			var self = this;
 			$.post(this.getActionPHP(), {
 				act: 'login',
@@ -309,7 +311,7 @@ function toId() {
 				if (data && data.curuser && data.curuser.loggedin) {
 					// success!
 					self.set('registered', data.curuser);
-					self.finishRename(name, data.assertion);
+					self.finishRename(name, data.assertion, nextAction);
 				} else {
 					// wrong password
 					if (special === '@gmail') {
@@ -320,7 +322,8 @@ function toId() {
 					app.addPopup(LoginPasswordPopup, {
 						username: name,
 						error: data.error || 'Wrong password.',
-						special: special
+						special: special,
+						nextAction: nextAction
 					});
 				}
 			}), 'text');
@@ -546,12 +549,20 @@ function toId() {
 				self.addPopup(ReconnectPopup, {cantconnect: true});
 			});
 
-			this.user.on('login:invalidname', function (name, reason) {
-				self.addPopup(LoginPopup, {name: name, reason: reason});
+			this.user.on('login:invalidname', function (name, reason, nextAction) {
+				self.addPopup(LoginPopup, {
+					name: name,
+					reason: reason,
+					nextAction: nextAction
+				});
 			});
 
-			this.user.on('login:authrequired', function (name, special) {
-				self.addPopup(LoginPasswordPopup, {username: name, special: special});
+			this.user.on('login:authrequired', function (name, special, nextAction) {
+				self.addPopup(LoginPasswordPopup, {
+					username: name,
+					special: special,
+					nextAction: nextAction
+				});
 			});
 
 			this.on('loggedin', function () {


### PR DESCRIPTION
I propose this general-purpose action queuing feature. The idea originates from the "battle -> choose name -> battle" flow.

When a non-named user clicks on the "Battle" button in the home, they are asked to choose a name (and log in, if the chosen name is registered). After choosing a name/logging in, they need to click the "Battle" button again to do what they originally wanted to do. Ideally, the action that generated the name choice request should be executed automatically once the user has chosen their name.

So, with this change, a general mechanism for action queuing is added - and currently applied to the "Battle" button in the home. The new behaviour is: after finishing the name choice/login flow, the pending action is executed automatically, with [no further clicks needed](https://github.com/smogon/pokemon-showdown/blob/master/CONTRIBUTING.md#d3-remove-unnecessary-clicks).