### PR TITLE
Wrap long format names

### DIFF
--- a/play.pokemonshowdown.com/style/battle-log.css
+++ b/play.pokemonshowdown.com/style/battle-log.css
@@ -375,7 +375,6 @@ select.button {
 	font-size: 9pt;
 	font-family: Verdana, sans-serif;
 	text-align: left;
-	white-space: nowrap;
 	overflow: hidden;
 }
 .option.sel, .option.cur {


### PR DESCRIPTION
![image](https://github.com/smogon/pokemon-showdown-client/assets/25151198/55b1e832-4c7f-436a-8522-3fbc44d6e463)

I noticed certain format names in the formats dropdown are too long and end up cutting off, this change removes no-wrap from .option to make sure they do.

I went through every usage of the `.option` class and most of them have static-length content that is not affected by this change, the only other place this matters is for long team names in the team dropdown, which seems like a neutral (maybe slightly positive?) outcome for usability