### PR TITLE
Teambuilder: Fix IV values for certain Indigo Disk Pokemon

### DIFF
--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -3286,6 +3286,9 @@
 				minSpe = true;
 			}
 
+			// only available through an event with 31 Spe IVs
+			if (set.species.startsWith('Terapagos')) minSpe = false;
+
 			if (this.curTeam.format === 'gen7hiddentype') return;
 
 			var minAtk = true;
@@ -3337,10 +3340,10 @@
 			if (minAtk) {
 				// min Atk
 				if (['Gouging Fire', 'Iron Boulder', 'Iron Crown', 'Raging Bolt'].includes(set.species)) {
-					// Min 20 IVs
+					// only available with 20 Atk IVs
 					set.ivs['atk'] = 20;
 				} else if (set.species.startsWith('Terapagos')) {
-					// Min 15 IVs
+					// only available with 15 Atk IVs
 					set.ivs['atk'] = 15;
 				} else {
 					set.ivs['atk'] = (hasHiddenPower ? set.ivs['atk'] % hpModulo : 0);

--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -3336,7 +3336,15 @@
 			if (!set.ivs['atk'] && set.ivs['atk'] !== 0) set.ivs['atk'] = 31;
 			if (minAtk) {
 				// min Atk
-				set.ivs['atk'] = (hasHiddenPower ? set.ivs['atk'] % hpModulo : 0);
+				if (['Gouging Fire', 'Iron Boulder', 'Iron Crown', 'Raging Bolt'].includes(set.species)) {
+					// Min 20 IVs
+					set.ivs['atk'] = 20;
+				} else if (set.species.startsWith('Terapagos')) {
+					// Min 15 IVs
+					set.ivs['atk'] = 15;
+				} else {
+					set.ivs['atk'] = (hasHiddenPower ? set.ivs['atk'] % hpModulo : 0);
+				}
 			} else {
 				// max Atk
 				set.ivs['atk'] = (hasHiddenPower ? 30 + (set.ivs['atk'] % 2) : 31);


### PR DESCRIPTION
streamlines validation progress for the new Min-20/15 IV pokemon given to us in Indigo Disk DLC