### PR TITLE
Gen 2 Thief: Not Useless

### DIFF
--- a/play.pokemonshowdown.com/src/battle-dex-search.ts
+++ b/play.pokemonshowdown.com/src/battle-dex-search.ts
@@ -1496,6 +1496,8 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 				!moves.includes('bitterblade') && !moves.includes('firepunch')) || this.formatType === 'doubles';
 		case 'terrainpulse': case 'waterpulse':
 			return ['megalauncher', 'technician'].includes(abilityid) && !moves.includes('originpulse');
+		case 'thief':
+			return dex.gen === 2;
 		case 'toxicspikes':
 			return abilityid !== 'toxicdebris';
 		case 'trickroom':


### PR DESCRIPTION
Thief is ubiquitous in gen 2 as it is the only way to remove an opponent's Leftovers.

fulfilling this suggestion: https://www.smogon.com/forums/threads/move-category-suggestions.3671530/page-3#post-9008076