### PR TITLE
Add animation for Electro Shot

### DIFF
--- a/play.pokemonshowdown.com/src/battle-animations-moves.ts
+++ b/play.pokemonshowdown.com/src/battle-animations-moves.ts
@@ -35893,3 +35893,7 @@ BattleMoveAnims['trailblaze'] = {anim: BattleMoveAnims['powerwhip'].anim};
 BattleMoveAnims['tripledive'] = {anim: BattleMoveAnims['dive'].anim};
 BattleMoveAnims['hydrosteam'] = {anim: BattleMoveAnims['steameruption'].anim};
 BattleMoveAnims['psyblade'] = {anim: BattleMoveAnims['psychocut'].anim};
+BattleMoveAnims['electroshot'] = {
+	anim: BattleMoveAnims['zapcannon'].anim,
+	prepareAnim: BattleOtherAnims.lightstatus.anim,
+};


### PR DESCRIPTION
I'm sure animations for all the new moves are being worked on, but I figured it would be best to get something in for Electro Shot rn so that the crash text for not having a prepareAnim doesn't appear every time it gets used.