### PR TITLE
Fix copy buttons within popups

### DIFF
--- a/play.pokemonshowdown.com/js/client.js
+++ b/play.pokemonshowdown.com/js/client.js
@@ -2608,6 +2608,10 @@ function toId() {
 				app.addPopupMessage("You are already registered!");
 			}
 		},
+
+		copyText: function (value, target) {
+			app.curRoom.copyText(value, target);
+		},
 	});
 
 	var PromptPopup = this.PromptPopup = Popup.extend({


### PR DESCRIPTION
Fixes bug report: https://www.smogon.com/forums/threads/bug-report-copy-button-for-replays-does-not-work.3733583/

Popups lack support for copy buttons currently, this adds support by simply delegating the work to the current room's `copyText` method.