### PR TITLE
Fix Tourney Bracket panning for touch devices

### DIFF
--- a/js/client-chat-tournament.js
+++ b/js/client-chat-tournament.js
@@ -60,11 +60,11 @@
 		var innerX = 0;
 		var innerY = 0;
 
-		$element.on('mousedown', function (e) {
+		$element.on('pointerdown', function (e) {
 			innerX = e.pageX + ($element.parent().width() - $element.width() - this.offsetLeft);
 			innerY = e.pageY - this.offsetTop;
 
-			function mouseMoveCallback(e) {
+			function pointerMoveCallback(e) {
 				position.right = innerX - e.pageX;
 				position.top = e.pageY - innerY;
 				delete position.isDefault;
@@ -74,9 +74,9 @@
 					top: position.top
 				});
 			}
-			$(document).on('mousemove', mouseMoveCallback)
-				.one('mouseup', function () {
-					$(document).off('mousemove', mouseMoveCallback);
+			$(document).on('pointermove', pointerMoveCallback)
+				.one('pointerup', function () {
+					$(document).off('pointermove', pointerMoveCallback);
 				});
 		});
 	}

--- a/style/client.css
+++ b/style/client.css
@@ -1219,6 +1219,7 @@ a.ilink.yours {
 	overflow: hidden;
 	transition: max-height 0.15s;
 	-webkit-transition: max-height 0.15s;
+	touch-action: none;
 }
 
 .tournament-bracket {
@@ -1226,14 +1227,18 @@ a.ilink.yours {
 	padding: 10px;
 	overflow: hidden;
 	font-size: 8pt;
+	touch-action: none;
 }
+
 .tournament-bracket-overflowing {
 	height: 200px;
 	padding: 0;
 	position: relative;
 	left: 0;
 	top: 0;
+	touch-action: none;
 }
+
 
 .tournament-popout-link {
 	position: absolute;

--- a/style/client2.css
+++ b/style/client2.css
@@ -1147,6 +1147,7 @@ a.ilink.yours {
 	overflow: hidden;
 	transition: max-height 0.15s;
 	-webkit-transition: max-height 0.15s;
+	touch-action: none;
 }
 
 .tournament-bracket {
@@ -1154,6 +1155,7 @@ a.ilink.yours {
 	padding: 10px;
 	overflow: hidden;
 	font-size: 8pt;
+	touch-action: none;
 }
 .tournament-bracket-overflowing {
 	height: 200px;
@@ -1161,6 +1163,7 @@ a.ilink.yours {
 	position: relative;
 	left: 0;
 	top: 0;
+	touch-action: none;
 }
 
 .tournament-popout-link {


### PR DESCRIPTION
Mobile devices that don't have a mouse-attached can't pan the tournament bracket view.  This was because the listeners were registered for specifically _mouse_ instead of _pointer_

This presents a fix.
I tested this for mobile versions of chrome, firefox, and opera (dev tools).  The panel can now be panned with touch.

-Quazizata