### PR TITLE
Fix client sending the wrong team to the server in some cases

### DIFF
--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -794,12 +794,11 @@
 			var newTeam = this.createTeam(null, type === "box");
 			teams.unshift(newTeam);
 			for (var room in app.rooms) {
-				var teamSelectButton = app.rooms[room].$('button.teamselect');
-				var selection = teamSelectButton.val();
+				var selection = app.rooms[room].$('button.teamselect').val();
 				if (!selection || selection === 'random') continue;
 				var obj = app.rooms[room].id === "" ? app.rooms[room] : app.rooms[room].tournamentBox;
 				obj.curTeamIndex++;
-				teamSelectButton.val(parseInt(selection, 10) + 1);
+				obj.updateTeams();
 			}
 			this.edit(0);
 		},

--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -794,10 +794,12 @@
 			var newTeam = this.createTeam(null, type === "box");
 			teams.unshift(newTeam);
 			for (var room in app.rooms) {
-				var selection = app.rooms[room].$('button.teamselect').val();
+				var teamSelectButton = app.rooms[room].$('button.teamselect');
+				var selection = teamSelectButton.val();
 				if (!selection || selection === 'random') continue;
 				var obj = app.rooms[room].id === "" ? app.rooms[room] : app.rooms[room].tournamentBox;
 				obj.curTeamIndex++;
+				teamSelectButton.val(parseInt(selection, 10) + 1);
 			}
 			this.edit(0);
 		},


### PR DESCRIPTION
Bug fix for this report: https://www.smogon.com/forums/threads/bug-report-team-selector-after-creating-teams.3733626/

Teams are stored as an array in `Storage.teams`. The team selection dropdown determines which team to send to the server when a player hits "Battle!" by using its `value` attribute as an index for the teams array. When a new team is created at the top of the team list, its placed at the front of this array becoming index 0 and shifting all other indexes up by 1. However, the team selection drop down's value was not updated resulting in the client sending the wrong team to the server. This fixes this by incrementing the value when a new team is added to the top of the list.