### PR TITLE
Add horizontal scroll bars to wide infoboxes on small screens

### DIFF
--- a/play.pokemonshowdown.com/style/battle-log.css
+++ b/play.pokemonshowdown.com/style/battle-log.css
@@ -749,6 +749,7 @@ details.readmore[open] summary:hover:before {
 	border: 1px solid #7799BB;
 	padding: 2px 4px;
 	border-radius: 4px;
+	overflow-x: auto;
 }
 .dark .infobox {
 	border-color: #506070;


### PR DESCRIPTION
implements the [suggestion to add a horizontal scrollbar for boxes on smaller resolution screens](https://www.smogon.com/forums/threads/add-a-horizontal-scrollbar-for-boxes-on-smaller-resolution-screens.3671644/)

This only affects boxes that have a set width that is already overflowing, and as such shouldn't have any implications for boxes that didn't already look horrid to begin with. This would put burden on writers of infoboxes to use width or min-width properties if they don't function below a certain width, but they should've been doing that anyway so I don't think it's within the scope of this change to do it for them.