### PR TITLE
Change footer to fixed positioning

### DIFF
--- a/style/client.css
+++ b/style/client.css
@@ -944,7 +944,7 @@ p.or:after {
 	min-height: 100%;
 }
 .mainmenufooter {
-	position: absolute;
+	position: fixed;
 	bottom: 15px;
 	left: 20px;
 	color: #BBBBBB;


### PR DESCRIPTION
When you have a lot of PM windows open, the footer now probably stays put when you scroll through them.