### PR TITLE
Fix dynamax using Pokemon-specific animations

### DIFF
--- a/play.pokemonshowdown.com/src/battle-animations.ts
+++ b/play.pokemonshowdown.com/src/battle-animations.ts
@@ -2474,7 +2474,6 @@ export class PokemonSprite extends Sprite {
 		}
 	}
 	customAnimAndIfCry(speciesid: ID, isDynamaxing?: boolean): boolean {
-		console.log("customAnimAndIfCry is running");
 		const scene = this.scene;
 		if (isDynamaxing) {
 			BattleOtherAnims.megaevo.anim(scene, [this]);

--- a/play.pokemonshowdown.com/src/battle-scene-stub.ts
+++ b/play.pokemonshowdown.com/src/battle-scene-stub.ts
@@ -67,7 +67,7 @@ export class BattleSceneStub {
 	resetStatbar(pokemon: Pokemon, startHidden?: boolean) { }
 	updateStatbar(pokemon: Pokemon, updatePrevhp?: boolean, updateHp?: boolean) { }
 	updateStatbarIfExists(pokemon: Pokemon, updatePrevhp?: boolean, updateHp?: boolean) { }
-	animTransform(pokemon: Pokemon, isCustomAnim?: boolean, isPermanent?: boolean) { }
+	animTransform(pokemon: Pokemon, isCustomAnim?: boolean, isPermanent?: boolean, isDynamaxing?: boolean) { }
 	clearEffects(pokemon: Pokemon) { }
 	removeTransform(pokemon: Pokemon) { }
 	animFaint(pokemon: Pokemon) { }

--- a/play.pokemonshowdown.com/src/battle.ts
+++ b/play.pokemonshowdown.com/src/battle.ts
@@ -2560,7 +2560,7 @@ export class Battle {
 				break;
 			case 'dynamax':
 				poke.addVolatile('dynamax' as ID, !!args[3]);
-				this.scene.animTransform(poke, true, undefined, true);
+				this.scene.animTransform(poke, true, false, true);
 				break;
 			case 'powertrick':
 				this.scene.resultAnim(poke, 'Power Trick', 'neutral');

--- a/play.pokemonshowdown.com/src/battle.ts
+++ b/play.pokemonshowdown.com/src/battle.ts
@@ -2560,7 +2560,7 @@ export class Battle {
 				break;
 			case 'dynamax':
 				poke.addVolatile('dynamax' as ID, !!args[3]);
-				this.scene.animTransform(poke, true);
+				this.scene.animTransform(poke, true, undefined, true);
 				break;
 			case 'powertrick':
 				this.scene.resultAnim(poke, 'Power Trick', 'neutral');


### PR DESCRIPTION
the term "customAnimation" was overloaded meaning dynamax or a number of other form changes within animTransform.  I've added a "isDynamax" flag to force dynamax animation.  I figure this is worth the flag since every pokemon can dynamax.

The bug report https://github.com/smogon/pokemon-showdown/projects/3#card-85878145 notes that it happens on zygard but it actually would occur on any pokemon with a custom animation.

# examples:
## before
![mimikyu dynamax before](https://github.com/smogon/pokemon-showdown-client/assets/33792307/5dada0d2-ee5a-4297-93b5-cb459e1e9baf)

![zygard complete dynamax before](https://github.com/smogon/pokemon-showdown-client/assets/33792307/18fb1f18-c4bc-4fde-9aec-ffa6d7e8d2fa)


## after:
![mimikyu dynamax after](https://github.com/smogon/pokemon-showdown-client/assets/33792307/018bf66c-73d8-4945-acd7-93755da3ad12)

![zygard complete dynamax after](https://github.com/smogon/pokemon-showdown-client/assets/33792307/54a15cac-d77a-412e-a0b4-469d1d5f671d)
