### PR TITLE
Support more variable best-of challenges

### DIFF
--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -943,12 +943,12 @@
 			var teamIndex = $pmWindow.find('button[name=team]').val();
 			var privacy = this.adjustPrivacy($pmWindow.find('input[name=private]').is(':checked'));
 
-			var bestof = $pmWindow.find('input[name=bestof]').is(':checked');
-			var bestofvalue = $pmWindow.find('input[name=bestofvalue]').val();
-			if (bestof && bestofvalue) {
+			var bestOf = $pmWindow.find('input[name=bestof]').is(':checked');
+			var bestOfValue = $pmWindow.find('input[name=bestofvalue]').val();
+			if (bestOf && bestOfValue) {
 				var hasCustomRules = format.includes('@@@');
 				format += hasCustomRules ? ', ' : '@@@';
-				format += 'Best of = ' + bestofvalue;
+				format += 'Best of = ' + bestOfValue;
 			}
 
 			var team = null;

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -896,8 +896,9 @@
 			buf += '<p><label class="label">Format:</label>' + this.renderFormats(format) + '</p>';
 			buf += '<p><label class="label">Team:</label>' + this.renderTeams(format) + '</p>';
 			buf += '<p><label class="checkbox"><input type="checkbox" name="private" ' + (Storage.prefs('disallowspectators') ? 'checked' : '') + ' /> <abbr title="You can still invite spectators by giving them the URL or using the /invite command">Don\'t allow spectators</abbr></label></p>';
-			buf += '<p' + (!(format && format.includes('vgc')) ? ' class="hidden">' : '>');
-			buf += '<label class="checkbox"><input type="checkbox" name="bestof" /> <abbr title="Start a team-locked best-of-3 series">Best-of-3</abbr></label></p>';
+			var bestOfDefault = format ? BattleFormats[format].bestOfDefault : false;
+			buf += '<p' + (!bestOfDefault ? ' class="hidden">' : '>');
+			buf += '<label class="checkbox"><input type="checkbox" name="bestof" /> <abbr title="Start a team-locked best-of-n series">Best-of-<input name="bestofvalue" type="number" min="3" max="9" step="2" value="3" style="width: 28px; vertical-align: initial;"></abbr></label></p>';
 			buf += '<p class="buttonbar"><button name="makeChallenge"><strong>Challenge</strong></button> <button type="button" name="dismissChallenge">Cancel</button></p></form>';
 			$challenge.html(buf);
 		},
@@ -943,10 +944,11 @@
 			var privacy = this.adjustPrivacy($pmWindow.find('input[name=private]').is(':checked'));
 
 			var bestof = $pmWindow.find('input[name=bestof]').is(':checked');
-			var hasCustomRules = format.includes('@@@');
-			if (bestof) {
+			var bestofvalue = $pmWindow.find('input[name=bestofvalue]').val();
+			if (bestof && bestofvalue) {
+				var hasCustomRules = format.includes('@@@');
 				format += hasCustomRules ? ', ' : '@@@';
-				format += 'Best of = 3';
+				format += 'Best of = ' + bestofvalue;
 			}
 
 			var team = null;
@@ -1381,10 +1383,13 @@
 				if ($teamButton.length) $teamButton.replaceWith(app.rooms[''].renderTeams(format));
 
 				var $bestOfCheckbox = this.sourceEl.closest('form').find('input[name=bestof]');
-				if ($bestOfCheckbox) {
+				var $bestOfValueInput = this.sourceEl.closest('form').find('input[name=bestofvalue]');
+				if ($bestOfCheckbox && $bestOfValueInput) {
 					var $parentTag = $bestOfCheckbox.parent().parent();
-					if (format.includes('vgc')) {
+					var bestOfDefault = BattleFormats[format].bestOfDefault;
+					if (bestOfDefault) {
 						$parentTag.removeClass('hidden');
+						$bestOfValueInput.val(3);
 					} else {
 						$parentTag.addClass('hidden');
 						$bestOfCheckbox.prop('checked', false);

--- a/js/client.js
+++ b/js/client.js
@@ -1328,6 +1328,7 @@ function toId() {
 					var challengeShow = true;
 					var tournamentShow = true;
 					var partner = false;
+					var bestOfDefault = false;
 					var team = null;
 					var teambuilderLevel = null;
 					var lastCommaIndex = name.lastIndexOf(',');
@@ -1340,6 +1341,7 @@ function toId() {
 						if (!(code & 8)) tournamentShow = false;
 						if (code & 16) teambuilderLevel = 50;
 						if (code & 32) partner = true;
+						if (code & 64) bestOfDefault = true;
 					} else {
 						// Backwards compatibility: late 0.9.0 -> 0.10.0
 						if (name.substr(name.length - 2) === ',#') { // preset teams
@@ -1403,6 +1405,7 @@ function toId() {
 						searchShow: searchShow,
 						challengeShow: challengeShow,
 						tournamentShow: tournamentShow,
+						bestOfDefault: bestOfDefault,
 						rated: searchShow && id.substr(4, 7) !== 'unrated',
 						teambuilderLevel: teambuilderLevel,
 						partner: partner,


### PR DESCRIPTION
Right now, the checkbox used for team-locked best-of-3 play is limited to VGC formats. This change allows the server's format list to determine which formats have the checkbox by default. This was initially requested by side servers, but also fixes a very minor bug of team-locked bo3 challenges showing up for Gen 4 VGC, where you weren't team-locked (you could move around items in between a best-of-three and change team order). I'm sure we'll eventually have a non-VGC format that wants best-of-n support on main as well.

It also allows the challenger to select any of the supported best-of-n options, rather than exclusively being best-of-3.
![image](https://github.com/smogon/pokemon-showdown-client/assets/23667022/fbbc9566-228d-46fd-ade2-2db1b9e41f01)

I'm not super sure about the policy of inline CSS; it's needed for the number input. I can move it to a proper CSS file if desired.