### PR TITLE
Overhaul the format selector to be more easily used

### DIFF
--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -1235,8 +1235,8 @@
 				// avoiding that decision for now because it requires either an ugly hack
 				// or an overhaul of BattleFormats.
 				this.open = Storage.prefs('openformats') || {
-					"S/V Singles": true, "S/V Doubles": true, "National Dex": true,
-					"OM of the Month": true, "Randomized Format Spotlight": true, "RoA Spotlight": true,
+					"S/V Singles": true, "S/V Doubles": true, "National Dex": true, "OM of the Month": true,
+					"Other Metagames": true, "Randomized Format Spotlight": true, "RoA Spotlight": true,
 				};
 			}
 			if (!this.search) this.search = "";

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -1281,7 +1281,7 @@
 					if (!bufs[curBuf]) {
 						bufs[curBuf] = '';
 					}
-					var open = (this.open[curSection] || this.search && this.search.length >= 3) ? ' open' : '';
+					var open = (this.open[curSection] || toID(this.search)) ? ' open' : '';
 					bufs[curBuf] += '<p><details' + open + ' section="' + curSection + '">';
 					bufs[curBuf] += '<summary><strong style="color: #579">';
 					bufs[curBuf] += BattleLog.escapeHTML(curSection) + '</strong></summary>';


### PR DESCRIPTION
This adds a search button to the format list, and collapses most of the section dropdowns by default (defaults were determined by US and hardcoded for now, since the panel will just cache which dropdowns users open/close).