### PR TITLE
Improve April Fool's sprite support

### DIFF
--- a/play.pokemonshowdown.com/js/client-chat.js
+++ b/play.pokemonshowdown.com/js/client-chat.js
@@ -1054,11 +1054,11 @@
 				if (this.checkBroadcast(cmd, text)) return false;
 				var cleanedTarget = toID(target);
 				if (cleanedTarget === 'off' || cleanedTarget === 'disable') {
-					Config.server.afd = false;
+					Storage.prefs('afd', false);
 					if (typeof BattleTextNotAFD !== 'undefined') BattleText = BattleTextNotAFD;
 					this.add('April Fools\' day mode disabled.');
 				} else {
-					Config.server.afd = true;
+					Storage.prefs('afd', true);
 					if (typeof BattleTextAFD !== 'undefined') BattleText = BattleTextAFD;
 					this.add('April Fools\' day mode enabled.');
 				}

--- a/play.pokemonshowdown.com/src/battle-dex.ts
+++ b/play.pokemonshowdown.com/src/battle-dex.ts
@@ -742,13 +742,15 @@ const Dex = new class implements ModdedDex {
 			spriteid = species.spriteid || toID(pokemon.species);
 		}
 		if (species.exists === false) return { spriteDir: 'sprites/gen5', spriteid: '0', x: 10, y: 5 };
-		if (window.Config?.server?.afd || Dex.prefs('afd')) return {
-			spriteid,
-			spriteDir: 'sprites/afd',
-			shiny: !!pokemon.shiny,
-			x: 10,
-			y: 5,
-		};
+		if (window.Config?.server?.afd || Dex.prefs('afd')) {
+			return {
+				spriteid,
+				spriteDir: 'sprites/afd',
+				shiny: !!pokemon.shiny,
+				x: 10,
+				y: 5,
+			};
+		}
 		const spriteData: TeambuilderSpriteData = {
 			spriteid,
 			spriteDir: 'sprites/dex',

--- a/play.pokemonshowdown.com/src/battle-dex.ts
+++ b/play.pokemonshowdown.com/src/battle-dex.ts
@@ -742,7 +742,13 @@ const Dex = new class implements ModdedDex {
 			spriteid = species.spriteid || toID(pokemon.species);
 		}
 		if (species.exists === false) return { spriteDir: 'sprites/gen5', spriteid: '0', x: 10, y: 5 };
-		if (window.Config?.server?.afd || Dex.prefs('afd')) return { spriteDir: 'sprites/afd', spriteid, x: 10, y: 5 };
+		if (window.Config?.server?.afd || Dex.prefs('afd')) return {
+			spriteid,
+			spriteDir: 'sprites/afd',
+			shiny: !!pokemon.shiny,
+			x: 10,
+			y: 5,
+		};
 		const spriteData: TeambuilderSpriteData = {
 			spriteid,
 			spriteDir: 'sprites/dex',

--- a/play.pokemonshowdown.com/src/battle-dex.ts
+++ b/play.pokemonshowdown.com/src/battle-dex.ts
@@ -602,7 +602,7 @@ const Dex = new class implements ModdedDex {
 		if (options.shiny && mechanicsGen > 1) dir += '-shiny';
 
 		// April Fool's 2014
-		if (window.Config && Config.server && Config.server.afd || options.afd) {
+		if (window.Config?.server?.afd || Dex.prefs('afd') || options.afd) {
 			dir = 'afd' + dir;
 			spriteData.url += dir + '/' + name + '.png';
 			// Duplicate code but needed to make AFD tinymax work
@@ -742,6 +742,7 @@ const Dex = new class implements ModdedDex {
 			spriteid = species.spriteid || toID(pokemon.species);
 		}
 		if (species.exists === false) return { spriteDir: 'sprites/gen5', spriteid: '0', x: 10, y: 5 };
+		if (window.Config?.server?.afd || Dex.prefs('afd')) return { spriteDir: 'sprites/afd', spriteid, x: 10, y: 5 };
 		const spriteData: TeambuilderSpriteData = {
 			spriteid,
 			spriteDir: 'sprites/dex',


### PR DESCRIPTION
https://www.smogon.com/forums/threads/show-afd-sprites-in-teambuilder-if-the-mode-in-on.3731991/

- AFD sprites can now show up in the teambuilder
- Turning on AFD sprites now persists through reloads