### PR TITLE
Design refresh

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -276,10 +276,18 @@
 					// spectator
 					if (this.battle.paused) {
 						// paused
-						this.$controls.html('<p><button class="button" name="resume"><i class="fa fa-play"></i><br />Play</button> <button class="button button-first" name="rewindTurn"><i class="fa fa-step-backward"></i><br />Last turn</button><button class="button button-last" name="skipTurn"><i class="fa fa-step-forward"></i><br />Skip turn</button> <button class="button button-first" name="instantReplay"><i class="fa fa-undo"></i><br />First turn</button><button class="button button-last" name="goToEnd"><i class="fa fa-fast-forward"></i><br />Skip to end</button></p>' + switchViewpointButton);
+						this.$controls.html(
+							'<p><button class="button" style="min-width:4.5em;margin-right:3px" name="resume"><i class="fa fa-play"></i><br />Play</button> ' +
+							'<button class="button button-first" name="instantReplay"><i class="fa fa-undo"></i><br />First turn</button><button class="button button-first" style="margin-left:1px" name="rewindTurn"><i class="fa fa-step-backward"></i><br />Prev turn</button><button class="button button-last" style="margin-right:2px" name="skipTurn"><i class="fa fa-step-forward"></i><br />Skip turn</button><button class="button button-last" name="goToEnd"><i class="fa fa-fast-forward"></i><br />Skip to end</button></p>' +
+							switchViewpointButton
+						);
 					} else {
 						// playing
-						this.$controls.html('<p><button class="button" name="pause"><i class="fa fa-pause"></i><br />Pause</button> <button class="button button-first" name="rewindTurn"><i class="fa fa-step-backward"></i><br />Last turn</button><button class="button button-last" name="skipTurn"><i class="fa fa-step-forward"></i><br />Skip turn</button> <button class="button button-first" name="instantReplay"><i class="fa fa-undo"></i><br />First turn</button><button class="button button-last" name="goToEnd"><i class="fa fa-fast-forward"></i><br />Skip to end</button></p>' + switchViewpointButton);
+						this.$controls.html(
+							'<p><button class="button" style="min-width:4.5em;margin-right:3px" name="pause"><i class="fa fa-pause"></i><br />Pause</button> ' +
+							'<button class="button button-first" name="instantReplay"><i class="fa fa-undo"></i><br />First turn</button><button class="button button-first" style="margin-left:1px" name="rewindTurn"><i class="fa fa-step-backward"></i><br />Prev turn</button><button class="button button-last" style="margin-right:2px" name="skipTurn"><i class="fa fa-step-forward"></i><br />Skip turn</button><button class="button button-last" name="goToEnd"><i class="fa fa-fast-forward"></i><br />Skip to end</button></p>' +
+							switchViewpointButton
+						);
 					}
 				} else {
 					// is a player
@@ -323,10 +331,18 @@
 				// full battle
 				if (this.battle.paused) {
 					// paused
-					this.$controls.html('<p><button class="button" name="resume"><i class="fa fa-play"></i><br />Play</button> <button class="button" name="rewindTurn"><i class="fa fa-step-backward"></i><br />Last turn</button><button class="button disabled" disabled><i class="fa fa-step-forward"></i><br />Skip turn</button> <button class="button" name="instantReplay"><i class="fa fa-undo"></i><br />First turn</button><button class="button disabled" disabled><i class="fa fa-fast-forward"></i><br />Skip to end</button></p>' + switchViewpointButton + '<p><em>Waiting for players...</em></p>');
+					this.$controls.html(
+						'<p><button class="button" style="min-width:4.5em;margin-right:3px" name="resume"><i class="fa fa-play"></i><br />Play</button> ' +
+						'<button class="button button-first" name="instantReplay"><i class="fa fa-undo"></i><br />First turn</button><button class="button button-first" style="margin-left:1px" name="rewindTurn"><i class="fa fa-step-backward"></i><br />Prev turn</button><button class="button button-last disabled" style="margin-right:2px" disabled><i class="fa fa-step-forward"></i><br />Skip turn</button><button class="button button-last disabled" disabled><i class="fa fa-fast-forward"></i><br />Skip to end</button></p>' +
+						switchViewpointButton + '<p><em>Waiting for players...</em></p>'
+					);
 				} else {
 					// playing
-					this.$controls.html('<p><button class="button" name="pause"><i class="fa fa-pause"></i><br />Pause</button> <button class="button" name="rewindTurn"><i class="fa fa-step-backward"></i><br />Last turn</button><button class="button disabled" disabled><i class="fa fa-step-forward"></i><br />Skip turn</button> <button class="button" name="instantReplay"><i class="fa fa-undo"></i><br />First turn</button><button class="button disabled" disabled><i class="fa fa-fast-forward"></i><br />Skip to end</button></p>' + switchViewpointButton + '<p><em>Waiting for players...</em></p>');
+					this.$controls.html(
+						'<p><button class="button" style="min-width:4.5em;margin-right:3px" name="pause"><i class="fa fa-pause"></i><br />Pause</button> ' +
+						'<button class="button button-first" name="instantReplay"><i class="fa fa-undo"></i><br />First turn</button><button class="button button-first" style="margin-left:1px" name="rewindTurn"><i class="fa fa-step-backward"></i><br />Prev turn</button><button class="button button-last disabled" style="margin-right:2px" disabled><i class="fa fa-step-forward"></i><br />Skip turn</button><button class="button button-last disabled" disabled><i class="fa fa-fast-forward"></i><br />Skip to end</button></p>' +
+						switchViewpointButton + '<p><em>Waiting for players...</em></p>'
+					);
 				}
 
 			}
@@ -1530,7 +1546,7 @@
 			this.room = data.room;
 			var rightPanelBattlesPossible = (MainMenuRoom.prototype.bestWidth + BattleRoom.prototype.minWidth < $(window).width());
 			var buf = '<p><strong>In this battle</strong></p>';
-			buf += '<p><label class="checkbox"><input type="checkbox" name="hardcoremode"' + (this.battle.hardcoreMode ? ' checked' : '') + '/> Hardcore mode (hide info not shown in-game) (beta)</label></p>';
+			buf += '<p><label class="checkbox"><input type="checkbox" name="hardcoremode"' + (this.battle.hardcoreMode ? ' checked' : '') + '/> Hardcore mode (hide info not shown in-game)</label></p>';
 			buf += '<p><label class="checkbox"><input type="checkbox" name="ignorespects"' + (this.battle.ignoreSpects ? ' checked' : '') + '/> Ignore spectators</label></p>';
 			buf += '<p><label class="checkbox"><input type="checkbox" name="ignoreopp"' + (this.battle.ignoreOpponent ? ' checked' : '') + '/> Ignore opponent</label></p>';
 			buf += '<p><strong>All battles</strong></p>';

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -614,7 +614,7 @@
 					}
 
 					if (disabled) {
-						targetMenus[0] += '<button disabled="disabled"></button> ';
+						targetMenus[0] += '<button disabled></button> ';
 					} else if (!pokemon || pokemon.fainted) {
 						targetMenus[0] += '<button name="chooseMoveTarget" value="' + (i + 1) + '"><span class="picon" style="' + Dex.getPokemonIcon('missingno') + '"></span></button> ';
 					} else {
@@ -634,7 +634,7 @@
 					if (moveTarget !== 'adjacentAllyOrSelf' && activePos == i) disabled = true;
 
 					if (disabled) {
-						targetMenus[1] += '<button disabled="disabled" style="visibility:hidden"></button> ';
+						targetMenus[1] += '<button disabled style="visibility:hidden"></button> ';
 					} else if (!pokemon || pokemon.fainted) {
 						targetMenus[1] += '<button name="chooseMoveTarget" value="' + (-(i + 1)) + '"><span class="picon" style="' + Dex.getPokemonIcon('missingno') + '"></span></button> ';
 					} else {
@@ -672,7 +672,7 @@
 					var moveType = this.tooltips.getMoveType(move, typeValueTracker)[0];
 					var tooltipArgs = 'move|' + moveData.move + '|' + pos;
 					if (moveData.disabled) {
-						movebuttons += '<button disabled="disabled" class="has-tooltip" data-tooltip="' + BattleLog.escapeHTML(tooltipArgs) + '">';
+						movebuttons += '<button disabled class="has-tooltip" data-tooltip="' + BattleLog.escapeHTML(tooltipArgs) + '">';
 					} else {
 						movebuttons += '<button class="type-' + moveType + ' has-tooltip" name="chooseMove" value="' + (i + 1) + '" data-move="' + BattleLog.escapeHTML(moveData.move) + '" data-target="' + BattleLog.escapeHTML(moveData.target) + '" data-tooltip="' + BattleLog.escapeHTML(tooltipArgs) + '">';
 						hasMoves = true;
@@ -712,7 +712,7 @@
 								}
 								movebuttons += specialMove.name + '<br /><small class="type">' + (moveType ? Dex.types.get(moveType).name : "Unknown") + '</small> <small class="pp">' + pp + '</small>&nbsp;</button> ';
 							} else {
-								movebuttons += '<button disabled="disabled">&nbsp;</button>';
+								movebuttons += '<button disabled>&nbsp;</button>';
 							}
 						}
 						if (!currentlyDynamaxed) movebuttons += '</div>';
@@ -910,7 +910,7 @@
 				var pokemon = switchables[oIndex];
 				var tooltipArgs = 'switchpokemon|' + oIndex;
 				if (i < this.choice.done) {
-					switchMenu += '<button disabled="disabled" class="has-tooltip" data-tooltip="' + BattleLog.escapeHTML(tooltipArgs) + '"><span class="picon" style="' + Dex.getPokemonIcon(pokemon) + '"></span>' + BattleLog.escapeHTML(pokemon.name) + '</button> ';
+					switchMenu += '<button disabled class="has-tooltip" data-tooltip="' + BattleLog.escapeHTML(tooltipArgs) + '"><span class="picon" style="' + Dex.getPokemonIcon(pokemon) + '"></span>' + BattleLog.escapeHTML(pokemon.name) + '</button> ';
 				} else {
 					switchMenu += '<button name="chooseTeamPreview" value="' + i + '" class="has-tooltip" data-tooltip="' + BattleLog.escapeHTML(tooltipArgs) + '"><span class="picon" style="' + Dex.getPokemonIcon(pokemon) + '"></span>' + BattleLog.escapeHTML(pokemon.name) + '</button> ';
 				}

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -260,7 +260,7 @@
 		updateControls: function () {
 			if (this.battle.scene.customControls) return;
 			var controlsShown = this.controlsShown;
-			var switchSidesButton = '<p><button class="button" name="switchViewpoint"><i class="fa fa-random"></i> Switch sides</button></p>';
+			var switchViewpointButton = '<p><button class="button" name="switchViewpoint"><i class="fa fa-random"></i> Switch viewpoint</button></p>';
 			this.controlsShown = false;
 
 			if (this.battle.seeking !== null) {
@@ -276,10 +276,10 @@
 					// spectator
 					if (this.battle.paused) {
 						// paused
-						this.$controls.html('<p><button class="button" name="resume"><i class="fa fa-play"></i><br />Play</button> <button class="button" name="rewindTurn"><i class="fa fa-step-backward"></i><br />Last turn</button><button class="button" name="skipTurn"><i class="fa fa-step-forward"></i><br />Skip turn</button> <button class="button" name="instantReplay"><i class="fa fa-undo"></i><br />First turn</button><button class="button" name="goToEnd"><i class="fa fa-fast-forward"></i><br />Skip to end</button></p>' + switchSidesButton);
+						this.$controls.html('<p><button class="button" name="resume"><i class="fa fa-play"></i><br />Play</button> <button class="button button-first" name="rewindTurn"><i class="fa fa-step-backward"></i><br />Last turn</button><button class="button button-last" name="skipTurn"><i class="fa fa-step-forward"></i><br />Skip turn</button> <button class="button button-first" name="instantReplay"><i class="fa fa-undo"></i><br />First turn</button><button class="button button-last" name="goToEnd"><i class="fa fa-fast-forward"></i><br />Skip to end</button></p>' + switchViewpointButton);
 					} else {
 						// playing
-						this.$controls.html('<p><button class="button" name="pause"><i class="fa fa-pause"></i><br />Pause</button> <button class="button" name="rewindTurn"><i class="fa fa-step-backward"></i><br />Last turn</button><button class="button" name="skipTurn"><i class="fa fa-step-forward"></i><br />Skip turn</button> <button class="button" name="instantReplay"><i class="fa fa-undo"></i><br />First turn</button><button class="button" name="goToEnd"><i class="fa fa-fast-forward"></i><br />Skip to end</button></p>' + switchSidesButton);
+						this.$controls.html('<p><button class="button" name="pause"><i class="fa fa-pause"></i><br />Pause</button> <button class="button button-first" name="rewindTurn"><i class="fa fa-step-backward"></i><br />Last turn</button><button class="button button-last" name="skipTurn"><i class="fa fa-step-forward"></i><br />Skip turn</button> <button class="button button-first" name="instantReplay"><i class="fa fa-undo"></i><br />First turn</button><button class="button button-last" name="goToEnd"><i class="fa fa-fast-forward"></i><br />Skip to end</button></p>' + switchViewpointButton);
 					}
 				} else {
 					// is a player
@@ -299,7 +299,7 @@
 					this.closeNotification('choice');
 					this.$controls.html('<div class="controls"><p>' + replayDownloadButton + '<button class="button" name="instantReplay"><i class="fa fa-undo"></i><br />Instant replay</button></p><p><button class="button" name="closeAndMainMenu"><strong>Main menu</strong><br /><small>(closes this battle)</small></button> <button class="button" name="closeAndRematch"><strong>Rematch</strong><br /><small>(closes this battle)</small></button></p></div>');
 				} else {
-					this.$controls.html('<div class="controls"><p>' + replayDownloadButton + '<button class="button" name="instantReplay"><i class="fa fa-undo"></i><br />Instant replay</button></p>' + switchSidesButton + '</div>');
+					this.$controls.html('<div class="controls"><p>' + replayDownloadButton + '<button class="button" name="instantReplay"><i class="fa fa-undo"></i><br />Instant replay</button></p>' + switchViewpointButton + '</div>');
 				}
 
 			} else if (this.side) {
@@ -323,10 +323,10 @@
 				// full battle
 				if (this.battle.paused) {
 					// paused
-					this.$controls.html('<p><button class="button" name="resume"><i class="fa fa-play"></i><br />Play</button> <button class="button" name="rewindTurn"><i class="fa fa-step-backward"></i><br />Last turn</button><button class="button disabled" disabled><i class="fa fa-step-forward"></i><br />Skip turn</button> <button class="button" name="instantReplay"><i class="fa fa-undo"></i><br />First turn</button><button class="button disabled" disabled><i class="fa fa-fast-forward"></i><br />Skip to end</button></p>' + switchSidesButton + '<p><em>Waiting for players...</em></p>');
+					this.$controls.html('<p><button class="button" name="resume"><i class="fa fa-play"></i><br />Play</button> <button class="button" name="rewindTurn"><i class="fa fa-step-backward"></i><br />Last turn</button><button class="button disabled" disabled><i class="fa fa-step-forward"></i><br />Skip turn</button> <button class="button" name="instantReplay"><i class="fa fa-undo"></i><br />First turn</button><button class="button disabled" disabled><i class="fa fa-fast-forward"></i><br />Skip to end</button></p>' + switchViewpointButton + '<p><em>Waiting for players...</em></p>');
 				} else {
 					// playing
-					this.$controls.html('<p><button class="button" name="pause"><i class="fa fa-pause"></i><br />Pause</button> <button class="button" name="rewindTurn"><i class="fa fa-step-backward"></i><br />Last turn</button><button class="button disabled" disabled><i class="fa fa-step-forward"></i><br />Skip turn</button> <button class="button" name="instantReplay"><i class="fa fa-undo"></i><br />First turn</button><button class="button disabled" disabled><i class="fa fa-fast-forward"></i><br />Skip to end</button></p>' + switchSidesButton + '<p><em>Waiting for players...</em></p>');
+					this.$controls.html('<p><button class="button" name="pause"><i class="fa fa-pause"></i><br />Pause</button> <button class="button" name="rewindTurn"><i class="fa fa-step-backward"></i><br />Last turn</button><button class="button disabled" disabled><i class="fa fa-step-forward"></i><br />Skip turn</button> <button class="button" name="instantReplay"><i class="fa fa-undo"></i><br />First turn</button><button class="button disabled" disabled><i class="fa fa-fast-forward"></i><br />Skip to end</button></p>' + switchViewpointButton + '<p><em>Waiting for players...</em></p>');
 				}
 
 			}
@@ -1486,17 +1486,17 @@
 			}
 			if (this.gameType === 'help') {
 				buf += ' Are you sure?</p><p><label><input type="checkbox" name="closeroom" checked /> Close room</label></p>';
-				buf += '<p><button type="submit"><strong>Close ticket</strong></button> ';
+				buf += '<p><button type="submit" class="button"><strong>Close ticket</strong></button> ';
 			} else if (this.gameType === 'room') {
-				buf += ' </p><p><button type="leaveRoom" name="leaveRoom"><strong>Close room</strong></button>';
+				buf += ' </p><p><button type="submit" name="leaveRoom" class="button"><strong>Close room</strong></button>';
 			} else {
-				buf += ' Are you sure?</p><p><label><input type="checkbox" name="closeroom" checked /> Close after forfeiting</label></p>';
-				buf += '<p><button type="submit"><strong>Forfeit</strong></button> ';
+				buf += ' Are you sure?</p><p><label class="checkbox"><input type="checkbox" name="closeroom" checked /> Close after forfeiting</label></p>';
+				buf += '<p><button type="submit" class="button"><strong>Forfeit</strong></button> ';
 			}
 			if (this.gameType === 'battle' && this.room.battle && !this.room.battle.rated) {
-				buf += '<button type="button" name="replacePlayer">Replace player</button> ';
+				buf += '<button type="button" name="replacePlayer" class="button">Replace player</button> ';
 			}
-			buf += '<button type="button" name="close" class="autofocus">Cancel</button></p></form>';
+			buf += '<button type="button" name="close" class="autofocus" class="button">Cancel</button></p></form>';
 			this.$el.html(buf);
 		},
 		replacePlayer: function (data) {
@@ -1530,16 +1530,16 @@
 			this.room = data.room;
 			var rightPanelBattlesPossible = (MainMenuRoom.prototype.bestWidth + BattleRoom.prototype.minWidth < $(window).width());
 			var buf = '<p><strong>In this battle</strong></p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="hardcoremode"' + (this.battle.hardcoreMode ? ' checked' : '') + '/> Hardcore mode (hide info not shown in-game) (beta)</label></p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="ignorespects"' + (this.battle.ignoreSpects ? ' checked' : '') + '/> Ignore spectators</label></p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="ignoreopp"' + (this.battle.ignoreOpponent ? ' checked' : '') + '/> Ignore opponent</label></p>';
+			buf += '<p><label class="checkbox"><input type="checkbox" name="hardcoremode"' + (this.battle.hardcoreMode ? ' checked' : '') + '/> Hardcore mode (hide info not shown in-game) (beta)</label></p>';
+			buf += '<p><label class="checkbox"><input type="checkbox" name="ignorespects"' + (this.battle.ignoreSpects ? ' checked' : '') + '/> Ignore spectators</label></p>';
+			buf += '<p><label class="checkbox"><input type="checkbox" name="ignoreopp"' + (this.battle.ignoreOpponent ? ' checked' : '') + '/> Ignore opponent</label></p>';
 			buf += '<p><strong>All battles</strong></p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="ignorenicks"' + (Dex.prefs('ignorenicks') ? ' checked' : '') + ' /> Ignore nicknames</label></p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="allignorespects"' + (Dex.prefs('ignorespects') ? ' checked' : '') + '/> Ignore spectators</label></p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="allignoreopp"' + (Dex.prefs('ignoreopp') ? ' checked' : '') + '/> Ignore opponent</label></p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="autotimer"' + (Dex.prefs('autotimer') ? ' checked' : '') + '/> Automatically start timer</label></p>';
-			if (rightPanelBattlesPossible) buf += '<p><label class="optlabel"><input type="checkbox" name="rightpanelbattles"' + (Dex.prefs('rightpanelbattles') ? ' checked' : '') + ' /> Open new battles on the right side</label></p>';
-			buf += '<p><button name="close">Close</button></p>';
+			buf += '<p><label class="checkbox"><input type="checkbox" name="ignorenicks"' + (Dex.prefs('ignorenicks') ? ' checked' : '') + ' /> Ignore nicknames</label></p>';
+			buf += '<p><label class="checkbox"><input type="checkbox" name="allignorespects"' + (Dex.prefs('ignorespects') ? ' checked' : '') + '/> Ignore spectators</label></p>';
+			buf += '<p><label class="checkbox"><input type="checkbox" name="allignoreopp"' + (Dex.prefs('ignoreopp') ? ' checked' : '') + '/> Ignore opponent</label></p>';
+			buf += '<p><label class="checkbox"><input type="checkbox" name="autotimer"' + (Dex.prefs('autotimer') ? ' checked' : '') + '/> Automatically start timer</label></p>';
+			if (rightPanelBattlesPossible) buf += '<p><label class="checkbox"><input type="checkbox" name="rightpanelbattles"' + (Dex.prefs('rightpanelbattles') ? ' checked' : '') + ' /> Open new battles on the right side</label></p>';
+			buf += '<p><button name="close" class="button">Done</button></p>';
 			this.$el.html(buf);
 		},
 		events: {

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -33,7 +33,7 @@
 				this.$chatAdd.html('Connecting...');
 				this.$chatbox = null;
 			} else if (!app.user.get('named')) {
-				this.$chatAdd.html('<form><button name="login">Join chat</button></form>');
+				this.$chatAdd.html('<form><button name="login" class="button">Join chat</button></form>');
 				this.$chatbox = null;
 			} else {
 				var color = app.user.get('away') ? 'color:#888;' : BattleLog.hashColor(app.user.get('userid'));

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -1260,7 +1260,7 @@
 			var bufs = [];
 			var curBuf = 0;
 			if (this.selectType === 'watch' && !this.search) {
-				bufs[1] = '<li><button name="selectFormat" value="" class="option' + (curFormat === '' ? ' sel' : '') + '">(All formats)</button></li>';
+				bufs[1] = '<li><button name="selectFormat" value="" class="option' + (curFormat === '' ? ' cur' : '') + '">(All formats)</button></li>';
 			}
 
 			for (var i in this.starred) {
@@ -1278,7 +1278,7 @@
 				var formatName = BattleLog.escapeFormat(BattleFormats[i].id);
 				bufs[1] += (
 					'<li><button name="selectFormat" value="' + i +
-					'" class="option' + (curFormat === i ? ' sel' : '') + '">' + formatName +
+					'" class="option' + (curFormat === i ? ' cur' : '') + '">' + formatName +
 					'<i class="fa fa-star" style="float: right; color: #FFD700; text-shadow: 0 0 1px #000;"></i></button></li>'
 				);
 			}
@@ -1314,7 +1314,7 @@
 				formatName = formatName.replace('[Gen 7 ', '[');
 				bufs[curBuf] += (
 					'<li><button name="selectFormat" value="' + i +
-					'" class="option' + (curFormat === i ? ' sel' : '') + '">' + formatName +
+					'" class="option' + (curFormat === i ? ' cur' : '') + '">' + formatName +
 					'<i class="fa fa-star subtle" style="float: right;"></i></button></li>'
 				);
 			}
@@ -1507,7 +1507,7 @@
 								if ((!teams[i].format && !teamFormat) || teams[i].format === teamFormat) {
 									var selected = (i === curTeam);
 									if (teams[i].folder === "") {
-										bufs[curBuf] += '<li><button name="selectTeam" value="' + i + '" class="option' + (selected ? ' sel' : '') + '">' + BattleLog.escapeHTML(teams[i].name) + '</button></li>';
+										bufs[curBuf] += '<li><button name="selectTeam" value="' + i + '" class="option' + (selected ? ' cur' : '') + '">' + BattleLog.escapeHTML(teams[i].name) + '</button></li>';
 										count++;
 										if (count % bufBoundary === 0 && curBuf < 4) curBuf++;
 									}
@@ -1527,7 +1527,7 @@
 					for (var i = 0; i < teams.length; i++) {
 						if (teamFormat && teams[i].format === teamFormat) continue;
 						var selected = (i === curTeam);
-						bufs[curBuf] += '<li><button name="selectTeam" value="' + i + '" class="option' + (selected ? ' sel' : '') + '">' + BattleLog.escapeHTML(teams[i].name) + '</button></li>';
+						bufs[curBuf] += '<li><button name="selectTeam" value="' + i + '" class="option' + (selected ? ' cur' : '') + '">' + BattleLog.escapeHTML(teams[i].name) + '</button></li>';
 						count++;
 						if (count % bufBoundary === 0 && curBuf < 4) curBuf++;
 					}

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -1260,7 +1260,7 @@
 			var bufs = [];
 			var curBuf = 0;
 			if (this.selectType === 'watch' && !this.search) {
-				bufs[1] = '<li><button name="selectFormat" value=""' + (curFormat === '' ? ' class="sel"' : '') + '>(All formats)</button></li>';
+				bufs[1] = '<li><button name="selectFormat" value="" class="option' + (curFormat === '' ? ' sel' : '') + '">(All formats)</button></li>';
 			}
 
 			for (var i in this.starred) {
@@ -1278,7 +1278,7 @@
 				var formatName = BattleLog.escapeFormat(BattleFormats[i].id);
 				bufs[1] += (
 					'<li><button name="selectFormat" value="' + i +
-					'"' + (curFormat === i ? ' class="sel"' : '') + '>' + formatName +
+					'" class="option' + (curFormat === i ? ' sel' : '') + '">' + formatName +
 					'<i class="fa fa-star" style="float: right; color: #FFD700; text-shadow: 0 0 1px #000;"></i></button></li>'
 				);
 			}
@@ -1314,7 +1314,7 @@
 				formatName = formatName.replace('[Gen 7 ', '[');
 				bufs[curBuf] += (
 					'<li><button name="selectFormat" value="' + i +
-					'"' + (curFormat === i ? ' class="sel"' : '') + '>' + formatName +
+					'" class="option' + (curFormat === i ? ' sel' : '') + '">' + formatName +
 					'<i class="fa fa-star subtle" style="float: right;"></i></button></li>'
 				);
 			}
@@ -1448,7 +1448,7 @@
 						if ((!teams[i].format && !teamFormat) || teams[i].format === teamFormat) {
 							var selected = (i === curTeam);
 							if (!this.folderToggleOn) {
-								bufs[curBuf] += '<li><button name="selectTeam" value="' + i + '"' + (selected ? ' class="sel"' : '') + '>' + BattleLog.escapeHTML(teams[i].name) + '</button></li>';
+								bufs[curBuf] += '<li><button name="selectTeam" value="' + i + '" class="option' + (selected ? 'sel' : '') + '">' + BattleLog.escapeHTML(teams[i].name) + '</button></li>';
 								count++;
 								if (count % bufBoundary === 0 && curBuf < 4) curBuf++;
 							} else {
@@ -1473,7 +1473,7 @@
 								}
 							}
 							if (!exists) {
-								bufs[curBuf] += '<li><button name="selectFolder" class="folderButtonOpen folderButtonOver" value="' + key + '"><i class="fa fa-folder-open" style="margin-right: 7px; margin-left: 4px;"></i>' + BattleLog.escapeHTML(key) + '</button></li>';
+								bufs[curBuf] += '<li><button name="selectFolder" class="button" value="' + key + '"><i class="fa fa-folder-open" style="margin-right: 7px; margin-left: 4px;"></i>' + BattleLog.escapeHTML(key) + '</button></li>';
 								count++;
 								if (count % bufBoundary === 0 && curBuf < 4) curBuf++;
 								for (var j = 0; j < folderData.length; j++) {
@@ -1483,7 +1483,7 @@
 									if (count % bufBoundary === 0 && curBuf < 4) curBuf++;
 								}
 							} else {
-								bufs[curBuf] += '<li><button name="selectFolder" class="folderButton" value="' + key + '"><i class="fa fa-folder" style="margin-right: 7px; margin-left: 4px;"></i>' + BattleLog.escapeHTML(key) + '</button></li>';
+								bufs[curBuf] += '<li><button name="selectFolder" class="button" value="' + key + '"><i class="fa fa-folder" style="margin-right: 7px; margin-left: 4px;"></i>' + BattleLog.escapeHTML(key) + '</button></li>';
 								count++;
 								if (count % bufBoundary === 0 && curBuf < 4) curBuf++;
 							}
@@ -1496,19 +1496,18 @@
 							}
 						}
 						if (!isNoFolder) {
-							bufs[curBuf] += '<li><button name="selectFolder" class="folderButtonOpen folderButtonOver" value="(No Folder)"><i class="fa fa-folder-open" style="margin-right: 7px; margin-left: 4px;"></i>(No Folder)</button></li>';
+							bufs[curBuf] += '<li><button name="selectFolder" class="button" value="(No Folder)"><i class="fa fa-folder-open" style="margin-right: 7px; margin-left: 4px;"></i>(No Folder)</button></li>';
 						} else {
-							bufs[curBuf] += '<li><button name="selectFolder" class="folderButton" value="(No Folder)"><i class="fa fa-folder" style="margin-right: 7px; margin-left: 4px;"></i>(No Folder)</button></li>';
+							bufs[curBuf] += '<li><button name="selectFolder" class="button" value="(No Folder)"><i class="fa fa-folder" style="margin-right: 7px; margin-left: 4px;"></i>(No Folder)</button></li>';
 							count++;
 							if (count % bufBoundary === 0 && count != 0 && curBuf < 4) curBuf++;
 						}
-						console.log(teamFormat);
 						if (!isNoFolder) {
 							for (var i = 0; i < teams.length; i++) {
 								if ((!teams[i].format && !teamFormat) || teams[i].format === teamFormat) {
 									var selected = (i === curTeam);
 									if (teams[i].folder === "") {
-										bufs[curBuf] += '<li><button name="selectTeam" value="' + i + '"' + (selected ? ' class="sel"' : '') + '>' + BattleLog.escapeHTML(teams[i].name) + '</button></li>';
+										bufs[curBuf] += '<li><button name="selectTeam" value="' + i + '" class="option' + (selected ? ' sel' : '') + '">' + BattleLog.escapeHTML(teams[i].name) + '</button></li>';
 										count++;
 										if (count % bufBoundary === 0 && curBuf < 4) curBuf++;
 									}
@@ -1528,7 +1527,7 @@
 					for (var i = 0; i < teams.length; i++) {
 						if (teamFormat && teams[i].format === teamFormat) continue;
 						var selected = (i === curTeam);
-						bufs[curBuf] += '<li><button name="selectTeam" value="' + i + '"' + (selected ? ' class="sel"' : '') + '>' + BattleLog.escapeHTML(teams[i].name) + '</button></li>';
+						bufs[curBuf] += '<li><button name="selectTeam" value="' + i + '" class="option' + (selected ? ' sel' : '') + '">' + BattleLog.escapeHTML(teams[i].name) + '</button></li>';
 						count++;
 						if (count % bufBoundary === 0 && curBuf < 4) curBuf++;
 					}

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -262,7 +262,7 @@
 				if (formatName) {
 					buf += '<p><label class="label">' + (teamFormat ? 'Format' : 'Game') + ':</label>' + this.renderFormats(formatName, true) + '</p>';
 				}
-				buf += '<p class="buttonbar"><button name="cancelChallenge">Cancel</button></p></form>';
+				buf += '<p class="buttonbar"><button name="cancelChallenge" class="button">Cancel</button></p></form>';
 				$challenge.html(buf);
 				return;
 			}
@@ -277,7 +277,7 @@
 				buf += '<p><label class="label">Team:</label>' + this.renderTeams(teamFormat) + '</p>';
 				buf += '<p><label class="checkbox"><input type="checkbox" name="private" ' + (Storage.prefs('disallowspectators') ? 'checked' : '') + ' /> <abbr title="You can still invite spectators by giving them the URL or using the /invite command">Don\'t allow spectators</abbr></label></p>';
 			}
-			buf += '<p class="buttonbar"><button name="acceptChallenge"><strong>' + BattleLog.escapeHTML(acceptButtonLabel) + '</strong></button> <button type="button" name="rejectChallenge">' + BattleLog.escapeHTML(rejectButtonLabel) + '</button></p></form>';
+			buf += '<p class="buttonbar"><button name="acceptChallenge" class="button"><strong>' + BattleLog.escapeHTML(acceptButtonLabel) + '</strong></button> <button type="button" name="rejectChallenge" class="button">' + BattleLog.escapeHTML(rejectButtonLabel) + '</button></p></form>';
 			$challenge.html(buf);
 		},
 
@@ -736,7 +736,7 @@
 					buf += '<div><a href="/' + toRoomid(roomid) + '" class="ilink" style="text-align: center">' + BattleLog.escapeHTML(name) + '</a></div>';
 				}
 				buf += '</div>';
-				if (!$searchGroup.is(':visible')) buf += '<p class="buttonbar"><button name="showSearchGroup">Add game</button></p>';
+				if (!$searchGroup.is(':visible')) buf += '<p class="buttonbar"><button name="showSearchGroup" class="button">Add game</button></p>';
 				buf += '</form>';
 				this.$gamesGroup.html(buf);
 			} else {
@@ -772,7 +772,7 @@
 
 				var buf = '<form class="battleform"><p>Waiting for ' + BattleLog.escapeHTML(name) + '...</p>';
 				buf += '<p><label class="label">Format:</label>' + this.renderFormats(challenge.format, true) + '</p>';
-				buf += '<p class="buttonbar"><button name="cancelChallenge">Cancel</button></p></form>';
+				buf += '<p class="buttonbar"><button name="cancelChallenge" class="button">Cancel</button></p></form>';
 
 				$challenge.html(buf);
 				if (challenge.format.substr(0, 4) === 'gen5') atLeastOneGen5 = true;
@@ -796,7 +796,7 @@
 						buf += '<p><label class="label">Format:</label>' + self.renderFormats(format, true) + '</p>';
 						buf += '<p><label class="label">Team:</label>' + self.renderTeams(format) + '</p>';
 						buf += '<p><label class="checkbox"><input type="checkbox" name="private" ' + (Storage.prefs('disallowspectators') ? 'checked' : '') + ' /> <abbr title="You can still invite spectators by giving them the URL or using the /invite command">Don\'t allow spectators</abbr></label></p>';
-						buf += '<p class="buttonbar"><button name="acceptChallenge"><strong>Accept</strong></button> <button type="button" name="rejectChallenge">Reject</button></p></form>';
+						buf += '<p class="buttonbar"><button name="acceptChallenge" class="button"><strong>Accept</strong></button> <button type="button" name="rejectChallenge" class="button">Reject</button></p></form>';
 						$challenge.html(buf);
 						if (format.substr(0, 4) === 'gen5') atLeastOneGen5 = true;
 					}
@@ -810,7 +810,7 @@
 								$challenge.remove();
 							} else {
 								// Someone was challenging you, but cancelled their challenge
-								$challenge.html('<form class="battleform"><p>The challenge was cancelled.</p><p class="buttonbar"><button name="dismissChallenge">OK</button></p></form>');
+								$challenge.html('<form class="battleform"><p>The challenge was cancelled.</p><p class="buttonbar"><button name="dismissChallenge" class="button">OK</button></p></form>');
 							}
 						} else if ($challenge.find('button[name=cancelChallenge]').length && challengeToUserid !== userid) {
 							// You were challenging someone else, and they either accepted
@@ -840,7 +840,7 @@
 				var $searchForm = $('.mainmenu button.big').closest('form');
 				$searchForm.find('button.big').html('<em>Disconnected</em>').addClass('disabled');
 				$searchForm.find('.mainmenu p.cancel').remove();
-				$searchForm.append('<p class="cancel buttonbar"><button name="reconnect">Reconnect</button></p>');
+				$searchForm.append('<p class="cancel buttonbar"><button name="reconnect" class="button">Reconnect</button></p>');
 				this.$('button.onlineonly').addClass('disabled');
 				return;
 			}
@@ -899,7 +899,7 @@
 			var bestOfDefault = format && BattleFormats[format] ? BattleFormats[format].bestOfDefault : false;
 			buf += '<p' + (!bestOfDefault ? ' class="hidden">' : '>');
 			buf += '<label class="checkbox"><input type="checkbox" name="bestof" /> <abbr title="Start a team-locked best-of-n series">Best-of-<input name="bestofvalue" type="number" min="3" max="9" step="2" value="3" style="width: 28px; vertical-align: initial;"></abbr></label></p>';
-			buf += '<p class="buttonbar"><button name="makeChallenge"><strong>Challenge</strong></button> <button type="button" name="dismissChallenge">Cancel</button></p></form>';
+			buf += '<p class="buttonbar"><button name="makeChallenge" class="button"><strong>Challenge</strong></button> <button type="button" name="dismissChallenge" class="button">Cancel</button></p></form>';
 			$challenge.html(buf);
 		},
 		acceptChallenge: function (i, target) {
@@ -962,7 +962,7 @@
 
 			var buf = '<form class="battleform pending"><p>Challenging ' + BattleLog.escapeHTML(name) + '...</p>';
 			buf += '<p><label class="label">Format:</label>' + this.renderFormats(format, true) + '</p>';
-			buf += '<p class="buttonbar"><button name="cancelChallenge">Cancel</button></p></form>';
+			buf += '<p class="buttonbar"><button name="cancelChallenge" class="button">Cancel</button></p></form>';
 
 			$(target).closest('.challenge').html(buf);
 			app.sendTeam(team, function () {
@@ -1105,7 +1105,7 @@
 			$formatButton.addClass('preselected')[0].disabled = true;
 			$teamButton.addClass('preselected')[0].disabled = true;
 			$searchForm.find('button.big').html('<strong><i class="fa fa-refresh fa-spin"></i> Connecting...</strong>').addClass('disabled');
-			$searchForm.append('<p class="cancel buttonbar"><button name="cancelSearch">Cancel</button></p>');
+			$searchForm.append('<p class="cancel buttonbar"><button name="cancelSearch" class="button">Cancel</button></p>');
 
 			var self = this;
 			app.sendTeam(team, function () {
@@ -1176,7 +1176,7 @@
 				var roomid = toRoomid(target);
 				return [
 					'<div class="chat">' + timestamp + '<em>' + clickableName + ' invited you to join the room "' + roomid + '"</em></div>',
-					'<div class="notice"><button name="joinRoom" value="' + roomid + '">Join ' + roomid + '</button></div>'
+					'<div class="notice"><button name="joinRoom" value="' + roomid + '" class="button">Join ' + roomid + '</button></div>'
 				];
 			case 'announce':
 				return '<div class="chat chatmessage-' + toID(name) + hlClass + mineClass + '">' + timestamp + '<strong style="' + color + '">' + clickableName + ':</strong> <span class="message-announce">' + BattleLog.parseMessage(target) + '</span></div>';
@@ -1248,8 +1248,7 @@
 			this.selectType = data.selectType;
 			if (!this.selectType) this.selectType = (this.sourceEl.closest('form').data('search') ? 'search' : 'challenge');
 
-
-			var html = '<p><ul class="popupmenu"><li><input name="search" placeholder="Search formats" value="' + this.search + '"/>';
+			var html = '<p><ul class="popupmenu"><li><input name="search" placeholder="Search formats" value="' + this.search + '" class="textbox" />';
 			html += '</li></ul></p><span name="formats">';
 			html += this.renderFormats();
 			html += '</span><div style="clear:left"></div><p></p>';

--- a/js/client-rooms.js
+++ b/js/client-rooms.js
@@ -96,11 +96,11 @@
 
 		renderRoomBtn: function (roomData) {
 			var id = toID(roomData.title);
-			var buf = '<div><a href="' + app.root + id + '" class="ilink"><small style="float:right">(' + Number(roomData.userCount) + ' users)</small><strong><i class="fa fa-comment-o"></i> ' + BattleLog.escapeHTML(roomData.title) + '<br /></strong><small>' + BattleLog.escapeHTML(roomData.desc || '') + '</small></a>';
+			var buf = '<div><a href="' + app.root + id + '" class="blocklink"><small style="float:right">(' + Number(roomData.userCount) + ' users)</small><strong><i class="fa fa-comment-o"></i> ' + BattleLog.escapeHTML(roomData.title) + '<br /></strong><small>' + BattleLog.escapeHTML(roomData.desc || '') + '</small></a>';
 			if (roomData.subRooms && roomData.subRooms.length) {
 				buf += '<div class="subrooms"><i class="fa fa-level-up fa-rotate-90"></i> Subrooms:';
 				for (var i = 0; i < roomData.subRooms.length; i++) {
-					buf += ' <a class="ilink" href="' + app.root + toID(roomData.subRooms[i]) + '"><i class="fa fa-comment-o"></i> <strong>' + BattleLog.escapeHTML(roomData.subRooms[i]) + '</strong></a>';
+					buf += ' <a class="blocklink" href="' + app.root + toID(roomData.subRooms[i]) + '"><i class="fa fa-comment-o"></i> <strong>' + BattleLog.escapeHTML(roomData.subRooms[i]) + '</strong></a>';
 				}
 				buf += '</div>';
 			}
@@ -280,7 +280,7 @@
 			} else if (!roomData.p2) {
 				roomDesc = formatBuf + '<em class="p1">' + BattleLog.escapeHTML(roomData.p1) + '</em>';
 			}
-			return '<div><a href="' + app.root + id + '" class="ilink">' + roomDesc + '</a></div>';
+			return '<div><a href="' + app.root + id + '" class="blocklink">' + roomDesc + '</a></div>';
 		},
 		submitSearch: function (e) {
 			e.preventDefault();

--- a/js/client-rooms.js
+++ b/js/client-rooms.js
@@ -14,7 +14,7 @@
 
 			this.$el.addClass('ps-room-light').addClass('scrollable');
 			var buf = '<div class="pad"><button class="button" style="float:right;font-size:10pt;margin-top:3px" name="closeHide"><i class="fa fa-caret-right"></i> Hide</button>';
-			buf += '<div class="roomlisttop"></div><p>Rooms filter: <select name="sections"><option value="all">(All rooms)</option></select></p>';
+			buf += '<div class="roomlisttop"></div><p><select name="sections" class="button"><option value="all">(All rooms)</option></select></p>';
 			buf += '<div class="roomlist"><p><em style="font-size:20pt">Loading...</em></p></div><div class="roomlist"></div>';
 			buf += '<p><button name="toggleMoreRooms" class="button">Show more rooms</button><p>';
 			buf += '<p><button name="joinRoomPopup" class="button">Join other room</button></p></div>';
@@ -224,7 +224,7 @@
 			var buf = '<div class="pad"><button class="button" style="float:right;font-size:10pt;margin-top:3px" name="close"><i class="fa fa-times"></i> Close</button><div class="roomlist"><p><button class="button" name="refresh"><i class="fa fa-refresh"></i> Refresh</button> <span style="' + Dex.getPokemonIcon('meloetta-pirouette') + ';display:inline-block;vertical-align:middle" class="picon" title="Meloetta is PS\'s mascot! The Pirouette forme is Fighting-type, and represents our battles."></span></p>';
 
 			buf += '<p><label class="label">Format:</label><button class="select formatselect" name="selectFormat">(All formats)</button></p>';
-			buf += '<label>Minimum Elo: <select name="elofilter"><option value="none">None</option><option value="1100">1100</option><option value="1300">1300</option><option value="1500">1500</option><option value="1700">1700</option><option value="1900">1900</option></select></label>';
+			buf += '<label>Minimum Elo: <select name="elofilter" class="button"><option value="none">None</option><option value="1100">1100</option><option value="1300">1300</option><option value="1500">1500</option><option value="1700">1700</option><option value="1900">1900</option></select></label>';
 			buf += '<p><form class="search"><input type="text" name="prefixsearch" class="textbox" value="' + BattleLog.escapeHTML(this.usernamePrefix) + '" placeholder="username prefix"/><button type="submit" class="button">Search</button></form></p>';
 			buf += '<div class="list"><p>Loading...</p></div>';
 			buf += '</div></div>';

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -189,10 +189,10 @@
 
 			if (this.exportMode) {
 				if (this.curFolder) {
-					buf = '<div class="pad"><button name="back"><i class="fa fa-chevron-left"></i> List</button></div>';
+					buf = '<div class="pad"><button name="back" class="button"><i class="fa fa-chevron-left"></i> List</button></div>';
 					buf += '<div class="teamedit"><textarea readonly class="textbox" rows="17">' + BattleLog.escapeHTML(Storage.exportFolder(this.curFolder)) + '</textarea></div>';
 				} else {
-					buf = '<div class="pad"><button name="back"><i class="fa fa-chevron-left"></i> List</button> <button name="saveBackup" class="savebutton"><i class="fa fa-floppy-o"></i> Save</button></div>';
+					buf = '<div class="pad"><button name="back" class="button"><i class="fa fa-chevron-left"></i> List</button> <button name="saveBackup" class="savebutton button"><i class="fa fa-floppy-o"></i> Save</button></div>';
 					buf += '<div class="teamedit"><textarea class="textbox" rows="17">';
 					if (Storage.teams.length > 350) {
 						buf += BattleLog.escapeHTML(Storage.getPackedTeams());
@@ -3538,23 +3538,21 @@
 			}
 
 			var buf = '';
-			buf += '<p>Pick a variant or <button name="close">Cancel</button></p>';
+			buf += '<p>Pick a variant or <button name="close" class="button">Cancel</button></p>';
 			buf += '<div class="formlist">';
 
 			var formCount = forms.length;
 			for (var i = 0; i < formCount; i++) {
 				var formid = forms[i].substring(baseid.length);
 				var form = (formid ? formid[0].toUpperCase() + formid.slice(1) : '');
-				var offset = '-' + (((i - 1) % 7) * spriteSize) + 'px -' + (Math.floor((i - 1) / 7) * spriteSize) + 'px';
-				buf += '<button name="setForm" value="' + form + '"  style="';
-				buf += 'background-position:' + offset + '; background: url(' + spriteDir + '/' + baseid + (form ? '-' + formid : '') + '.png) no-repeat; ' + spriteDim + '"';
-				buf += (form === species.form || (form === '' && !species.form) ? ' class="cur"' : '') + '></button>';
+				buf += '<button name="setForm" value="' + form + '" style="';
+				buf += 'background-image: url(' + spriteDir + '/' + baseid + (form ? '-' + formid : '') + '.png); ' + spriteDim + '" class="option';
+				buf += (form === (species.forme || '') ? ' cur' : '') + '"></button>';
 			}
+			buf += '<div style="clear:both"></div>';
 			buf += '</div>';
 
-			var height = Math.ceil(formCount / 7);
-			var width = Math.ceil(formCount / height);
-			this.$el.html(buf).css({'max-width': (4 + spriteSize) * width, 'height': 42 + (4 + spriteSize) * height});
+			this.$el.html(buf).css({'max-width': (4 + spriteSize) * 7});
 		},
 		setForm: function (form) {
 			var species = Dex.species.get(this.curSet.species);

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -1221,15 +1221,15 @@
 				buf += '<input type="hidden" name="paste" id="pasteData">';
 				buf += '<input type="hidden" name="author" id="pasteAuthor">';
 				buf += '<input type="hidden" name="notes" id="pasteNotes">';
-				buf += '<button name="psExport" type="submit" class="button exportbutton"> <i class="fa fa-upload"></i> Upload to Showdown database (saves across devices)</button>';
+				buf += '<p><button name="psExport" type="submit" class="button exportbutton"> <i class="fa fa-upload"></i> Upload to Showdown database (saves across devices)</button>';
 				var privacy = (Storage.prefs('uploadprivacy') || typeof Storage.prefs('uploadprivacy') !== 'boolean') ? 'checked' : '';
-				buf += ' <small>(Private:</small> <input type="checkbox" name="teamprivacy" ' + privacy + ' /><small>)</small>';
-				buf += '<br />';
-				buf += '<button name="pokepasteExport" type="submit" class="button exportbutton"><i class="fa fa-upload"></i> Upload to PokePaste</button></form>';
+				buf += ' <label><small>(Private:</small> <input type="checkbox" name="teamprivacy" ' + privacy + ' /><small>)</small></label>';
+				buf += '</p>';
+				buf += '<p><button name="pokepasteExport" type="submit" class="button exportbutton"><i class="fa fa-upload"></i> Upload to PokePaste</button></p>';
 				if (this.curTeam.format.includes('vgc')) {
-					buf += '<button name="pokepasteExport" value="openteamsheet" type="submit" class="button exportbutton"><i class="fa fa-upload"></i> Upload to PokePaste (Open Team Sheet)</button></form>';
+					buf += '<p><button name="pokepasteExport" value="openteamsheet" type="submit" class="button exportbutton"><i class="fa fa-upload"></i> Upload to PokePaste (Open Team Sheet)</button></p>';
 				}
-				buf += '</div>';
+				buf += '</form></div>';
 			}
 			this.$el.html('<div class="teamwrapper">' + buf + '</div>');
 			this.$(".teamedit textarea").focus().select();
@@ -1906,10 +1906,10 @@
 				var set = this.curSetList[i];
 				var pokemonicon = '<span class="picon pokemonicon-' + i + '" style="' + Dex.getPokemonIcon(set) + '"></span>';
 				if (!set.species) {
-					buf += '<button disabled="disabled" class="addpokemon" aria-label="Add Pok&eacute;mon"><i class="fa fa-plus"></i></button> ';
+					buf += '<button disabled class="addpokemon" aria-label="Add Pok&eacute;mon"><i class="fa fa-plus"></i></button> ';
 					isAdd = true;
 				} else if (i == this.curSetLoc) {
-					buf += '<button disabled="disabled" class="pokemon">' + pokemonicon + BattleLog.escapeHTML(set.name || this.curTeam.dex.species.get(set.species).baseSpecies || '<i class="fa fa-plus"></i>') + '</button> ';
+					buf += '<button disabled class="pokemon">' + pokemonicon + BattleLog.escapeHTML(set.name || this.curTeam.dex.species.get(set.species).baseSpecies || '<i class="fa fa-plus"></i>') + '</button> ';
 				} else {
 					buf += '<button name="selectPokemon" value="' + i + '" class="pokemon">' + pokemonicon + BattleLog.escapeHTML(set.name || this.curTeam.dex.species.get(set.species).baseSpecies) + '</button> ';
 				}
@@ -2176,7 +2176,7 @@
 			if (role === '?') {
 				buf += ' (Please choose 4 moves to get a guessed spread) (<a target="_blank" href="' + this.smogdexLink(species) + '">Smogon&nbsp;analysis</a>)</small></p>';
 			} else {
-				buf += ' </small><button name="setStatFormGuesses">' + role + ': ';
+				buf += ' </small><button name="setStatFormGuesses" class="button">' + role + ': ';
 				for (var i in BattleStatNames) {
 					if (guessedEVs[i]) {
 						var statName = this.curTeam.gen === 1 && i === 'spa' ? 'Spc' : BattleStatNames[i];
@@ -2331,7 +2331,7 @@
 					case 'fighting':
 						hpIVs = ['001000', '110000', '100000']; break;
 					}
-					buf += '<div style="margin-left:-80px;text-align:right"><select name="ivspread">';
+					buf += '<div style="margin-left:-80px;text-align:right"><select name="ivspread" class="button">';
 					buf += '<option value="" selected>HP ' + hpType.charAt(0).toUpperCase() + hpType.slice(1) + ' IVs</option>';
 
 					var minStat = this.curTeam.gen >= 6 ? 0 : 2;
@@ -2379,7 +2379,7 @@
 
 					buf += '</select></div>';
 				} else {
-					buf += '<div style="margin-left:-80px;text-align:right"><select name="ivspread">';
+					buf += '<div style="margin-left:-80px;text-align:right"><select name="ivspread" class="button">';
 					buf += '<option value="" selected>IV spreads</option>';
 
 					buf += '<optgroup label="min Atk">';
@@ -2416,7 +2416,7 @@
 			buf += '</div>';
 
 			if (this.curTeam.gen > 2) {
-				buf += '<p style="clear:both">Nature: <select name="nature">';
+				buf += '<p style="clear:both">Nature: <select name="nature" class="button">';
 				for (var i in BattleNatures) {
 					var curNature = BattleNatures[i];
 					buf += '<option value="' + i + '"' + (curNature === nature ? 'selected="selected"' : '') + '>' + i;
@@ -2427,7 +2427,7 @@
 				}
 				buf += '</select></p>';
 
-				buf += '<p><em>Protip:</em> You can also set natures by typing "+" and "-" next to a stat.</p>';
+				buf += '<p><em>Protip:</em> You can also set natures by typing <kbd>+</kbd> and <kbd>-</kbd> next to a stat.</p>';
 			}
 
 			buf += '</div>';
@@ -2698,12 +2698,12 @@
 					var genderTable = {'M': "Male", 'F': "Female", 'N': "Genderless"};
 					buf += genderTable[species.gender];
 				} else {
-					buf += '<label><input type="radio" name="gender" value="M"' + (set.gender === 'M' ? ' checked' : '') + ' /> Male</label> ';
-					buf += '<label><input type="radio" name="gender" value="F"' + (set.gender === 'F' ? ' checked' : '') + ' /> Female</label> ';
+					buf += '<label class="checkbox inline"><input type="radio" name="gender" value="M"' + (set.gender === 'M' ? ' checked' : '') + ' /> Male</label> ';
+					buf += '<label class="checkbox inline"><input type="radio" name="gender" value="F"' + (set.gender === 'F' ? ' checked' : '') + ' /> Female</label> ';
 					if (!isHackmons) {
-						buf += '<label><input type="radio" name="gender" value="N"' + (!set.gender ? ' checked' : '') + ' /> Random</label>';
+						buf += '<label class="checkbox inline"><input type="radio" name="gender" value="N"' + (!set.gender ? ' checked' : '') + ' /> Random</label>';
 					} else {
-						buf += '<label><input type="radio" name="gender" value="N"' + (set.gender === 'N' ? ' checked' : '') + ' /> Genderless</label>';
+						buf += '<label class="checkbox inline"><input type="radio" name="gender" value="N"' + (set.gender === 'N' ? ' checked' : '') + ' /> Genderless</label>';
 					}
 				}
 				buf += '</div></div>';
@@ -2715,8 +2715,8 @@
 				}
 
 				buf += '<div class="formrow"><label class="formlabel">Shiny:</label><div>';
-				buf += '<label><input type="radio" name="shiny" value="yes"' + (set.shiny ? ' checked' : '') + ' /> Yes</label> ';
-				buf += '<label><input type="radio" name="shiny" value="no"' + (!set.shiny ? ' checked' : '') + ' /> No</label>';
+				buf += '<label class="checkbox inline"><input type="radio" name="shiny" value="yes"' + (set.shiny ? ' checked' : '') + ' /> Yes</label> ';
+				buf += '<label class="checkbox inline"><input type="radio" name="shiny" value="no"' + (!set.shiny ? ' checked' : '') + ' /> No</label>';
 				buf += '</div></div>';
 
 				if (this.curTeam.gen === 8 && !isBDSP) {
@@ -2728,8 +2728,8 @@
 						if (species.forme === 'Gmax') {
 							buf += 'Yes';
 						} else {
-							buf += '<label><input type="radio" name="gigantamax" value="yes"' + (set.gigantamax ? ' checked' : '') + ' /> Yes</label> ';
-							buf += '<label><input type="radio" name="gigantamax" value="no"' + (!set.gigantamax ? ' checked' : '') + ' /> No</label>';
+							buf += '<label class="checkbox inline"><input type="radio" name="gigantamax" value="yes"' + (set.gigantamax ? ' checked' : '') + ' /> Yes</label> ';
+							buf += '<label class="checkbox inline"><input type="radio" name="gigantamax" value="no"' + (!set.gigantamax ? ' checked' : '') + ' /> No</label>';
 						}
 						buf += '</div></div>';
 					}
@@ -2737,7 +2737,7 @@
 			}
 
 			if (this.curTeam.gen > 2) {
-				buf += '<div class="formrow" style="display:none"><label class="formlabel">Pokeball:</label><div><select name="pokeball">';
+				buf += '<div class="formrow" style="display:none"><label class="formlabel">Pokeball:</label><div><select name="pokeball" class="button">';
 				buf += '<option value=""' + (!set.pokeball ? ' selected="selected"' : '') + '></option>'; // unset
 				var balls = this.curTeam.dex.getPokeballs();
 				for (var i = 0; i < balls.length; i++) {
@@ -2747,7 +2747,7 @@
 			}
 
 			if (!isLetsGo && (this.curTeam.gen === 7 || isNatDex || (isBDSP && species.baseSpecies === 'Unown'))) {
-				buf += '<div class="formrow"><label class="formlabel" title="Hidden Power Type">Hidden Power:</label><div><select name="hptype">';
+				buf += '<div class="formrow"><label class="formlabel" title="Hidden Power Type">Hidden Power:</label><div><select name="hptype" class="button">';
 				buf += '<option value=""' + (!set.hpType ? ' selected="selected"' : '') + '>(automatic type)</option>'; // unset
 				var types = Dex.types.all();
 				for (var i = 0; i < types.length; i++) {
@@ -2763,7 +2763,7 @@
 				if (species.forceTeraType) {
 					buf += species.forceTeraType;
 				} else {
-					buf += '<select name="teratype">';
+					buf += '<select name="teratype" class="button">';
 					var types = Dex.types.all();
 					var teraType = set.teraType || species.types[0];
 					for (var i = 0; i < types.length; i++) {
@@ -2776,7 +2776,7 @@
 
 			buf += '</form>';
 			if (species.cosmeticFormes) {
-				buf += '<button class="altform">Change sprite</button>';
+				buf += '<button class="altform button">Change sprite</button>';
 			}
 
 			this.$chart.html(buf);
@@ -3470,12 +3470,12 @@
 			for (var i = 0; i < data.team.length; i++) {
 				var set = data.team[i];
 				if (i !== data.i && i !== data.i + 1) {
-					buf += '<li><button name="moveHere" value="' + i + '"><i class="fa fa-arrow-right"></i> Move here</button></li>';
+					buf += '<li><button name="moveHere" value="' + i + '" class="option"><i class="fa fa-arrow-right"></i> Move here</button></li>';
 				}
 				buf += '<li' + (i === data.i ? ' style="opacity:.3"' : ' style="opacity:.6"') + '><span class="picon" style="display:inline-block;vertical-align:middle;' + Dex.getPokemonIcon(set) + '"></span> ' + BattleLog.escapeHTML(set.name || set.species) + '</li>';
 			}
 			if (i !== data.i && i !== data.i + 1) {
-				buf += '<li><button name="moveHere" value="' + i + '"><i class="fa fa-arrow-right"></i> Move here</button></li>';
+				buf += '<li><button name="moveHere" value="' + i + '" class="option"><i class="fa fa-arrow-right"></i> Move here</button></li>';
 			}
 			buf += '</ul>';
 			this.$el.html(buf);

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -1169,12 +1169,12 @@
 
 			var buf = '';
 			if (this.exportMode) {
-				buf = '<div class="pad"><button name="back"><i class="fa fa-chevron-left"></i> List</button> <input class="textbox teamnameedit" type="text" class="teamnameedit" size="30" value="' + BattleLog.escapeHTML(this.curTeam.name) + '" /> <button name="saveImport"><i class="fa fa-upload"></i> Import/Export</button> <button name="saveImport" class="savebutton"><i class="fa fa-floppy-o"></i> Save</button></div>';
+				buf = '<div class="pad"><button name="back" class="button"><i class="fa fa-chevron-left"></i> List</button> <input class="textbox teamnameedit" type="text" class="teamnameedit" size="30" value="' + BattleLog.escapeHTML(this.curTeam.name) + '" /> <button name="saveImport" class="button"><i class="fa fa-upload"></i> Import/Export</button> <button name="saveImport" class="savebutton button"><i class="fa fa-floppy-o"></i> Save</button></div>';
 				buf += '<div class="teamedit"><textarea class="textbox" rows="17">' + BattleLog.escapeHTML(Storage.exportTeam(this.curSetList, this.curTeam.gen)) + '</textarea></div>';
 			} else {
-				buf = '<div class="pad"><button name="back"><i class="fa fa-chevron-left"></i> List</button> ';
+				buf = '<div class="pad"><button name="back" class="button"><i class="fa fa-chevron-left"></i> List</button> ';
 				buf += '<input class="textbox teamnameedit" type="text" class="teamnameedit" size="30" value="' + BattleLog.escapeHTML(this.curTeam.name) + '" /> ';
-				buf += '<button name="import"><i class="fa fa-upload"></i> Import/Export</button> ';
+				buf += '<button name="import" class="button"><i class="fa fa-upload"></i> Import/Export</button> ';
 				buf += '<div class="teamchartbox">';
 				buf += '<ol class="teamchart">';
 				buf += '<li>' + this.clipboardHTML() + '</li>';
@@ -1846,7 +1846,7 @@
 		updateSetView: function () {
 			// pokemon
 			var buf = '<div class="pad">';
-			buf += '<button name="back"><i class="fa fa-chevron-left"></i> Team</button></div>';
+			buf += '<button name="back" class="button"><i class="fa fa-chevron-left"></i> Team</button></div>';
 			buf += '<div class="teambar">';
 			buf += this.renderTeambar();
 			buf += '</div>';
@@ -1864,7 +1864,7 @@
 
 			// import/export
 			buf += '<div class="teambuilder-pokemon-import">';
-			buf += '<div class="pokemonedit-buttons"><button name="closePokemonImport"><i class="fa fa-chevron-left"></i> Back</button> <button name="savePokemonImport"><i class="fa fa-floppy-o"></i> Save</button></div>';
+			buf += '<div class="pokemonedit-buttons"><button name="closePokemonImport" class="button"><i class="fa fa-chevron-left"></i> Back</button> <button name="savePokemonImport" class="button"><i class="fa fa-floppy-o"></i> Save</button></div>';
 			buf += '<textarea class="pokemonedit textbox" rows="14"></textarea>';
 			buf += '<div class="teambuilder-import-smogon-sets"></div>';
 			buf += '</div>';

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -34,11 +34,11 @@
 			var status = app.user.get('status');
 			var color = away ? 'color:#888;' : BattleLog.hashColor(app.user.get('userid'));
 			if (!app.user.loaded) {
-				buf = '<button disabled>Loading...</button>';
+				buf = '<button disabled class="button disabled">Loading...</button>';
 			} else if (app.user.get('named')) {
 				buf = '<span class="username" data-name="' + BattleLog.escapeHTML(name) + '"' + (away ? ' data-away="true"' : '') + (status ? 'data-status="' + BattleLog.escapeHTML(status) + '"' : '') + ' style="' + color + '"><i class="fa fa-user" style="color:' + (away ? '#888;' : '#779EC5') + '"></i> <span class="usernametext">' + BattleLog.escapeHTML(name) + '</span></span>';
 			} else {
-				buf = '<button name="login">Choose name</button>';
+				buf = '<button name="login" class="button">Choose name</button>';
 			}
 			buf += ' <button class="icon button" name="openSounds" title="Sound" aria-label="Sound"><i class="' + (Dex.prefs('mute') ? 'fa fa-volume-off' : 'fa fa-volume-up') + '"></i></button> <button class="icon button" name="openOptions" title="Options" aria-label="Options"><i class="fa fa-cog"></i></button>';
 			this.$userbar.html(buf);
@@ -378,7 +378,7 @@
 			buf += '<p class="effect-volume"><label class="optlabel">Effect volume:</label>' + (muted ? '<em>(muted)</em>' : '<input type="range" min="0" max="100" step="1" name="effectvolume" value="' + this.getEffectVolume() + '" />') + '</p>';
 			buf += '<p class="music-volume"><label class="optlabel">Music volume:</label>' + (muted ? '<em>(muted)</em>' : '<input type="range" min="0" max="100" step="1" name="musicvolume" value="' + this.getMusicVolume() + '" />') + '</p>';
 			buf += '<p class="notif-volume"><label class="optlabel">Notification volume:</label>' + (muted ? '<em>(muted)</em>' : '<input type="range" min="0" max="100" step="1" name="notifvolume" value="' + this.getNotifVolume() + '" />') + '</p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="muted"' + (muted ? ' checked' : '') + ' /> Mute sounds</label></p>';
+			buf += '<p><label class="checkbox"><input type="checkbox" name="muted"' + (muted ? ' checked' : '') + ' /> Mute sounds</label></p>';
 			this.$el.html(buf).css('min-width', 160);
 		},
 		events: {
@@ -478,13 +478,13 @@
 
 			var buf = '';
 			buf += '<p>' + (avatar ? '<img class="trainersprite" src="' + Dex.resolveAvatar(avatar) + '" width="40" height="40" style="vertical-align:middle;cursor:pointer" />' : '') + '<strong>' + BattleLog.escapeHTML(name) + '</strong></p>';
-			buf += '<p><button name="avatars">Change avatar</button></p>';
+			buf += '<p><button class="button" name="avatars">Avatar...</button></p>';
 			if (app.user.get('named')) {
 				var registered = app.user.get('registered');
 				if (registered && (registered.userid === app.user.get('userid'))) {
-					buf += '<p><button name="changepassword">Password change</button></p>';
+					buf += '<p><button class="button" name="changepassword">Password...</button></p>';
 				} else {
-					buf += '<p><button name="register">Register</button></p>';
+					buf += '<p><button class="button" name="register">Register</button></p>';
 				}
 			}
 
@@ -492,37 +492,37 @@
 			buf += '<p><strong>Graphics</strong></p>';
 			var theme = Dex.prefs('theme');
 			var colorSchemeQuerySupported = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').media !== 'not all';
-			buf += '<p><label class="optlabel">Theme: <select name="theme"><option value="light"' + (!theme || theme === 'light' ? ' selected="selected"' : '') + '>Light</option><option value="dark"' + (theme === 'dark' ? ' selected="selected"' : '') + '>Dark</option>';
+			buf += '<p><label class="optlabel">Theme: <select name="theme" class="button"><option value="light"' + (!theme || theme === 'light' ? ' selected="selected"' : '') + '>Light</option><option value="dark"' + (theme === 'dark' ? ' selected="selected"' : '') + '>Dark</option>';
 			if (colorSchemeQuerySupported) {
 				buf += '<option value="system"' + (theme === 'system' ? ' selected="selected"' : '') + '>Match system theme</option>';
 			}
 			buf += '</select></label></p>';
 			var onePanel = !!Dex.prefs('onepanel');
 			if ($(window).width() >= 660) {
-				buf += '<p><label class="optlabel">Layout: <select name="onepanel"><option value=""' + (!onePanel ? ' selected="selected"' : '') + '>&#x25EB; Left and right panels</option><option value="1"' + (onePanel ? ' selected="selected"' : '') + '>&#x25FB; Single panel</option></select></label></p>';
+				buf += '<p><label class="optlabel">Layout: <select name="onepanel" class="button"><option value=""' + (!onePanel ? ' selected="selected"' : '') + '>&#x25EB; Left and right panels</option><option value="1"' + (onePanel ? ' selected="selected"' : '') + '>&#x25FB; Single panel</option></select></label></p>';
 			}
-			buf += '<p><label class="optlabel">Background: <button name="background">Change background</button></label></p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="noanim"' + (Dex.prefs('noanim') ? ' checked' : '') + ' /> Disable animations</label></p>';
+			buf += '<p><label class="optlabel">Background: <button class="button" name="background">Change background</button></label></p>';
+			buf += '<p><label class="checkbox"><input type="checkbox" name="noanim"' + (Dex.prefs('noanim') ? ' checked' : '') + ' /> Disable animations</label></p>';
 			if (navigator.userAgent.includes(' Chrome/64.')) {
-				buf += '<p><label class="optlabel"><input type="checkbox" name="nogif"' + (Dex.prefs('nogif') ? ' checked' : '') + ' /> Disable GIFs for Chrome 64 bug</label></p>';
+				buf += '<p><label class="checkbox"><input type="checkbox" name="nogif"' + (Dex.prefs('nogif') ? ' checked' : '') + ' /> Disable GIFs for Chrome 64 bug</label></p>';
 			}
-			buf += '<p><label class="optlabel"><input type="checkbox" name="bwgfx"' + (Dex.prefs('bwgfx') ? ' checked' : '') + ' /> Use BW sprites instead of XY models</label></p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="nopastgens"' + (Dex.prefs('nopastgens') ? ' checked' : '') + ' /> Use modern sprites for past generations</label></p>';
+			buf += '<p><label class="checkbox"><input type="checkbox" name="bwgfx"' + (Dex.prefs('bwgfx') ? ' checked' : '') + ' /> Use BW sprites instead of XY models</label></p>';
+			buf += '<p><label class="checkbox"><input type="checkbox" name="nopastgens"' + (Dex.prefs('nopastgens') ? ' checked' : '') + ' /> Use modern sprites for past generations</label></p>';
 
 			buf += '<hr />';
 			buf += '<p><strong>Chat</strong></p>';
 			if (Object.keys(settings).length) {
-				buf += '<p><label class="optlabel"><input type="checkbox" name="blockpms"' + (settings.blockPMs ? ' checked' : '') + ' /> Block PMs</label></p>';
-				buf += '<p><label class="optlabel"><input type="checkbox" name="blockchallenges"' + (settings.blockChallenges ? ' checked' : '') + ' /> Block Challenges</label></p>';
+				buf += '<p><label class="checkbox"><input type="checkbox" name="blockpms"' + (settings.blockPMs ? ' checked' : '') + ' /> Block PMs</label></p>';
+				buf += '<p><label class="checkbox"><input type="checkbox" name="blockchallenges"' + (settings.blockChallenges ? ' checked' : '') + ' /> Block Challenges</label></p>';
 			}
-			buf += '<p><label class="optlabel"><input type="checkbox" name="inchatpm"' + (Dex.prefs('inchatpm') ? ' checked' : '') + ' /> Show PMs in chat rooms</label></p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="selfhighlight"' + (!Dex.prefs('noselfhighlight') ? ' checked' : '') + '> Highlight when your name is said in chat</label></p>';
+			buf += '<p><label class="checkbox"><input type="checkbox" name="inchatpm"' + (Dex.prefs('inchatpm') ? ' checked' : '') + ' /> Show PMs in chat rooms</label></p>';
+			buf += '<p><label class="checkbox"><input type="checkbox" name="selfhighlight"' + (!Dex.prefs('noselfhighlight') ? ' checked' : '') + '> Highlight when your name is said in chat</label></p>';
 
 			if (window.Notification) {
-				buf += '<p><label class="optlabel"><input type="checkbox" name="temporarynotifications"' + (Dex.prefs('temporarynotifications') ? ' checked' : '') + ' /> Notifications disappear automatically</label></p>';
+				buf += '<p><label class="checkbox"><input type="checkbox" name="temporarynotifications"' + (Dex.prefs('temporarynotifications') ? ' checked' : '') + ' /> Notifications disappear automatically</label></p>';
 			}
-			buf += '<p><label class="optlabel"><input type="checkbox" name="leavePopupRoom"' + (Dex.prefs('leavePopupRoom') ? ' checked' : '') + ' /> Confirmation before leaving a room</label></p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="refreshprompt"' + (Dex.prefs('refreshprompt') ? ' checked' : '') + '> Prompt on refresh</label></p>';
+			buf += '<p><label class="checkbox"><input type="checkbox" name="leavePopupRoom"' + (Dex.prefs('leavePopupRoom') ? ' checked' : '') + ' /> Confirm before leaving a room</label></p>';
+			buf += '<p><label class="checkbox"><input type="checkbox" name="refreshprompt"' + (Dex.prefs('refreshprompt') ? ' checked' : '') + '> Confirm before refreshing</label></p>';
 			var curLang = toID(Dex.prefs('serversettings').language) || 'english';
 			var possibleLanguages = {
 				"Deutsch": 'german',
@@ -538,18 +538,18 @@
 				"简体中文": 'simplifiedchinese',
 				"中文": 'traditionalchinese',
 			};
-			buf += '<p><label class="optlabel">Language: <select name="language">';
+			buf += '<p><label class="optlabel">Language: <select name="language" class="button">';
 			for (var name in possibleLanguages) {
 				buf += '<option value="' + possibleLanguages[name] + '"' + (possibleLanguages[name] === curLang ? ' selected="selected"' : '') + '>' + name + '</option>';
 			}
 			buf += '</select></label></p>';
 
 			var tours = Dex.prefs('tournaments') || 'notify';
-			buf += '<p><label class="optlabel">Tournaments: <select name="tournaments"><option value="notify"' + (tours === 'notify' ? ' selected="selected"' : '') + '>Notifications</option><option value="nonotify"' + (tours === 'nonotify' ? ' selected="selected"' : '') + '>No Notifications</option><option value="hide"' + (tours === 'hide' ? ' selected="selected"' : '') + '>Hide</option></select></label></p>';
+			buf += '<p><label class="optlabel">Tournaments: <select name="tournaments" class="button"><option value="notify"' + (tours === 'notify' ? ' selected="selected"' : '') + '>Notifications</option><option value="nonotify"' + (tours === 'nonotify' ? ' selected="selected"' : '') + '>No Notifications</option><option value="hide"' + (tours === 'hide' ? ' selected="selected"' : '') + '>Hide</option></select></label></p>';
 			var timestamps = this.timestamps = (Dex.prefs('timestamps') || {});
-			buf += '<p><label class="optlabel">Timestamps in chat rooms: <select name="timestamps-lobby"><option value="off">Off</option><option value="minutes"' + (timestamps.lobby === 'minutes' ? ' selected="selected"' : '') + '>[HH:MM]</option><option value="seconds"' + (timestamps.lobby === 'seconds' ? ' selected="selected"' : '') + '>[HH:MM:SS]</option></select></label></p>';
-			buf += '<p><label class="optlabel">Timestamps in PMs: <select name="timestamps-pms"><option value="off">Off</option><option value="minutes"' + (timestamps.pms === 'minutes' ? ' selected="selected"' : '') + '>[HH:MM]</option><option value="seconds"' + (timestamps.pms === 'seconds' ? ' selected="selected"' : '') + '>[HH:MM:SS]</option></select></label></p>';
-			buf += '<p><label class="optlabel">Chat preferences: <button name="formatting">Text formatting</button></label></p>';
+			buf += '<p><label class="optlabel">Timestamps in chat rooms: <select name="timestamps-lobby" class="button"><option value="off">Off</option><option value="minutes"' + (timestamps.lobby === 'minutes' ? ' selected="selected"' : '') + '>[HH:MM]</option><option value="seconds"' + (timestamps.lobby === 'seconds' ? ' selected="selected"' : '') + '>[HH:MM:SS]</option></select></label></p>';
+			buf += '<p><label class="optlabel">Timestamps in PMs: <select name="timestamps-pms" class="button"><option value="off">Off</option><option value="minutes"' + (timestamps.pms === 'minutes' ? ' selected="selected"' : '') + '>[HH:MM]</option><option value="seconds"' + (timestamps.pms === 'seconds' ? ' selected="selected"' : '') + '>[HH:MM:SS]</option></select></label></p>';
+			buf += '<p><label class="optlabel">Chat preferences: <button name="formatting" class="button">Text formatting</button></label></p>';
 
 			if (window.nodewebkit) {
 				buf += '<hr />';
@@ -560,9 +560,9 @@
 
 			buf += '<hr />';
 			if (app.user.get('named')) {
-				buf += '<p class="buttonbar" style="text-align:right"><button name="login"><i class="fa fa-pencil"></i> Change name</button> <button name="logout"><i class="fa fa-power-off"></i> Log out</button></p>';
+				buf += '<p class="buttonbar" style="text-align:right"><button name="login" class="button"><i class="fa fa-pencil"></i> Change name</button> <button name="logout" class="button"><i class="fa fa-power-off"></i> Log out</button></p>';
 			} else {
-				buf += '<p class="buttonbar" style="text-align:right"><button name="login">Choose name</button></p>';
+				buf += '<p class="buttonbar" style="text-align:right"><button name="login" class="button">Choose name</button></p>';
 			}
 			this.$el.html(buf).css('min-width', 160);
 		},
@@ -688,18 +688,18 @@
 			var cur = this.chatformatting = Dex.prefs('chatformatting') || {};
 			var buf = '<p>Usable formatting:</p>';
 			var ctrlPlus = '<kbd>' + (navigator.platform === 'MacIntel' ? 'Cmd' : 'Ctrl') + '</kbd> + ';
-			buf += '<p class="optlabel">**<strong>bold</strong>** (' + ctrlPlus + '<kbd>B</kbd>)</p>';
-			buf += '<p class="optlabel">__<em>italics</em>__ (' + ctrlPlus + '<bkd>I</kbd>)</p>';
-			buf += '<p class="optlabel">``<code>code formatting</code>`` (<kbd>Ctrl</kbd> + <kbd>`</kbd>)</p>';
-			buf += '<p class="optlabel">~~<s>strikethrough</s>~~</p>';
-			buf += '<p class="optlabel">^^<sup>superscript</sup>^^</p>';
-			buf += '<p class="optlabel">\\\\<sub>subscript</sub>\\\\</p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="greentext" ' + (cur.hidegreentext ? 'checked' : '') + ' /> Suppress <span class="greentext">&gt;' + ['meme arrows', 'greentext', 'quote formatting'][Math.floor(Math.random() * 3)] + '</span></label></p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="me" ' + (cur.hideme ? 'checked' : '') + ' /> Suppress <kbd>/me</kbd> <em>action formatting</em></label></p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="spoiler" ' + (cur.hidespoiler ? 'checked' : '') + ' /> Auto-show spoilers: <span class="spoiler">these things</span></label></p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="links" ' + (cur.hidelinks ? 'checked' : '') + ' /> Make [[clickable links]] unclickable</label></p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="interstice"' + (cur.hideinterstice ? 'checked' : '') + ' /> Don\'t warn for untrusted links</label></p>';
-			buf += '<p><button name="close">Close</button></p>';
+			buf += '<p>**<strong>bold</strong>** (' + ctrlPlus + '<kbd>B</kbd>)</p>';
+			buf += '<p>__<em>italics</em>__ (' + ctrlPlus + '<bkd>I</kbd>)</p>';
+			buf += '<p>``<code>code formatting</code>`` (<kbd>Ctrl</kbd> + <kbd>`</kbd>)</p>';
+			buf += '<p>~~<s>strikethrough</s>~~</p>';
+			buf += '<p>^^<sup>superscript</sup>^^</p>';
+			buf += '<p>\\\\<sub>subscript</sub>\\\\</p>';
+			buf += '<p><label class="checkbox"><input type="checkbox" name="greentext" ' + (cur.hidegreentext ? 'checked' : '') + ' /> Suppress <span class="greentext">&gt;' + ['meme arrows', 'greentext', 'quote formatting'][Math.floor(Math.random() * 3)] + '</span></label></p>';
+			buf += '<p><label class="checkbox"><input type="checkbox" name="me" ' + (cur.hideme ? 'checked' : '') + ' /> Suppress <kbd>/me</kbd> <em>action formatting</em></label></p>';
+			buf += '<p><label class="checkbox"><input type="checkbox" name="spoiler" ' + (cur.hidespoiler ? 'checked' : '') + ' /> Auto-show spoilers: <span class="spoiler">these things</span></label></p>';
+			buf += '<p><label class="checkbox"><input type="checkbox" name="links" ' + (cur.hidelinks ? 'checked' : '') + ' /> Make [[clickable links]] unclickable</label></p>';
+			buf += '<p><label class="checkbox"><input type="checkbox" name="interstice"' + (cur.hideinterstice ? 'checked' : '') + ' /> Don\'t warn for untrusted links</label></p>';
+			buf += '<p><button name="close" class="button">Done</button></p>';
 			this.$el.html(buf);
 		},
 		setOption: function (e) {
@@ -714,7 +714,7 @@
 		initialize: function () {
 			var cur = +app.user.get('avatar');
 			var buf = '';
-			buf += '<p>Choose an avatar or <button name="close">Cancel</button></p>';
+			buf += '<p>Choose an avatar or <button name="close" class="button">Cancel</button></p>';
 
 			buf += '<div class="avatarlist">';
 			for (var i = 1; i <= 293; i++) {
@@ -724,7 +724,7 @@
 			}
 			buf += '</div><div style="clear:left"></div>';
 
-			buf += '<p><button name="close">Cancel</button></p>';
+			buf += '<p><button name="close" class="button">Cancel</button></p>';
 			this.$el.html(buf).css('max-width', 780);
 		},
 		setAvatar: function (avatar) {
@@ -813,7 +813,7 @@
 			buf += '<p><input type="file" accept="image/*" name="bgfile"></p>';
 			buf += '<p class="bgstatus"></p>';
 
-			buf += '<p><button name="close"><strong>Done</strong></button></p>';
+			buf += '<p><button name="close" class="button"><strong>Done</strong></button></p>';
 
 			// April Fool's 2016 - background change disabling
 			// buf = '<p>Sorry, the background chooser is experiencing technical difficulties. Please try again tomorrow!</p><p><button name="close"><strong>Done</strong></button></p>';
@@ -919,7 +919,7 @@
 			if (name) {
 				buf += '<p><small>(Others will be able to see your name change. To change name privately, use "Log out")</small></p>';
 			}
-			buf += '<p class="buttonbar"><button type="submit"><strong>Choose name</strong></button> <button type="button" name="close">Cancel</button></p>';
+			buf += '<p class="buttonbar"><button type="submit" class="button"><strong>Choose name</strong></button> <button type="button" name="close" class="button">Cancel</button></p>';
 
 			buf += '</form>';
 			this.$el.html(buf);
@@ -962,7 +962,7 @@
 			buf += '<p><label class="label">Old password: <input class="textbox autofocus" type="password" name="oldpassword" autocomplete="current-password" /></label></p>';
 			buf += '<p><label class="label">New password: <input class="textbox" type="password" name="password" autocomplete="new-password" /></label></p>';
 			buf += '<p><label class="label">New password (confirm): <input class="textbox" type="password" name="cpassword" autocomplete="new-password" /></label></p>';
-			buf += '<p class="buttonbar"><button type="submit"><strong>Change password</strong></button> <button type="button" name="close">Cancel</button></p></form>';
+			buf += '<p class="buttonbar"><button type="submit" class="button"><strong>Change password</strong></button> <button type="button" name="close" class="button">Cancel</button></p></form>';
 			this.$el.html(buf);
 		},
 		submit: function (data) {

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -857,8 +857,8 @@
 		initialize: function (data) {
 			var buf = '<br>';
 			buf += '<p><img src="' + data.bgUrl + '" style="display:block;margin:auto;max-width:90%;max-height:500px"></p>';
-			buf += '<p class="buttonbar"><button name="setBg" value="' + data.bgUrl + '"><strong>Change background</strong></button> ';
-			buf += '<button name="close">Cancel</button></p>';
+			buf += '<p class="buttonbar"><button name="setBg" value="' + data.bgUrl + '" class="button"><strong>Change background</strong></button> ';
+			buf += '<button name="close" class="button">Cancel</button></p>';
 
 			this.$el.css('max-width', 485).html(buf);
 			this.$el.html(buf);
@@ -905,8 +905,8 @@
 				if (noRenameGames) {
 					buf += '<p>You can\'t change name in the middle of these games:</p>';
 					buf += '<ul>' + noRenameGames + '</ul>';
-					buf += '<p class="buttonbar"><button type="button" name="force"><small style="color:red">Forfeit and change name</small></button></p>';
-					buf += '<p class="buttonbar"><button type="submit" autofocus><strong>Cancel</strong></button></p>';
+					buf += '<p class="buttonbar"><button type="button" name="force" class="button"><small style="color:red">Forfeit and change name</small></button></p>';
+					buf += '<p class="buttonbar"><button type="submit" autofocus class="button"><strong>Cancel</strong></button></p>';
 					buf += '</form>';
 					this.$el.html(buf);
 					return;
@@ -1000,7 +1000,7 @@
 			buf += '<p><label class="label">Password (confirm): <input class="textbox" type="password" name="cpassword" autocomplete="new-password" /></label></p>';
 			buf += '<p><label class="label"><img src="' + Dex.resourcePrefix + 'sprites/gen5ani/pikachu.gif" alt="An Electric-type mouse that is the mascot of the Pok\u00E9mon franchise." /></label></p>';
 			buf += '<p><label class="label">What is this pokemon? <input class="textbox" type="text" name="captcha" value="' + BattleLog.escapeHTML(data.captcha) + '" /></label></p>';
-			buf += '<p class="buttonbar"><button type="submit"><strong>Register</strong></button> <button type="button" name="close">Cancel</button></p></form>';
+			buf += '<p class="buttonbar"><button type="submit" class="button"><strong>Register</strong></button> <button type="button" name="close" class="button">Cancel</button></p></form>';
 			this.$el.html(buf);
 		},
 		submit: function (data) {
@@ -1073,12 +1073,12 @@
 				buf += '<p class="buttonbar"><button name="close">Cancel</button></p>';
 			} else {
 				buf += '<p><label class="label">Password: <input class="textbox autofocus" type="password" name="password" autocomplete="current-password" style="width:173px"><button type="button" name="showPassword" aria-label="Show password" style="float:right;margin:-21px 0 10px;padding: 2px 6px" class="button"><i class="fa fa-eye"></i></button></label></p>';
-				buf += '<p class="buttonbar"><button type="submit"><strong>Log in</strong></button> <button type="button" name="close">Cancel</button></p>';
+				buf += '<p class="buttonbar"><button type="submit" class="button"><strong>Log in</strong></button> <button type="button" name="close" class="button">Cancel</button></p>';
 			}
 
 			buf += '<p class="or">or</p>';
 			buf += '<p>If this is someone else\'s account:</p>';
-			buf += '<p class="buttonbar"><button type="button" name="login">Choose another name</button></p>';
+			buf += '<p class="buttonbar"><button type="button" name="login" class="button">Choose another name</button></p>';
 
 			buf += '</form>';
 			this.$el.html(buf);

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -34,7 +34,7 @@
 			var status = app.user.get('status');
 			var color = away ? 'color:#888;' : BattleLog.hashColor(app.user.get('userid'));
 			if (!app.user.loaded) {
-				buf = '<button disabled class="button disabled">Loading...</button>';
+				buf = '<button disabled class="button">Loading...</button>';
 			} else if (app.user.get('named')) {
 				buf = '<span class="username" data-name="' + BattleLog.escapeHTML(name) + '"' + (away ? ' data-away="true"' : '') + (status ? 'data-status="' + BattleLog.escapeHTML(status) + '"' : '') + ' style="' + color + '"><i class="fa fa-user" style="color:' + (away ? '#888;' : '#779EC5') + '"></i> <span class="usernametext">' + BattleLog.escapeHTML(name) + '</span></span>';
 			} else {

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -720,7 +720,7 @@
 			for (var i = 1; i <= 293; i++) {
 				if (i === 162 || i === 168) continue;
 				var offset = '-' + (((i - 1) % 16) * 80 + 1) + 'px -' + (Math.floor((i - 1) / 16) * 80 + 1) + 'px';
-				buf += '<button name="setAvatar" value="' + i + '" style="background-position:' + offset + '"' + (i === cur ? ' class="cur"' : '') + ' title="/avatar ' + i + '"></button>';
+				buf += '<button name="setAvatar" value="' + i + '" style="background-position:' + offset + '" class="option pixelated' + (i === cur ? ' cur' : '') + '" title="/avatar ' + i + '"></button>';
 			}
 			buf += '</div><div style="clear:left"></div>';
 
@@ -794,18 +794,18 @@
 			buf += '<p><strong>Default</strong></p>';
 			buf += '<div class="bglist">';
 
-			buf += '<button name="setBg" value=""' + (!cur ? ' class="cur"' : '') + '><strong style="background:#888888;color:white;padding:16px 18px;display:block;font-size:12pt">' + (location.host === Config.routes.client ? 'Random' : 'Default') + '</strong></button>';
+			buf += '<button name="setBg" value="" class="option' + (!cur ? ' cur' : '') + '"><strong style="background:#888888;color:white;padding:16px 18px;display:block;font-size:12pt">' + (location.host === Config.routes.client ? 'Random' : 'Default') + '</strong></button>';
 
 			buf += '</div><div style="clear:left"></div>';
 			buf += '<p><strong>Official</strong></p>';
 			buf += '<div class="bglist">';
 
-			buf += '<button name="setBg" value="charizards"' + (cur === 'charizards' ? ' class="cur"' : '') + '><span class="bg" style="background-position:0 -' + (90 * 0) + 'px"></span>Charizards</button>';
-			buf += '<button name="setBg" value="horizon"' + (cur === 'horizon' ? ' class="cur"' : '') + '><span class="bg" style="background-position:0 -' + (90 * 1) + 'px"></span>Horizon</button>';
-			buf += '<button name="setBg" value="waterfall"' + (cur === 'waterfall' ? ' class="cur"' : '') + '><span class="bg" style="background-position:0 -' + (90 * 2) + 'px"></span>Waterfall</button>';
-			buf += '<button name="setBg" value="ocean"' + (cur === 'ocean' ? ' class="cur"' : '') + '><span class="bg" style="background-position:0 -' + (90 * 3) + 'px"></span>Ocean</button>';
-			buf += '<button name="setBg" value="shaymin"' + (cur === 'shaymin' ? ' class="cur"' : '') + '><span class="bg" style="background-position:0 -' + (90 * 4) + 'px"></span>Shaymin</button>';
-			buf += '<button name="setBg" value="solidblue"' + (cur === 'solidblue' ? ' class="cur"' : '') + '><span class="bg" style="background: #344b6c"></span>Solid blue</button>';
+			buf += '<button name="setBg" value="charizards" class="option' + (cur === 'charizards' ? ' cur' : '') + '"><span class="bg" style="background-position:0 -' + (90 * 0) + 'px"></span>Charizards</button>';
+			buf += '<button name="setBg" value="horizon" class="option' + (cur === 'horizon' ? ' cur' : '') + '"><span class="bg" style="background-position:0 -' + (90 * 1) + 'px"></span>Horizon</button>';
+			buf += '<button name="setBg" value="waterfall" class="option' + (cur === 'waterfall' ? ' cur' : '') + '"><span class="bg" style="background-position:0 -' + (90 * 2) + 'px"></span>Waterfall</button>';
+			buf += '<button name="setBg" value="ocean" class="option' + (cur === 'ocean' ? ' cur' : '') + '"><span class="bg" style="background-position:0 -' + (90 * 3) + 'px"></span>Ocean</button>';
+			buf += '<button name="setBg" value="shaymin" class="option' + (cur === 'shaymin' ? ' cur' : '') + '"><span class="bg" style="background-position:0 -' + (90 * 4) + 'px"></span>Shaymin</button>';
+			buf += '<button name="setBg" value="solidblue" class="option' + (cur === 'solidblue' ? ' cur' : '') + '"><span class="bg" style="background: #344b6c"></span>Solid blue</button>';
 
 			buf += '</div><div style="clear:left"></div>';
 			buf += '<p><strong>Custom</strong></p>';

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -689,13 +689,13 @@
 			var buf = '<p>Usable formatting:</p>';
 			var ctrlPlus = '<kbd>' + (navigator.platform === 'MacIntel' ? 'Cmd' : 'Ctrl') + '</kbd> + ';
 			buf += '<p>**<strong>bold</strong>** (' + ctrlPlus + '<kbd>B</kbd>)</p>';
-			buf += '<p>__<em>italics</em>__ (' + ctrlPlus + '<bkd>I</kbd>)</p>';
+			buf += '<p>__<em>italics</em>__ (' + ctrlPlus + '<kbd>I</kbd>)</p>';
 			buf += '<p>``<code>code formatting</code>`` (<kbd>Ctrl</kbd> + <kbd>`</kbd>)</p>';
 			buf += '<p>~~<s>strikethrough</s>~~</p>';
 			buf += '<p>^^<sup>superscript</sup>^^</p>';
 			buf += '<p>\\\\<sub>subscript</sub>\\\\</p>';
 			buf += '<p><label class="checkbox"><input type="checkbox" name="greentext" ' + (cur.hidegreentext ? 'checked' : '') + ' /> Suppress <span class="greentext">&gt;' + ['meme arrows', 'greentext', 'quote formatting'][Math.floor(Math.random() * 3)] + '</span></label></p>';
-			buf += '<p><label class="checkbox"><input type="checkbox" name="me" ' + (cur.hideme ? 'checked' : '') + ' /> Suppress <kbd>/me</kbd> <em>action formatting</em></label></p>';
+			buf += '<p><label class="checkbox"><input type="checkbox" name="me" ' + (cur.hideme ? 'checked' : '') + ' /> Suppress <code>/me</code> <em>action formatting</em></label></p>';
 			buf += '<p><label class="checkbox"><input type="checkbox" name="spoiler" ' + (cur.hidespoiler ? 'checked' : '') + ' /> Auto-show spoilers: <span class="spoiler">these things</span></label></p>';
 			buf += '<p><label class="checkbox"><input type="checkbox" name="links" ' + (cur.hidelinks ? 'checked' : '') + ' /> Make [[clickable links]] unclickable</label></p>';
 			buf += '<p><label class="checkbox"><input type="checkbox" name="interstice"' + (cur.hideinterstice ? 'checked' : '') + ' /> Don\'t warn for untrusted links</label></p>';

--- a/js/client.js
+++ b/js/client.js
@@ -2797,17 +2797,17 @@ function toId() {
 
 			buf += '<p class="buttonbar">';
 			if (userid === app.user.get('userid') || !app.user.get('named')) {
-				buf += '<button disabled>Challenge</button>';
+				buf += '<button disabled class="button disabled">Challenge</button>';
 				if (userid === app.user.get('userid')) {
-					buf += ' <button name="pm">Chat self</button>';
+					buf += ' <button name="pm" class="button">Chat self</button>';
 					buf += '</p><hr /><p class="buttonbar" style="text-align: right">';
-					buf += '<button name="login"><i class="fa fa-pencil"></i> Change name</button> <button name="logout"><i class="fa fa-power-off"></i> Log out</button>';
+					buf += '<button name="login" class="button"><i class="fa fa-pencil"></i> Change name</button> <button name="logout" class="button"><i class="fa fa-power-off"></i> Log out</button>';
 				} else {
 					// Guests can't PM themselves
-					buf += ' <button disabled>Chat self</button>';
+					buf += ' <button disabled class="button disabled">Chat self</button>';
 				}
 			} else {
-				buf += '<button name="challenge">Challenge</button> <button name="pm">Chat</button> <button name="userOptions">\u2026</button>';
+				buf += '<button name="challenge" class="button">Challenge</button> <button name="pm" class="button">Chat</button> <button name="userOptions" class="button">\u2026</button>';
 			}
 			buf += '</p>';
 
@@ -2865,9 +2865,9 @@ function toId() {
 			var ignored = app.ignore[this.userid] ? 'Unignore' : 'Ignore';
 			var friended = this.data.friended ? 'Remove friend' : 'Add friend';
 			this.$el.html(
-				'<p><button name="toggleIgnoreUser">' + ignored + '</button></p>' +
-				'<p><button name="report">Report</button></p>' +
-				'<p><button name="toggleFriend">' + friended +
+				'<p><button name="toggleIgnoreUser" class="button">' + ignored + '</button></p>' +
+				'<p><button name="report" class="button">Report</button></p>' +
+				'<p><button name="toggleFriend" class="button">' + friended +
 				'</button></p>'
 			);
 		},

--- a/js/client.js
+++ b/js/client.js
@@ -2546,7 +2546,7 @@ function toId() {
 		},
 		initialize: function (data) {
 			if (!this.type) this.type = 'semimodal';
-			this.$el.html('<form><p style="white-space:pre-wrap;word-wrap:break-word">' + (data.htmlMessage || BattleLog.parseMessage(data.message)) + '</p><p class="buttonbar">' + (data.buttons || '<button type="button" name="close" class="autofocus"><strong>OK</strong></button>') + '</p></form>').css('max-width', data.maxWidth || 480);
+			this.$el.html('<form><p style="white-space:pre-wrap;word-wrap:break-word">' + (data.htmlMessage || BattleLog.parseMessage(data.message)) + '</p><p class="buttonbar">' + (data.buttons || '<button type="button" name="close" class="autofocus" class="button"><strong>OK</strong></button>') + '</p></form>').css('max-width', data.maxWidth || 480);
 		},
 
 		dispatchClickButton: function (e) {
@@ -2610,7 +2610,7 @@ function toId() {
 			var buf = '<form>';
 			buf += '<p><label class="label">' + data.message;
 			buf += '<input class="textbox autofocus" type="text" name="data" value="' + BattleLog.escapeHTML(data.value || '') + '" /></label></p>';
-			buf += '<p class="buttonbar"><button type="submit"><strong>' + data.button + '</strong></button> <button type="button" name="close">Cancel</button></p>';
+			buf += '<p class="buttonbar"><button type="submit" class="button"><strong>' + data.button + '</strong></button> <button type="button" name="close" class="button">Cancel</button></p>';
 			buf += '</form>';
 
 			this.$el.html(buf);

--- a/js/client.js
+++ b/js/client.js
@@ -2797,14 +2797,14 @@ function toId() {
 
 			buf += '<p class="buttonbar">';
 			if (userid === app.user.get('userid') || !app.user.get('named')) {
-				buf += '<button disabled class="button disabled">Challenge</button>';
+				buf += '<button disabled class="button">Challenge</button>';
 				if (userid === app.user.get('userid')) {
 					buf += ' <button name="pm" class="button">Chat self</button>';
 					buf += '</p><hr /><p class="buttonbar" style="text-align: right">';
 					buf += '<button name="login" class="button"><i class="fa fa-pencil"></i> Change name</button> <button name="logout" class="button"><i class="fa fa-power-off"></i> Log out</button>';
 				} else {
 					// Guests can't PM themselves
-					buf += ' <button disabled class="button disabled">Chat self</button>';
+					buf += ' <button disabled class="button">Chat self</button>';
 				}
 			} else {
 				buf += '<button name="challenge" class="button">Challenge</button> <button name="pm" class="button">Chat</button> <button name="userOptions" class="button">\u2026</button>';
@@ -2922,18 +2922,18 @@ function toId() {
 				buf += '<p class="error">Couldn\'t connect to server!</p>';
 				if (window.wiiu && document.location.protocol === 'https:') {
 					buf += '<p class="error">The Wii U does not support secure connections.</p>';
-					buf += '<p class="buttonbar"><button name="tryhttp" autofocus><strong>Connect insecurely</button> <button name="close">Work offline</button></p>';
+					buf += '<p class="buttonbar"><button name="tryhttp" class="button autofocus"><strong>Connect insecurely</button> <button name="close" class="button">Work offline</button></p>';
 				} else if (document.location.protocol === 'https:') {
-					buf += '<p class="buttonbar"><button type="submit"><strong>Retry</strong></button> <button name="tryhttp">Retry with HTTP</button> <button name="close">Work offline</button></p>';
+					buf += '<p class="buttonbar"><button type="submit" class="button"><strong>Retry</strong></button> <button name="tryhttp" class="button">Retry with HTTP</button> <button name="close">Work offline</button></p>';
 				} else {
-					buf += '<p class="buttonbar"><button type="submit"><strong>Retry</strong></button> <button name="close">Work offline</button></p>';
+					buf += '<p class="buttonbar"><button type="submit" class="button"><strong>Retry</strong></button> <button name="close" class="button">Work offline</button></p>';
 				}
 			} else if (data.message && data.message !== true) {
 				buf += '<p>' + data.message + '</p>';
-				buf += '<p class="buttonbar"><button type="submit" class="autofocus"><strong>Reconnect</strong></button> <button type="button" name="close">Work offline</button></p>';
+				buf += '<p class="buttonbar"><button type="submit" class="button autofocus"><strong>Reconnect</strong></button> <button type="button" name="close" class="button">Work offline</button></p>';
 			} else {
 				buf += '<p>You have been disconnected &ndash; possibly because the server was restarted.</p>';
-				buf += '<p class="buttonbar"><button type="submit" class="autofocus"><strong>Reconnect</strong></button> <button type="button" name="close">Work offline</button></p>';
+				buf += '<p class="buttonbar"><button type="submit" class="button autofocus"><strong>Reconnect</strong></button> <button type="button" name="close" class="button">Work offline</button></p>';
 			}
 
 			buf += '</form>';
@@ -2959,7 +2959,7 @@ function toId() {
 			buf += '<p>Please copy <strong>all the text</strong> from the box above and paste it in the box below.</p>';
 			buf += '<p>(You should probably <a href="https://github.com/smogon/pokemon-showdown-client#test-keys" target="_blank">set up</a> <code>config/testclient-key.js</code> so you don\'t have to do this every time.)</p>';
 			buf += '<p><label class="label" style="float: left;">Data from the box above:</label> <input style="width: 100%;" class="textbox autofocus" type="text" name="result" /></p>';
-			buf += '<p class="buttonbar"><button type="submit"><strong>Submit</strong></button> <button type="button" name="close">Cancel</button></p>';
+			buf += '<p class="buttonbar"><button type="submit" class="button"><strong>Submit</strong></button> <button type="button" name="close" class="button">Cancel</button></p>';
 			buf += '</form>';
 			this.$el.html(buf).css('min-width', 500);
 		},
@@ -2977,8 +2977,8 @@ function toId() {
 		initialize: function (data) {
 			var buf = '';
 			buf = '<p>Your replay has been uploaded! It\'s available at:</p>';
-			buf += '<p> <a class="replay-link" href="https://' + Config.routes.replays + '/' + data.id + '" target="_blank" class="no-panel-intercept">https://' + Config.routes.replays + '/' + data.id + '</a> <button name="copyReplayLink">Copy</button></p>';
-			buf += '<p><button class="autofocus" name="close">Close</button><p>';
+			buf += '<p> <a class="replay-link" href="https://' + Config.routes.replays + '/' + data.id + '" target="_blank" class="no-panel-intercept">https://' + Config.routes.replays + '/' + data.id + '</a> <button name="copyReplayLink" class="button">Copy</button></p>';
+			buf += '<p><button class="autofocus button" name="close">Close</button><p>';
 			this.$el.html(buf).css('max-width', 620);
 		},
 		clickClose: function () {
@@ -3033,11 +3033,11 @@ function toId() {
 					'<p>This policy is less restrictive than that of many places, so you might see some "borderline" nicknames that might not be accepted elsewhere. You might consider it unfair that they are allowed to keep their nickname. The fact remains that their nickname follows the above rules, and if you were asked to choose a new name, yours does not.</p>';
 			}
 			if (warning) {
-				buf += '<p class="buttonbar"><button name="close" disabled>Close</button><small class="overlay-warn"> You will be able to close this in 5 seconds</small></p>';
+				buf += '<p class="buttonbar"><button name="close" disabled class="button">Close</button><small class="overlay-warn"> You will be able to close this in 5 seconds</small></p>';
 				setTimeout(_.bind(this.rulesTimeout, this), 5000);
 			} else {
 				this.type = 'semimodal';
-				buf += '<p class="buttonbar"><button name="close" class="autofocus">Close</button></p>';
+				buf += '<p class="buttonbar"><button name="close" class="autofocus button">Close</button></p>';
 			}
 			this.$el.css('max-width', 760).html(buf);
 		},

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -677,9 +677,9 @@ class BattleTooltips {
 		if (zEffect) text += '<p>Z-Effect: ' + zEffect + '</p>';
 
 		if (this.battle.hardcoreMode) {
-			text += '<p class="section">' + move.shortDesc + '</p>';
+			text += '<p class="tooltip-section">' + move.shortDesc + '</p>';
 		} else {
-			text += '<p class="section">';
+			text += '<p class="tooltip-section">';
 			if (move.priority > 1) {
 				text += 'Nearly always moves first <em>(priority +' + move.priority + ')</em>.</p><p>';
 			} else if (move.priority <= -1) {
@@ -823,7 +823,7 @@ class BattleTooltips {
 		}
 
 		if (illusionIndex) {
-			text += `<p class="section"><strong>Possible Illusion #${illusionIndex}</strong>${levelBuf}</p>`;
+			text += `<p class="tooltip-section"><strong>Possible Illusion #${illusionIndex}</strong>${levelBuf}</p>`;
 		}
 
 		if (pokemon.fainted) {
@@ -904,7 +904,7 @@ class BattleTooltips {
 
 		if (serverPokemon && !isActive) {
 			// move list
-			text += `<p class="section">`;
+			text += `<p class="tooltip-section">`;
 			const battlePokemon = clientPokemon || this.battle.findCorrespondingPokemon(pokemon);
 			for (const moveid of serverPokemon.moves) {
 				const move = Dex.moves.get(moveid);
@@ -922,7 +922,7 @@ class BattleTooltips {
 			text += '</p>';
 		} else if (!this.battle.hardcoreMode && clientPokemon?.moveTrack.length) {
 			// move list (guessed)
-			text += `<p class="section">`;
+			text += `<p class="tooltip-section">`;
 			for (const row of clientPokemon.moveTrack) {
 				text += `${this.getPPUseText(row)}<br />`;
 			}
@@ -952,7 +952,7 @@ class BattleTooltips {
 		for (const side of this.battle.sides) {
 			const sideConditions = scene.sideConditionsLeft(side, true);
 			if (sideConditions) atLeastOne = true;
-			buf += `<td><p class="section"><strong>${BattleLog.escapeHTML(side.name)}</strong>${sideConditions || "<br />(no conditions)"}</p></td>`;
+			buf += `<td><p class="tooltip-section"><strong>${BattleLog.escapeHTML(side.name)}</strong>${sideConditions || "<br />(no conditions)"}</p></td>`;
 		}
 		buf += `</tr><table>`;
 		if (!atLeastOne) buf = ``;

--- a/src/panel-topbar.tsx
+++ b/src/panel-topbar.tsx
@@ -203,10 +203,10 @@ class PSHeader extends preact.Component<{style: {}}> {
 	}
 	renderUser() {
 		if (!PS.connected) {
-			return <button class="button disabled" disabled><em>Offline</em></button>;
+			return <button class="button" disabled><em>Offline</em></button>;
 		}
 		if (!PS.user.userid) {
-			return <button class="button disabled" disabled><em>Connecting...</em></button>;
+			return <button class="button" disabled><em>Connecting...</em></button>;
 		}
 		if (!PS.user.named) {
 			return <a class="button" href="login">Choose name</a>;
@@ -366,8 +366,8 @@ class UserPanel extends PSRoomPanel<UserRoom> {
 			</div>
 			{isSelf || !PS.user.named ?
 				<p class="buttonbar">
-					<button class="button disabled" disabled>Challenge</button> {}
-					<button class="button disabled" disabled>Chat</button>
+					<button class="button" disabled>Challenge</button> {}
+					<button class="button" disabled>Chat</button>
 				</p>
 			:
 				<p class="buttonbar">

--- a/style/STYLING.html
+++ b/style/STYLING.html
@@ -211,21 +211,21 @@ h1, h2, p {
     This is used for a button taking the role of <code>&lt;option></code> (in a drop-down selection menu). Normal button styling would look really cluttered, so option buttons are much subtler.
   </p>
   <p>
-    The currently-selected option should be given the <code>sel</code> class.
+    The currently-selected option should be given the <code>cur</code> class.
   </p>
 
   <div class="light-container">
-    <button class="option sel">Do the first thing</button>
+    <button class="option cur">Do the first thing</button>
     <button class="option">Do the second thing</button>
     <button class="option">Do the third thing</button>
   </div>
   <div class="dark-container dark">
-    <button class="option sel">Do the first thing</button>
+    <button class="option cur">Do the first thing</button>
     <button class="option">Do the second thing</button>
     <button class="option">Do the third thing</button>
   </div>
   <div class="dark-container code dark">
-    &lt;button class="option sel">Do the first thing&lt;/button>
+    &lt;button class="option cur">Do the first thing&lt;/button>
     &lt;button class="option">Do the second thing&lt;/button>
     &lt;button class="option">Do the third thing&lt;/button>
   </div>

--- a/style/STYLING.html
+++ b/style/STYLING.html
@@ -111,7 +111,7 @@ h1, h2, p {
   <p><code>.button.disabled</code></p>
 
   <p>
-    Disabled buttons are faded out. Implementing <code>disabled</code> as a class lets you detect when they're moused-over (for tooltips) and clicked, if necessary. Do also set the <code>disabled</code> attribute if you don't need to do that, though, for accessibility reasons.
+    Disabled buttons are faded out. Implementing <code>disabled</code> as a class lets you detect when they're moused-over (for tooltips) and clicked, if necessary. Do instead set the <code>disabled</code> attribute if you don't need to do that, though, for accessibility reasons.
   </p>
 
   <div class="light-container">

--- a/style/battle-log.css
+++ b/style/battle-log.css
@@ -586,7 +586,7 @@ input[type=range]:active::-webkit-slider-thumb {
 	background: #BBBBBB;
 	color: #BBBBBB;
 }
-code, .code,
+code, .code, kbd,
 .spoiler:hover code,
 .spoiler:active code,
 .spoiler-shown code {
@@ -596,6 +596,13 @@ code, .code,
 	color: black;
 	padding: 0 2px;
 	tab-size: 4;
+}
+kbd {
+	font-size: 90%;
+	padding: 0 4px;
+	border-radius: 4px;
+	border-width: 1px 3px 3px;
+	border-color: #CCC #BBB #AAA;
 }
 
 details.readmore {
@@ -641,14 +648,17 @@ details.readmore[open] summary:hover:before {
 	background: #777;
 	color: #777;
 }
-.dark code,
-.dark .code,
+.dark code, .dark .code, .dark kbd,
 .dark .spoiler:hover code,
 .dark .spoiler:active code,
 .dark .spoiler-shown code {
 	border-color: #555;
 	background: #333;
 	color: #DDD;
+}
+.dark kbd {
+	background: #555;
+	border-color: #666 #333 #111;
 }
 .stat-boosted {
 	color: #117911;

--- a/style/battle-log.css
+++ b/style/battle-log.css
@@ -444,6 +444,9 @@ input[type=range]:active::-webkit-slider-thumb {
 .chat > strong { /* username, changed rating */
 	color: #40576A;
 }
+.dark .username {
+	filter: brightness(1.2);
+}
 .chat > em,
 .chat > q { /* user's chat message */
 	padding: 0 4px 0 3px;
@@ -629,8 +632,12 @@ details.readmore[open] summary:hover:before {
 	padding: 2px 4px;
 }
 .infobox {
-	border: 1px solid #6688AA;
+	border: 1px solid #7799BB;
 	padding: 2px 4px;
+	border-radius: 4px;
+}
+.dark .infobox {
+	border-color: #506070;
 }
 .infobox-limited {
 	max-height: 200px;

--- a/style/battle-log.css
+++ b/style/battle-log.css
@@ -58,7 +58,6 @@ button, summary {
 	touch-action: manipulation;
 }
 .button {
-	outline: none;
 	cursor: pointer;
 	text-align: center;
 	text-decoration: none;
@@ -107,6 +106,22 @@ button:disabled {
 	cursor: default;
 }
 
+.button.notifying {
+	border-color: #AA8866;
+	background: #e3c3a3;
+}
+.button.alt-notifying {
+	border-color: #669caa;
+	background: #a3d0e3;
+}
+.button.notifying:hover {
+	border-color: #604020;
+	background: #cfaf8f;
+}
+.button.subtle-notifying {
+	color: #AA6600;
+}
+
 .button-first, .button-middle {
 	border-top-right-radius: 0;
 	border-bottom-right-radius: 0;
@@ -147,6 +162,30 @@ button:disabled {
 	border-color: #34373b;
 	box-shadow: 0.5px 1px 2px rgba(255, 255, 255, 0.45);
 	color: #999999;
+}
+
+.dark .button.notifying {
+	border-color: #34373b;
+	background: #417589;
+	background: linear-gradient(to bottom, #6BACC5, #417589);
+}
+.dark .button.notifying:hover {
+	border-color: #34373b;
+	background: #5499b4;
+	background: linear-gradient(to bottom, #7bc9e7, #5499b4);
+}
+.dark .button.alt-notifying {
+	border-color: #34373b;
+	background: #502646;
+	background: linear-gradient(to bottom, #713262, #502646);
+}
+.dark .button.alt-notifying:hover {
+	border-color: #34373b;
+	background: #713563;
+	background: linear-gradient(to bottom, #9f468b, #713563);
+}
+.dark .button.subtle-notifying {
+	color: #6BACC5;
 }
 
 /*********************************************************
@@ -223,8 +262,7 @@ button:disabled {
 	box-shadow: inset 0px 1px 2px #D2D2D2, 1px 1px 0 rgba(255,255,255,.6);
 	background: #FFFFFF;
 }
-.textbox:focus,
-.button:focus {
+.textbox:focus {
 	outline: 0 none;
 	border-color: #004488;
 	box-shadow: inset 0px 1px 2px #D2D2D2, 0px 0px 6px #2266AA;
@@ -249,8 +287,7 @@ button:disabled {
 	box-shadow: inset 0.5px 1px 2px rgba(0, 0, 0, 0.8), inset -0.5px -1px 1px rgba(255, 255, 255, 0.5), -0.5px -1px 1px rgba(255, 255, 255, 0.1);
 	background: #111111;
 }
-.dark .textbox:focus,
-.dark .button:focus {
+.dark .textbox:focus {
 	outline: 1px solid #88CCFF;
 	border-color: #9199a2;
 	/* box-shadow: 0px 0px 4px #88CCFF, 0px 0px 6px #88CCFF; */
@@ -621,15 +658,17 @@ details.readmore[open] summary:hover:before {
 	/* Readable link colour */
 	color: #DDEEFF;
 }
-.broadcast-green {
+.broadcast-green, .broadcast-blue, .broadcast-red {
 	background-color: #559955;
 	color: white;
 	padding: 2px 4px;
+	border-radius: 4px;
 }
 .broadcast-blue {
 	background-color: #6688AA;
-	color: white;
-	padding: 2px 4px;
+}
+.broadcast-red {
+	background-color: #AA5544;
 }
 .infobox {
 	border: 1px solid #7799BB;
@@ -642,11 +681,6 @@ details.readmore[open] summary:hover:before {
 .infobox-limited {
 	max-height: 200px;
 	overflow: auto;
-}
-.broadcast-red {
-	background-color: #AA5544;
-	color: white;
-	padding: 2px 4px;
 }
 .message-learn-canlearn {
 	font-weight: bold;

--- a/style/battle-log.css
+++ b/style/battle-log.css
@@ -330,7 +330,7 @@ button:disabled {
 }
 
 .option {
-	background: transparent;
+	background-color: transparent;
 	border: 1px solid transparent;
 	border-radius: 4px;
 	padding: 2px 5px;
@@ -341,13 +341,14 @@ button:disabled {
 	white-space: nowrap;
 	overflow: hidden;
 }
-.option.sel {
+.option.sel, .option.cur {
 	border-color: #999999;
 }
 .option:hover,
-.option.sel:hover {
+.option.sel:hover,
+.option.cur:hover {
 	border-color: #888888;
-	background: #D5D5D5;
+	background-color: #D5D5D5;
 	color: black;
 }
 
@@ -356,9 +357,10 @@ button:disabled {
 	box-shadow: none;
 }
 .dark .option:hover,
-.dark .option.sel:hover {
+.dark .option.sel:hover,
+.dark .option.cur:hover {
 	border-color: #777777;
-	background: rgba(100, 100, 100, 0.5);
+	background-color: rgba(100, 100, 100, 0.5);
 	color: #FFFFFF;
 }
 

--- a/style/battle-log.css
+++ b/style/battle-log.css
@@ -183,17 +183,17 @@ button:disabled {
 .dark .button.notifying {
 	border-color: #34373b;
 	background: #417589;
-	background: linear-gradient(to bottom, #6BACC5, #417589);
+	background: linear-gradient(to bottom, #449cbf, #2b6d87);
 }
 .dark .button.notifying:hover {
 	border-color: #34373b;
 	background: #5499b4;
-	background: linear-gradient(to bottom, #7bc9e7, #5499b4);
+	background: linear-gradient(to bottom, #4fb7df, #398bac);
 }
 .dark .button.notifying:active {
 	border-color: #34373b;
 	background: #5499b4;
-	background: linear-gradient(to bottom, #417589, #7bc9e7);
+	background: linear-gradient(to bottom, #2b6d87, #4ebde9);
 }
 .dark .button.alt-notifying {
 	border-color: #34373b;
@@ -211,7 +211,7 @@ button:disabled {
 	background: linear-gradient(to bottom, #502646, #9f468b);
 }
 .dark .button.subtle-notifying {
-	color: #6BACC5;
+	color: #72bcda;
 }
 
 /*********************************************************

--- a/style/battle-log.css
+++ b/style/battle-log.css
@@ -109,14 +109,30 @@ button:disabled {
 .button.notifying {
 	border-color: #AA8866;
 	background: #e3c3a3;
-}
-.button.alt-notifying {
-	border-color: #669caa;
-	background: #a3d0e3;
+	background: linear-gradient(to bottom, #f6d6b6, #d3b396);
 }
 .button.notifying:hover {
 	border-color: #604020;
 	background: #cfaf8f;
+	background: linear-gradient(to bottom, #f2c6a6, #b28e6e);
+}
+.button.notifying:active {
+	background: #b28e6e;
+	background: linear-gradient(to bottom, #b28e6e, #f6d6b6);
+}
+.button.alt-notifying {
+	border-color: #669caa;
+	background: #a3d0e3;
+	background: linear-gradient(to bottom, #daf2fc, #a3d0e3);
+}
+.button.alt-notifying:hover {
+	border-color: #406070;
+	background: #8fb2cf;
+	background: linear-gradient(to bottom, #daf2fc, #8fb2cf);
+}
+.button.alt-notifying:active {
+	background: #8fb2cf;
+	background: linear-gradient(to bottom, #8fb2cf, #daf2fc);
 }
 .button.subtle-notifying {
 	color: #AA6600;
@@ -174,6 +190,11 @@ button:disabled {
 	background: #5499b4;
 	background: linear-gradient(to bottom, #7bc9e7, #5499b4);
 }
+.dark .button.notifying:active {
+	border-color: #34373b;
+	background: #5499b4;
+	background: linear-gradient(to bottom, #417589, #7bc9e7);
+}
 .dark .button.alt-notifying {
 	border-color: #34373b;
 	background: #502646;
@@ -183,6 +204,11 @@ button:disabled {
 	border-color: #34373b;
 	background: #713563;
 	background: linear-gradient(to bottom, #9f468b, #713563);
+}
+.dark .button.alt-notifying:active {
+	border-color: #34373b;
+	background: #713563;
+	background: linear-gradient(to bottom, #502646, #9f468b);
 }
 .dark .button.subtle-notifying {
 	color: #6BACC5;
@@ -288,7 +314,7 @@ button:disabled {
 	background: #111111;
 }
 .dark .textbox:focus {
-	outline: 1px solid #88CCFF;
+	outline: 1px solid #6295bc;
 	border-color: #9199a2;
 	/* box-shadow: 0px 0px 4px #88CCFF, 0px 0px 6px #88CCFF; */
 }

--- a/style/battle-log.css
+++ b/style/battle-log.css
@@ -93,7 +93,10 @@ select.button {
 
 .button.disabled,
 .button.disabled:hover,
-.button.disabled:active {
+.button.disabled:active,
+.button:disabled,
+.button:disabled:hover,
+.button:disabled:active {
 	cursor: default;
 	background: #EEEEEE;
 	border: 1px solid #CCCCCC;
@@ -173,7 +176,10 @@ button:disabled {
 }
 .dark .button.disabled,
 .dark .button.disabled:hover,
-.dark .button.disabled:active {
+.dark .button.disabled:active,
+.dark .button:disabled,
+.dark .button:disabled:hover,
+.dark .button:disabled:active {
 	background: #555555;
 	border-color: #34373b;
 	box-shadow: 0.5px 1px 2px rgba(255, 255, 255, 0.45);

--- a/style/battle-log.css
+++ b/style/battle-log.css
@@ -39,7 +39,7 @@
 .dark .blocklink {
 	box-shadow: none;
 	text-shadow: none;
-	border-color: #7799BB;
+	border-color: #526c87;
 	background: rgba(30, 40, 50, .5);
 	color: #7799BB;
 }
@@ -75,18 +75,21 @@ button, summary {
 	text-shadow: 0 1px 0 white;
 	border: 1px solid #AAAAAA;
 	background: #e3e3e3;
-	background: linear-gradient(to bottom,  #f6f6f6,  #e3e3e3);
+	background: linear-gradient(to bottom,  #f6f6f6,  #d3d3d3);
 
 	font-size: 9pt;
 	padding: 3px 8px;
 }
+select.button {
+	text-align: left;
+}
 .button:hover {
 	background: #cfcfcf;
-	background: linear-gradient(to bottom,  #f2f2f2,  #c2c2c2);
+	background: linear-gradient(to bottom,  #f2f2f2,  #b2b2b2);
 	border-color: #606060;
 }
 .button:active {
-	background: linear-gradient(to bottom,  #cfcfcf,  #f2f2f2);
+	background: linear-gradient(to bottom,  #bfbfbf,  #f2f2f2);
 }
 
 .button.disabled,
@@ -104,28 +107,45 @@ button:disabled {
 	cursor: default;
 }
 
+.button-first, .button-middle {
+	border-top-right-radius: 0;
+	border-bottom-right-radius: 0;
+}
+.button-last, .button-middle {
+	border-top-left-radius: 0;
+	border-bottom-left-radius: 0;
+	margin-left: -1px;
+}
+.button-first:hover, .button-middle:hover {
+	/* puts the right-border over the left border of the button to the right of it */
+	position: relative;
+}
+
 .dark .button {
-	background: #484848;
-	box-shadow: inset 0 3px 4px rgba(255, 255, 255, 0.25);
-	border-color: #A9A9A9;
+	background: #2b2c31;
+	background: linear-gradient(to bottom, #4e525a, #2b2c31);
+	box-shadow: 0.5px 1px 2px rgba(255, 255, 255, 0.45), inset 0.5px 1px 1px rgba(255, 255, 255, 0.5);
+	border-color: #34373b;
 	text-shadow: none;
 	color: #F9F9F9;
 }
 .dark .button:hover {
-	background: #606060;
-	border-color: #EEEEEE;
+	background: #3e4149;
+	background: linear-gradient(to bottom, #646877, #3e4149);
+	border-color: #50555b
 }
 .dark .button:active {
-	background: #3A3A3A;
-	border-color: #EEEEEE;
+	background: #2b2c31;
+	background: linear-gradient(to bottom, #2b2c31, #4e525a);
+	border-color: #34373b;
 	box-shadow: none;
 }
 .dark .button.disabled,
 .dark .button.disabled:hover,
 .dark .button.disabled:active {
 	background: #555555;
-	border-color: #555555;
-	box-shadow: none;
+	border-color: #34373b;
+	box-shadow: 0.5px 1px 2px rgba(255, 255, 255, 0.45);
 	color: #999999;
 }
 
@@ -217,26 +237,33 @@ button:disabled {
 	color: #555555;
 }
 .dark .textbox {
-	border-color: #888888;
+	border-color: #6b7178;
 
-	box-shadow: inset 0px -1px 2px #606060, -1px -1px 0 rgba(255,255,255,.2);
-	background: #282B2D;
+	/* box-shadow: inset 0px -1px 2px #606060, -1px -1px 0 rgba(255,255,255,.2); */
+	box-shadow: inset 0.5px 1px 2px rgba(0, 0, 0, 1), inset -0.5px -1px 1px rgba(255, 255, 255, 0.2), -0.5px -1px 1px rgba(255, 255, 255, 0.1);
+	background: #222527;
 	color: #DDD;
 }
 .dark .textbox:hover {
-	border-color: #BBBBBB;
-	box-shadow: inset 0px -1px 2px #606060, -1px -1px 0 rgba(255,255,255,.2);
-	background: #222222;
+	border-color: #8d959f;
+	box-shadow: inset 0.5px 1px 2px rgba(0, 0, 0, 0.8), inset -0.5px -1px 1px rgba(255, 255, 255, 0.5), -0.5px -1px 1px rgba(255, 255, 255, 0.1);
+	background: #111111;
 }
 .dark .textbox:focus,
 .dark .button:focus {
-	outline: 0 none;
-	border-color: #BBBBBB;
-	box-shadow: 0px 0px 4px #88CCFF, 0px 0px 6px #88CCFF;
+	outline: 1px solid #88CCFF;
+	border-color: #9199a2;
+	/* box-shadow: 0px 0px 4px #88CCFF, 0px 0px 6px #88CCFF; */
 }
 .dark .textbox:focus {
 	background: #111111;
-	box-shadow: inset 0px -1px 2px #606060, 0px 0px 4px #88CCFF, 0px 0px 6px #88CCFF;
+	/* box-shadow: inset 0.5px 1px 2px rgba(0, 0, 0, 0.8), inset -0.5px -1px 1px rgba(255, 255, 255, 0.5), 0px 0px 4px #88CCFF, 0px 0px 6px #88CCFF; */
+}
+.dark .textbox.disabled, .dark .textbox:disabled {
+	opacity: 0.7;
+	color: #AAA;
+	border-color: #444;
+	box-shadow: none;
 }
 
 .option {
@@ -277,6 +304,10 @@ hr {
 	border-bottom: 0;
 	border-left: 0;
 	border-right: 0;
+}
+
+.dark hr {
+	border-color: #707070;
 }
 
 select {
@@ -338,6 +369,50 @@ input[type=range]:active::-webkit-slider-thumb {
 	box-shadow: inset 0px 1px 1px #DDD;
 }
 
+/** stolen from devdocs.io */
+.dark:not(.native-scrollbars) *::-webkit-scrollbar {
+	-webkit-appearance: none
+}
+.dark:not(.native-scrollbars) *::-webkit-scrollbar:vertical {
+	width: 16px
+}
+.dark:not(.native-scrollbars) *::-webkit-scrollbar:horizontal {
+	height: 16px
+}
+.dark:not(.native-scrollbars) *::-webkit-scrollbar-button,.dark:not(.native-scrollbars) *::-webkit-scrollbar-corner {
+	display: none
+}
+.dark:not(.native-scrollbars) *::-webkit-scrollbar-track {
+	background: transparent;
+	border: 1px solid transparent;
+}
+.dark:not(.native-scrollbars) *::-webkit-scrollbar-track:hover {
+	background: #24282a;
+	border-color: #000000;
+}
+.dark:not(.native-scrollbars) *::-webkit-scrollbar-track:vertical {
+	border-width: 0 0 0 1px;
+}
+.dark:not(.native-scrollbars) *::-webkit-scrollbar-track:vertical:corner-present {
+	border-width: 0 0 1px 1px;
+	border-radius: 0 0 0 2px;
+}
+.dark:not(.native-scrollbars) *::-webkit-scrollbar-track:horizontal {
+	border-width: 1px 1px 0 1px;
+	border-radius: 2px 2px 0 0;
+}
+.dark:not(.native-scrollbars) *::-webkit-scrollbar-thumb {
+	min-height: 2rem;
+	background: #6c6c6f;
+	background-clip: padding-box;
+	border: 5px solid transparent;
+	border-radius: 10px;
+}
+.dark:not(.native-scrollbars) *::-webkit-scrollbar-thumb:hover,.dark:not(.native-scrollbars) *::-webkit-scrollbar-thumb:active {
+	background-color: #949697;
+	border-width: 4px;
+}
+
 /*********************************************************
  * Everything else
  *********************************************************/
@@ -353,6 +428,7 @@ input[type=range]:active::-webkit-slider-thumb {
 }
 .dark .message-log h2 {
 	background: #555555;
+	border-color: #5A5A5A;
 }
 .chat, .notice {
 	vertical-align: middle;

--- a/style/battle.css
+++ b/style/battle.css
@@ -5,7 +5,7 @@ License: GPLv2
 
 */
 
-@import url(./battle-log.css?v4);
+@import url(./battle-log.css?v6);
 
 .battle {
 	position: absolute;

--- a/style/battle.css
+++ b/style/battle.css
@@ -75,6 +75,9 @@ License: GPLv2
 	overflow-scrolling: touch;
 	word-wrap: break-word;
 }
+.dark .battle, .dark .battle-log, .dark .battle-log-add {
+	border-color: #5A5A5A;
+}
 .battle-log-inline {
 	position: static;
 	top: auto;

--- a/style/battle.css
+++ b/style/battle.css
@@ -790,7 +790,7 @@ License: GPLv2
 #tooltipwrapper .tooltip p small {
 	font-size: 8pt;
 }
-#tooltipwrapper .tooltip p.section {
+#tooltipwrapper .tooltip p.tooltip-section {
 	border-top: 1px solid #888888;
 }
 #tooltipwrapper .tooltip .textaligned-typeicons img {

--- a/style/client.css
+++ b/style/client.css
@@ -437,7 +437,6 @@ span.header-username:hover {
 .scrollable {
 	overflow: auto;
 	-webkit-overflow-scrolling: touch;
-	overflow-scrolling: touch;
 }
 .ps-room.ps-room-light {
 	background: rgba(242,247,250,.85);
@@ -459,7 +458,6 @@ span.header-username:hover {
 
 	overflow: auto;
 	-webkit-overflow-scrolling: touch;
-	overflow-scrolling: touch;
 	z-index: 20;
 }
 .ps-popup {
@@ -757,7 +755,6 @@ p.or:after {
 
 	overflow: auto;
 	-webkit-overflow-scrolling: touch;
-	overflow-scrolling: touch;
 	word-wrap: break-word;
 }
 .pm-buttonbar {
@@ -1071,7 +1068,6 @@ p.or:after {
 	overflow: auto;
 	overflow-x: hidden;
 	-webkit-overflow-scrolling: touch;
-	overflow-scrolling: touch;
 	word-wrap: break-word;
 }
 .chat-log-add {
@@ -1444,7 +1440,6 @@ a.ilink.yours {
 
 	overflow: auto;
 	-webkit-overflow-scrolling: touch;
-	overflow-scrolling: touch;
 }
 .pm-buttonbar {
 	height: 21px;
@@ -2586,8 +2581,6 @@ a.ilink.yours {
 	color: #CC3311;
 	border-color: #CC3311;
 }
-.setchart-nickname input {
-}
 .setchart .setcell-details input {
 	width: 216px;
 }
@@ -2711,7 +2704,6 @@ a.ilink.yours {
 
 	overflow-y: scroll;
 	-webkit-overflow-scrolling: touch;
-	overflow-scrolling: touch;
 }
 @media (max-height:410px) {
 	.teambuilder-results {
@@ -2748,7 +2740,6 @@ a.ilink.yours {
 
 	overflow: auto;
 	-webkit-overflow-scrolling: touch;
-	overflow-scrolling: touch;
 }
 .teamwrapper.scaled {
 	width: 640px;

--- a/style/client.css
+++ b/style/client.css
@@ -843,14 +843,20 @@ p.or:after {
 	border-color: #AA8866;
 	background: #E3C3A3;
 }
+.dark .pm-window h3.pm-notifying {
+	background: #417589;
+}
 .pm-window h3.pm-notifying:hover {
 	border-color: #604020;
 	background: #CFAF8F;
 }
+.dark .pm-window h3.pm-notifying:hover {
+	background: #417589;
+}
 .pm-window h3 .closebutton,
 .pm-window h3 .minimizebutton {
 	float: right;
-	margin: -3px -3px;
+	margin: -2px -3px;
 	width: 22px;
 	height: 22px;
 }

--- a/style/client.css
+++ b/style/client.css
@@ -28,20 +28,8 @@ body {
 .pad p {
 	margin: 9px 0;
 }
-.label {
-	font-size: 9pt;
-	font-weight: bold;
-	display: block;
-}
-.optlabel {
-	font-size: 9pt;
-	display: block;
-}
 .label strong {
 	font-size: 11pt;
-	display: block;
-}
-.label .textbox {
 	display: block;
 }
 .buttonbar {
@@ -54,79 +42,11 @@ select {
 	font-family: Verdana, Helvetica, Arial, sans-serif;
 }
 
-/* .dark a.button {
-	color: #222222;
-	text-shadow: 0 1px 0 white;
-	border: solid 1px #AAAAAA;
-	background: #e3e3e3;
-	background: linear-gradient(to bottom,  #f6f6f6,  #e3e3e3);
+.dark .tabbar a.button {
+	box-shadow: inset 0.5px 1px 1px rgba(255, 255, 255, 0.5);
 }
-.dark a.button:hover {
-	background: #cfcfcf;
-	background: linear-gradient(to bottom,  #f2f2f2,  #c2c2c2);
-	border-color: #606060;
-}
-.dark a.button:active {
-	background: linear-gradient(to bottom,  #cfcfcf,  #f2f2f2);
-} */
-
-.dark .button.notifying {
-	background: #417589;
-	background: linear-gradient(to bottom, #6BACC5, #417589);
-}
-
-.dark .button.notifying.subtle {
-	border-color: #000000;
-	background: #b2d7f7;
-	color: black;
-}
-
-.dark .button.notifying:hover {
-	background: #5499b4;
-	background: linear-gradient(to bottom, #7bc9e7, #5499b4);
-}
-
-.dark a.button:visited {
-	color: #F9F9F9;
-}
-.dark a.button.subtle-notifying {
-	color: #61A3BB;
-}
-
-/* .dark .roomtab.button.closable,
-.dark .roomtab.button {
-	background: #3A3A3A;
-	border-color: #A9A9A9;
-	color: #F9F9F9;
-	text-shadow: 1px 1px 0 #111;
-}
-.dark .roomtab.button:hover {
-	background: #606060;
-	border-color: #EEEEEE;
-}
-.dark .roomtab.button.cur.closable,
-.dark .roomtab.button.cur {
-	background: #636363;
-	border-color: #A9A9A9;
-	color: #F9F9F9;
-	text-shadow: 1px 1px 0 #111;
-} */
-.dark .tabbar a.button.subtle-notifying {
-	color: #6BACC5;
-}
-.dark .tabbar a.button.notifying {
-	background: #417589;
-	background: linear-gradient(to bottom, #6BACC5, #417589);
-	text-shadow: none;
-}
-.dark .tabbar a.button.notifying:hover {
-	background: #5499b4;
-	background: linear-gradient(to bottom, #7bc9e7, #5499b4);
-}
-.dark .tabbar a.button:active {
-	background: #2b2c31;
-	background: linear-gradient(to bottom, #2b2c31, #4e525a);
-	border-color: #34373b;
+.dark .tabbar a.button:active,
+.dark .tabbar a.button.cur:active {
 	box-shadow: none;
 }
 .dark .maintabbarbottom {
@@ -135,16 +55,7 @@ select {
 	border-top-color: #34373b;
 }
 
-/* .dark button {
-	background: #777777;
-	box-shadow: none;
-	border: 1px solid #EEEEEE;
-	color: #EEEEEE;
-	border-radius: 5px;
-}
-*/
 .dark .folderButton,
-.dark .tabbar a.button,
 .dark .popupmenu .folderButton,
 .dark .popupmenu .folderButtonOpen,
 .dark .popupmenu button.button {
@@ -167,8 +78,7 @@ select {
 .dark .popupmenu button.folderButtonOpen:hover,
 .dark .folderButton:hover,
 .dark .popupmenu button.folderButton:hover,
-.dark .popupmenu button.button:hover,
-.dark .tabbar a.button:hover {
+.dark .popupmenu button.button:hover {
 	background: #3e4149;
 	background: linear-gradient(to bottom, #646877, #3e4149);
 	border-color: #34373b;
@@ -389,30 +299,14 @@ select {
 	box-shadow: 0 1px 2px rgba(0,0,0,.1);
 }
 
-.button.notifying {
-	border-color: #AA8866;
-	background: #e3c3a3;
-}
-.button.notifying:hover {
-	border-color: #604020;
-	background: #cfaf8f;
-}
-.button.notifying.subtle {
-	border-color: #000000;
-	background: #b2d7f7;
-	color: black;
-}
 .button.cur,
 .folderButton.cur,
 .button.cur:hover {
-	color: #777777;
+	color: #333333;
 	background: #f8f8f8;
 	box-shadow: none;
 	border-color: #AAAAAA;
 	cursor: default;
-}
-.button.subtle-notifying {
-	color: #AA6600;
 }
 .button.subtle-notifying .fa-comment-o:before,
 .button.notifying .fa-comment-o:before {
@@ -428,7 +322,6 @@ i.subtle:hover {
 	opacity: 1.0;
 	filter: alpha(opacity=100);
 }
-
 
 .tabbar li,
 .tabbar ul {
@@ -450,8 +343,11 @@ i.subtle:hover {
 	margin: 0 -1px 0 0;
 	top: 1px;
 	border-radius: 0;
-	box-shadow: none;
+	box-shadow: inset 0 -1px 2px rgba(255,255,255,1);
 	font-size: 11px;
+}
+.tabbar a.button.cur {
+	box-shadow: none;
 }
 .tabbar a.button i {
 	display: block;
@@ -552,10 +448,12 @@ span.header-username:hover {
 	color: #661111;
 }
 .pm-minimized .minimizebutton .fa-minus-circle:before {
+	/** replace the minus with a plus when PM is minimized */
 	content: "\f055";
 }
 
 .tablist li, .tablist ul {
+	/** tablist is the menu that's displayed when the window is too wide for all the tabs */
 	list-style: none;
 	margin: 0;
 	padding: 0;
@@ -1254,32 +1152,6 @@ p.or:after {
 	max-width: 480px;
 	text-align: left;
 }
-.roomlist a.ilink {
-	display: block;
-	margin: 2px 7px 4px 7px;
-	padding: 1px 4px 2px 4px;
-	border: 1px solid #BBCCDD;
-	background: rgba(248, 251, 253, 0.5);
-
-	border-radius: 4px;
-	text-decoration: none;
-	color: #336699;
-	text-shadow: #ffffff 0px -1px 0;
-	cursor: pointer;
-	font-size: 10pt;
-
-	overflow: hidden;
-	white-space: nowrap;
-}
-.roomlist a.ilink small {
-	font-size: 8pt;
-}
-.roomlist a.ilink:hover {
-	border-color: #778899;
-	background: #E5EAED;
-	color: #224466;
-	text-decoration: none;
-}
 .roomlist .subrooms {
 	font-size: 8pt;
 	padding-left: 20px;
@@ -1288,7 +1160,7 @@ p.or:after {
 .roomlist .subrooms i.fa-level-up {
 	margin-right: 5px;
 }
-.roomlist .subrooms a.ilink {
+.roomlist .subrooms a.blocklink {
 	display: inline-block;
 	margin: 0;
 	vertical-align: middle;
@@ -3289,6 +3161,7 @@ a.ilink.yours {
 .dark .pm-log {
 	background: rgba(0,0,0,.85);
 	color: #DDD;
+	backdrop-filter: blur(4px);
 }
 
 .dark .userlist-maximized {
@@ -3325,6 +3198,7 @@ a.ilink.yours {
 .dark .chat-log {
 	background: rgba(0,0,0,.5);
 	color: #DDD;
+	backdrop-filter: blur(4px);
 }
 
 .dark .userbar .username {
@@ -3562,49 +3436,9 @@ a.ilink.yours {
 	color: #BBB;
 }
 
-/* rooms */
-.dark .roomlist a.ilink {
-	box-shadow: none;
-	text-shadow: none;
-}
-
-.dark .roomlist a.ilink {
-	background: rgba(30, 40, 50, .5);
-	color: #7799BB;
-}
-.dark .roomlist a.ilink:hover {
-	border-color: #AACCEE;
-	background: rgba(30, 40, 50, 1);
-	color: #AACCEE;
-}
-
-/* misc */
+/* for testclient */
 .dark iframe.textbox,
 .dark iframe.textbox:hover,
 .dark iframe.textbox:focus {
 	background: #DDDDDD;
-}
-
-/*********************************************************
- * <blink>
- *********************************************************/
-
-@-webkit-keyframes blinker {
-	from { opacity: 1.0; }
-	to { opacity: 0.0; }
-}
-@keyframes blinker {
-	from { opacity: 1.0; }
-	to { opacity: 0.0; }
-}
-blink {
-	-webkit-animation-name: blinker;
-	-webkit-animation-iteration-count: infinite;
-	-webkit-animation-timing-function: cubic-bezier(1.0,0,0,1.0);
-	-webkit-animation-duration: 1s;
-	animation-name: blinker;
-	animation-iteration-count: infinite;
-	animation-timing-function: cubic-bezier(1.0,0,0,1.0);
-	animation-duration: 1s;
-	text-decoration: none;
 }

--- a/style/client.css
+++ b/style/client.css
@@ -71,8 +71,8 @@ select {
 } */
 
 .dark .button.notifying {
-	background: #6BACC5;
-	border-color: #2C9CC1;
+	background: #417589;
+	background: linear-gradient(to bottom, #6BACC5, #417589);
 }
 
 .dark .button.notifying.subtle {
@@ -82,8 +82,8 @@ select {
 }
 
 .dark .button.notifying:hover {
-	background: #6BACC5;
-	border-color: #FFFFFF;
+	background: #5499b4;
+	background: linear-gradient(to bottom, #7bc9e7, #5499b4);
 }
 
 .dark a.button:visited {
@@ -118,6 +118,16 @@ select {
 	background: #417589;
 	background: linear-gradient(to bottom, #6BACC5, #417589);
 	text-shadow: none;
+}
+.dark .tabbar a.button.notifying:hover {
+	background: #5499b4;
+	background: linear-gradient(to bottom, #7bc9e7, #5499b4);
+}
+.dark .tabbar a.button:active {
+	background: #2b2c31;
+	background: linear-gradient(to bottom, #2b2c31, #4e525a);
+	border-color: #34373b;
+	box-shadow: none;
 }
 .dark .maintabbarbottom {
 	background: #555555;
@@ -170,16 +180,6 @@ select {
 	color: #F9F9F9;
 }
 
-.dark .tabbar a.button.notifying:hover {
-	background: #5499b4;
-	background: linear-gradient(to bottom, #7bc9e7, #5499b4);
-}
-.dark .tabbar a.button:active {
-	background: #2b2c31;
-	background: linear-gradient(to bottom, #2b2c31, #4e525a);
-	border-color: #34373b;
-	box-shadow: none;
-}
 .dark .button.cur,
 .dark .button.cur:hover,
 .dark .tabbar a.button.cur,
@@ -189,21 +189,6 @@ select {
 	box-shadow: none;
 	color: #F9F9F9;
 }
-.dark .button.disabled,
-.dark .button.disabled:hover,
-.dark .button.disabled:active {
-	background: #555555;
-	border-color: #555555;
-	box-shadow: none;
-	color: #999999;
-}
-/*
-.dark .closebutton,
-.dark .minimizebutton,
-.dark button.subtle {
-	background: none;
-	border: none;
-} */
 
 /*********************************************************
  * Header
@@ -691,7 +676,9 @@ span.header-username:hover {
 	margin: 80px auto 20px auto;
 	max-width: 320px;
 }
-.ps-popup p,
+.ps-popup p {
+	margin: 4px 0;
+}
 .ps-popup h3 {
 	margin: 7px 0;
 }

--- a/style/client.css
+++ b/style/client.css
@@ -55,41 +55,6 @@ select {
 	border-top-color: #34373b;
 }
 
-.dark .folderButton,
-.dark .popupmenu .folderButton,
-.dark .popupmenu .folderButtonOpen,
-.dark .popupmenu button.button {
-	background: #2b2c31;
-	background: linear-gradient(to bottom, #4e525a, #2b2c31);
-	box-shadow: inset 0.5px 1px 1px rgba(255, 255, 255, 0.5);
-	border-color: #34373b;
-	text-shadow: none;
-	color: #F9F9F9;
-}
-
-.dark .popupmenu button.folderButtonOver {
-	background: linear-gradient(to bottom, #2a2a2a, #313131);
-}
-
-.dark .popupmenu button.folderButtonOpen:hover {
-	color: #F9F9F9;
-}
-
-.dark .popupmenu button.folderButtonOpen:hover,
-.dark .folderButton:hover,
-.dark .popupmenu button.folderButton:hover,
-.dark .popupmenu button.button:hover {
-	background: #3e4149;
-	background: linear-gradient(to bottom, #646877, #3e4149);
-	border-color: #34373b;
-}
-
-.dark .folderButton:hover,
-.dark .popupmenu button.folderButton:hover,
-.dark .popupmenu button.button:hover {
-	color: #F9F9F9;
-}
-
 .dark .button.cur,
 .dark .button.cur:hover,
 .dark .tabbar a.button.cur,
@@ -208,61 +173,13 @@ select {
 	border-radius: 0;
 }
 
-.popupmenu button.button {
-	outline: none;
-	cursor: pointer;
-	text-align: center;
-	text-decoration: none;
-	border-radius: 5px;
-	-webkit-box-shadow: 0 1px 2px rgba(0,0,0,.2), inset 0 -1px 2px rgba(255,255,255,1);
-	-moz-box-shadow: 0 1px 2px rgba(0,0,0,.2), inset 0 -1px 2px rgba(255,255,255,1);
-	box-shadow: 0 1px 2px rgba(0,0,0,.2), inset 0 -1px 2px rgba(255,255,255,1);
-	border-radius: 5px;
-	font-family: Verdana, Helvetica, Arial, sans-serif;
-	display: inline-block;
-
-	/* default colors */
-	color: #222222;
-	text-shadow: 0 1px 0 white;
-	border: solid 1px #AAAAAA;
-	background: #e3e3e3;
-	background: linear-gradient(to bottom,  #f6f6f6,  #e3e3e3);
-
-	font-size: 9pt;
-	padding: 3px 8px;
+.popupmenu .option {
+	width: 204px;
 }
-
 .popupmenu i {
 	display: inline-block;
 	width: 16px;
 	color: #777777;
-}
-
-.popupmenu button.folderButton,
-.popupmenu button.folderButtonOpen {
-	width: 172px;
-	outline: none;
-	cursor: pointer;
-	text-decoration: none;
-	border-radius: 5px;
-	-webkit-box-shadow: 0 1px 2px rgba(0,0,0,.2), inset 0 -1px 2px rgba(255,255,255,1);
-	-moz-box-shadow: 0 1px 2px rgba(0,0,0,.2), inset 0 -1px 2px rgba(255,255,255,1);
-	box-shadow: 0 1px 2px rgba(0,0,0,.2), inset 0 -1px 2px rgba(255,255,255,1);
-	border-radius: 5px;
-	font-family: Verdana, Helvetica, Arial, sans-serif;
-	display: inline-block;
-	/* default colors */
-	color: #222222;
-	text-shadow: 0 1px 0 white;
-	border: solid 1px #AAAAAA;
-	background: #e3e3e3;
-	background: linear-gradient(to bottom,  #f6f6f6,  #e3e3e3);
-	font-size: 9pt;
-	padding: 3px 8px;
-}
-
-.popupmenu button.folderButtonOpen {
-	background: linear-gradient(to bottom,  #e4e4e4,  #d3d3d3);
 }
 
 .button.small,
@@ -274,16 +191,6 @@ select {
 .button.big {
 	font-size: 12pt;
 	padding: 5px 10px;
-}
-.popupmenu button.folderButton:hover,
-.popupmenu button.folderButtonOpen:hover,
-.popupmenu button.button:hover {
-	background: #cfcfcf;
-	background: linear-gradient(to bottom,  #f2f2f2,  #c2c2c2);
-	border-color: #606060;
-}
-.popupmenu button.button:active {
-	background: linear-gradient(to bottom,  #cfcfcf,  #f2f2f2);
 }
 
 .mainmenuwrapper .menugroup .button.disabled,
@@ -300,7 +207,6 @@ select {
 }
 
 .button.cur,
-.folderButton.cur,
 .button.cur:hover {
 	color: #333333;
 	background: #f8f8f8;
@@ -624,21 +530,6 @@ p.or:after {
 .popupmenu li:first-child h3 {
 	margin-top: 0;
 }
-.popupmenu button {
-	display: block;
-	font-size: 8pt;
-	font-family: Verdana, Helvetica, Arial, sans-serif;
-	margin: 0 0 0 6px;
-	padding: 2px 3px;
-	border: 1px solid transparent;
-	border-radius: 2px;
-	background: transparent;
-	color: black;
-	width: 204px;
-	text-align: left;
-
-	box-sizing: border-box;
-}
 @media (max-height:590px) {
 	.popupmenu h3 {
 		margin-top: 2px;
@@ -653,18 +544,7 @@ p.or:after {
 	}
 }
 
-.popupmenu button.sel {
-	border-color: #AAAAAA;
-	white-space: nowrap;
-	overflow: hidden;
-}
-.popupmenu button:hover,
-.popupmenu button.sel:hover {
-	border-color: #888888;
-	background: #D5D5D5;
-	color: black;
-}
-.popupmenu button.button {
+.popupmenu .button {
 	margin: 2px auto 5px;
 	width: 184px;
 }
@@ -845,6 +725,7 @@ p.or:after {
 }
 .dark .pm-window h3.pm-notifying {
 	background: #417589;
+	color: #BBBBBB;
 }
 .pm-window h3.pm-notifying:hover {
 	border-color: #604020;
@@ -3090,11 +2971,6 @@ a.ilink.yours {
 	float: left;
 	margin: 2px;
 	padding: 2px;
-
-	border: 1px solid transparent;
-	border-radius: 4px;
-	box-shadow: none;
-	background: transparent;
 }
 .avatarlist button {
 	width: 80px;
@@ -3107,20 +2983,8 @@ a.ilink.yours {
 	height: 90px;
 	background: url(../fx/client-bgsheet.png) no-repeat scroll 0px 0px;
 }
-.avatarlist button.cur,
-.formlist button.cur,
-.bglist button.cur {
-	border-color: #999999;
-}
-.avatarlist button:hover,
-.avatarlist button.cur:hover,
-.formlist button:hover,
-.formlist button.cur:hover,
-.bglist button:hover,
-.bglist button.cur:hover {
-	border: 1px solid #8899AA;
-	background-color: #F1F4F9;
-	box-shadow: 1px 1px 1px #D5D5D5;
+.formlist button {
+	background-repeat: no-repeat;
 }
 
 .effect-volume,
@@ -3226,20 +3090,6 @@ a.ilink.yours {
 	color: #BBB;
 }
 
-.dark .popupmenu button,
-.dark .bglist button,
-.dark .avatarlist button {
-	color: #AAA;
-	box-shadow: none;
-}
-.dark .popupmenu button:hover,
-.dark .popupmenu button.sel:hover,
-.dark .bglist button:hover,
-.dark .avatarlist button:hover {
-	border-color: #AAAAAA;
-	background-color: #AAAAAA;
-	color: black;
-}
 .dark .changeform i {
 	border-color: #bbb;
 	color: #bbb;

--- a/style/client.css
+++ b/style/client.css
@@ -44,45 +44,9 @@ body {
 .label .textbox {
 	display: block;
 }
-.textbox {
-	border: 1px solid #AAAAAA;
-	border-radius: 3px;
-	padding: 2px 3px;
-	font-family: Verdana, Helvetica, Arial, sans-serif;
-	font-size: 9pt;
-
-	box-shadow: inset 0px 1px 2px #CCCCCC, 1px 1px 0 rgba(255,255,255,.6);
-	background: #F8FBFD;
-	color: black;
-}
-.textbox:hover {
-	border-color: #474747;
-	box-shadow: inset 0px 1px 2px #D2D2D2, 1px 1px 0 rgba(255,255,255,.6);
-	background: #FFFFFF;
-}
-.textbox:focus,
-.button:focus {
-	outline: 0 none;
-	border-color: #004488;
-	box-shadow: inset 0px 1px 2px #D2D2D2, 0px 0px 5px #2266AA;
-}
-.textbox:focus {
-	background: #FFFFFF;
-}
-.textbox.disabled, .textbox:disabled {
-	background: #CCCCCC;
-	color: #555555;
-}
 .buttonbar {
 	margin-top: 1em;
 	text-align: center;
-}
-
-hr {
-	border-top: 1px solid #999999;
-	border-bottom: 0;
-	border-left: 0;
-	border-right: 0;
 }
 
 select {
@@ -129,27 +93,6 @@ select {
 	color: #61A3BB;
 }
 
-.dark .textbox {
-	border-color: #888888;
-
-	box-shadow: none;
-	background: #282B2D;
-	color: #DDD;
-}
-.dark .textbox:hover {
-	border-color: #BBBBBB;
-	box-shadow: none;
-	background: #222222;
-}
-.dark .textbox:focus,
-.dark .button:focus {
-	outline: 0 none;
-	border-color: #BBBBBB;
-	box-shadow: 0px 0px 4px #88CCFF, 0px 0px 4px #88CCFF;
-}
-.dark .textbox:focus {
-	background: #111111;
-}
 /* .dark .roomtab.button.closable,
 .dark .roomtab.button {
 	background: #3A3A3A;
@@ -172,14 +115,14 @@ select {
 	color: #6BACC5;
 }
 .dark .tabbar a.button.notifying {
-	background: #6BACC5;
-	border-color: #2C9CC1;
-	color: #000;
+	background: #417589;
+	background: linear-gradient(to bottom, #6BACC5, #417589);
 	text-shadow: none;
 }
 .dark .maintabbarbottom {
-	background: #636363;
-	border-color: #A9A9A9;
+	background: #555555;
+	border-color: #5A5A5A;
+	border-top-color: #34373b;
 }
 
 /* .dark button {
@@ -195,9 +138,10 @@ select {
 .dark .popupmenu .folderButton,
 .dark .popupmenu .folderButtonOpen,
 .dark .popupmenu button.button {
-	background: #484848;
-	box-shadow: inset 0 3px 4px rgba(255, 255, 255, 0.25);
-	border-color: #A9A9A9;
+	background: #2b2c31;
+	background: linear-gradient(to bottom, #4e525a, #2b2c31);
+	box-shadow: inset 0.5px 1px 1px rgba(255, 255, 255, 0.5);
+	border-color: #34373b;
 	text-shadow: none;
 	color: #F9F9F9;
 }
@@ -215,8 +159,9 @@ select {
 .dark .popupmenu button.folderButton:hover,
 .dark .popupmenu button.button:hover,
 .dark .tabbar a.button:hover {
-	background: #606060;
-	border-color: #EEEEEE;
+	background: #3e4149;
+	background: linear-gradient(to bottom, #646877, #3e4149);
+	border-color: #34373b;
 }
 
 .dark .folderButton:hover,
@@ -226,19 +171,21 @@ select {
 }
 
 .dark .tabbar a.button.notifying:hover {
-	background: #92C2D3;
+	background: #5499b4;
+	background: linear-gradient(to bottom, #7bc9e7, #5499b4);
 }
 .dark .tabbar a.button:active {
-	background: #3A3A3A;
-	border-color: #EEEEEE;
+	background: #2b2c31;
+	background: linear-gradient(to bottom, #2b2c31, #4e525a);
+	border-color: #34373b;
 	box-shadow: none;
 }
 .dark .button.cur,
 .dark .button.cur:hover,
 .dark .tabbar a.button.cur,
 .dark .tabbar a.button.cur:hover {
-	background: #636363;
-	border-color: #A9A9A9;
+	background: #555555;
+	border-color: #34373b;
 	box-shadow: none;
 	color: #F9F9F9;
 }
@@ -314,7 +261,7 @@ select {
 	display: block;
 	list-style: none;
 	margin: 0;
-	padding: 0 0 0 0;
+	padding: 2px 0 0 0;
 	height: 37px;
 	text-align: left;
 
@@ -335,6 +282,7 @@ select {
 	background: #f8f8f8;
 	border: solid 1px #AAAAAA;
 	border-left: 0;
+	border-right: 0;
 	margin: -1px 0 0 0;
 	-webkit-box-shadow: 0 1px 2px rgba(0,0,0,.2);
 	-moz-box-shadow: 0 1px 2px rgba(0,0,0,.2);
@@ -543,7 +491,9 @@ i.subtle:hover {
 	margin-right: -6px;
 }
 .tabbar a.button:hover,
-.tablist a.button:hover {
+.tablist a.button:hover,
+.tabbar a.button:focus,
+.tablist a.button:focus {
 	z-index: 10;
 }
 .tabbar a.button.cur,
@@ -592,12 +542,19 @@ i.subtle:hover {
 .closebutton:hover {
 	color: #BB2222;
 }
+.dark .closebutton:hover {
+	color: #EE7777;
+}
 span.header-username:hover {
 	color: #333333;
 }
 .minimizebutton:hover,
 .pm-window h3:hover .minimizebutton {
 	color: #333333;
+}
+.dark .minimizebutton:hover,
+.dark .pm-window h3:hover .minimizebutton {
+	color: #CCCCCC;
 }
 .pm-window h3 .closebutton:hover + .minimizebutton {
 	color: #999999 !important;
@@ -1054,6 +1011,18 @@ p.or:after {
 .pm-window.focused h3:hover {
 	background: #f8f8f8;
 	color: #222222;
+}
+.dark .pm-window h3 {
+	background: rgba(50,50,50,.8);
+	color: #AAA;
+}
+.dark .pm-window h3:hover {
+	color: #CCC;
+}
+.dark .pm-window.focused h3,
+.dark .pm-window.focused h3:hover {
+	background: #222;
+	color: #EEE;
 }
 .challenge {
 	margin-top: -1px;
@@ -1744,6 +1713,9 @@ a.ilink.yours {
 	border-right: 1px solid #AAAAAA;
 	border-bottom: 1px solid #AAAAAA;
 }
+.dark .userlist, .dark .pm-buttonbar button, .dark .chat-log-add, .dark .pm-window h3, .dark .pm-log, .dark .newsentry {
+	border-color: #5A5A5A;
+}
 .userlist-minimized {
 	height: 21px;
 	bottom: auto;
@@ -1780,8 +1752,7 @@ a.ilink.yours {
 	text-align: left;
 }
 .userlist li {
-	border-bottom: 1px solid #CCCCCC;
-	height: 19px;
+	height: 20px;
 	font: 10pt Verdana, sans-serif;
 	white-space: nowrap;
 }
@@ -1804,7 +1775,7 @@ a.ilink.yours {
 	border: 0;
 	padding: 1px 0;
 	margin: 0;
-	height: 19px;
+	height: 20px;
 	width: 100%;
 	white-space: nowrap;
 	font: 9pt Verdana, sans-serif;
@@ -3325,6 +3296,7 @@ a.ilink.yours {
 .dark .pm-log-add {
 	background: rgba(0,0,0,.70);
 	color: #DDD;
+	border-color: #5A5A5A;
 }
 
 .dark .pm-log {
@@ -3378,9 +3350,9 @@ a.ilink.yours {
 .dark .ps-popup {
 	background: #0D151E;
 	color: #DDD;
-	border-color: #888;
+	border-color: #34373b;
 
-	box-shadow: 2px 2px 3px rgba(0,0,0,.2);
+	box-shadow: 2px 2px 3px rgba(0,0,0,.5), inset 0.5px 1px 1px rgba(255, 255, 255, 0.5);
 }
 
 .dark .usergroup {
@@ -3482,6 +3454,7 @@ a.ilink.yours {
 }
 .dark a.ilink {
 	color: #4488EE;
+	border-color: #526c87;
 }
 .dark .chat.mine {
 	background: rgba(255,255,255,0.05);
@@ -3609,7 +3582,6 @@ a.ilink.yours {
 }
 
 .dark .roomlist a.ilink {
-	border-color: #7799BB;
 	background: rgba(30, 40, 50, .5);
 	color: #7799BB;
 }


### PR DESCRIPTION
Felucia mentioned she had some custom CSS in dark mode to make it darker, so I figured I'd try my hand at a design refresh to make it not quite so bright. In the process, I've made the buttons look more 3D, matching light mode. Sorry, any dark mode users who prefer flat design.

This also updates all remaining OS-style buttons into PS-style buttons, so they'll be properly dark-mode.

This refresh focuses on dark mode, but light mode gets some improvements as well.


![image](https://github.com/smogon/pokemon-showdown-client/assets/551184/08e82dd1-4106-45a2-ac6a-4fbee836fdd0)
(top: old, bottom: new)


![image](https://github.com/smogon/pokemon-showdown-client/assets/551184/7ac7d258-c8d5-47f8-97d7-9b220087f9bc)
(left: old, right: new)


![image](https://github.com/smogon/pokemon-showdown-client/assets/551184/836f8c3c-4e7e-4e54-8369-173404b4e405)
(left: old, right: new)


![image](https://github.com/smogon/pokemon-showdown-client/assets/551184/c9a47d17-630a-421c-88fd-61107f023bc3)
(left: old, right: new)


![image](https://github.com/smogon/pokemon-showdown-client/assets/551184/30a40c7e-1701-46a6-84f9-ca890c96ae8c)
(left: old, right: new)


![image](https://github.com/smogon/pokemon-showdown-client/assets/551184/b958def5-81dd-44c2-871c-590390a87d90)
(left: old, right: new)


![image](https://github.com/smogon/pokemon-showdown-client/assets/551184/85d7bc52-cc7e-4168-9cbd-4388eddbba87)
(left: old, right: new)


![image](https://github.com/smogon/pokemon-showdown-client/assets/551184/ac1be91c-3596-4d03-95f8-7af425a59e82)
(left: old, right: new)