### PR TITLE
Teambuilder: Generate user samples from boxes

### DIFF
--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -1786,7 +1786,7 @@
 			// this into an object based on the content-type header.
 			$.get('https://' + Config.routes.client + '/data/sets/' + format + '.json', {}, function (data) {
 				try {
-					self.smogonSets[format] = $.extend(self.smogonSets[format], JSON.parse(data));
+					self.smogonSets[format] = JSON.parse(data);
 				} catch (e) {
 					// An error occured. Mark this as false, so that we don't try to reimport sets for this format
 					// in the future.
@@ -1798,12 +1798,16 @@
 		},
 		getUserSets: function (format) {
 			this.smogonSets[format] = $.extend(this.smogonSets[format], {"user": {}});
+
+			var duplicateNameIndices = {};
 			for(const team of teams) {
 				if(team.format === format && team.capacity === 24) {
 					const setList = Storage.unpackTeam(team.team);
 					for(const pokemon of setList) {
-						console.log(pokemon);
-						this.smogonSets[format]['user'][pokemon.species] = $.extend(this.smogonSets[format]['user'][pokemon.species], {[pokemon.name] : pokemon});
+						var name = pokemon.name + " " + (duplicateNameIndices[pokemon.name] || "");
+						var sets = this.smogonSets[format]['user'][pokemon.species];
+						this.smogonSets[format]['user'][pokemon.species] = $.extend({}, sets, {[name] : pokemon});
+						duplicateNameIndices[pokemon.name] = 1 + (duplicateNameIndices[pokemon.name] || 0);
 					}
 				}
 			}

--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -1798,7 +1798,8 @@
 		updateCachedUserSets: function (format) {
 			if(this.smogonSets[format]?.['user']) return;
 
-			$.extend(this.smogonSets[format], {'user': {}});
+			this.smogonSets[format] = $.extend(this.smogonSets[format] || {}, {'user': {}});
+
 			var duplicateNameIndices = {};
 			for(const team of teams) {
 				if(team.format === format && team.capacity === 24) {

--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -104,10 +104,7 @@
 				this.curSet = null;
 				Storage.saveTeam(this.curTeam);
 			} else if (this.curTeam) {
-				var format = this.curTeam.format;
-				if(this.smogonSets?.[format]) {
-					this.smogonSets[format]['user'] = undefined;
-				}
+				this.clearCachedUserSetsIfNecessary(this.curTeam.format);
 				this.curTeam.team = Storage.packTeam(this.curSetList);
 				this.curTeam.iconCache = '';
 				var team = this.curTeam;
@@ -1798,8 +1795,9 @@
 				self.importSetButtons();
 			}, 'text');
 		},
-		getUserSets: function (format) {
-			console.log("lazily fetching user sets");
+		updateCachedUserSets: function (format) {
+			if(this.smogonSets[format]?.['user']) return;
+
 			$.extend(this.smogonSets[format], {'user': {}});
 			var duplicateNameIndices = {};
 			for(const team of teams) {
@@ -1812,6 +1810,12 @@
 						duplicateNameIndices[pokemon.name] = 1 + (duplicateNameIndices[pokemon.name] || 0);
 					}
 				}
+			}
+		},
+		clearCachedUserSetsIfNecessary: function (format) {
+			// clear cached user sets if we have just been in a box for given format
+			if(this.curTeam?.capacity === 24 && this.smogonSets?.[format]) {
+				this.smogonSets[format]['user'] = undefined;
 			}
 		},
 		importSetButtons: function () {
@@ -1836,10 +1840,7 @@
 				$setDiv.append(' <small>(<a target="_blank" href="' + this.smogdexLink(species) + '">Smogon&nbsp;analysis</a>)</small>');
 			}
 
-			if(!this.smogonSets[format]?.['user']) {
-				this.getUserSets(format);
-			}
-
+			this.updateCachedUserSets(format);
 			var userSets = formatSets['user']?.[species];
 			if(userSets) {
 				$userSetDiv.text('User sets: ');

--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -1781,8 +1781,6 @@
 				return;
 			}
 
-			this.getUserSets(format);
-
 			// We fetch this as 'text' and JSON.parse it ourserves in order to have consistent behavior
 			// between the localdev CORS helper and the real jQuery.get function, which would already parse
 			// this into an object based on the content-type header.
@@ -1794,6 +1792,7 @@
 					// in the future.
 					self.smogonSets[format] = false;
 				}
+				self.getUserSets(format);
 				self.importSetButtons();
 			}, 'text');
 		},
@@ -1803,7 +1802,8 @@
 				if(team.format === format && team.capacity === 24) {
 					const setList = Storage.unpackTeam(team.team);
 					for(const pokemon of setList) {
-						this.smogonSets[format]["user"][pokemon.species] = {[pokemon.name] : pokemon};
+						console.log(pokemon);
+						this.smogonSets[format]['user'][pokemon.species] = $.extend(this.smogonSets[format]['user'][pokemon.species], {[pokemon.name] : pokemon});
 					}
 				}
 			}
@@ -1839,7 +1839,7 @@
 
 			var setName = this.$(button).text();
 			var smogonSet = formatSets['dex'][species][setName] || formatSets['stats'][species][setName] || formatSets['user'][species][setName];
-			var curSet = $.extend({}, this.curSet, smogonSet);
+			var curSet = $.extend({}, smogonSet);
 
 			var text = Storage.exportTeam([curSet], this.curTeam.gen);
 			this.$('.teambuilder-pokemon-import .pokemonedit').val(text);

--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -1797,7 +1797,7 @@
 			}, 'text');
 		},
 		getUserSets: function (format) {
-			this.smogonSets[format] = $.extend(this.smogonSets[format], {"user": {}});
+			this.smogonSets[format] = $.extend(this.smogonSets[format], {'user': {}});
 
 			var duplicateNameIndices = {};
 			for(const team of teams) {

--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -1824,17 +1824,21 @@
 
 			if (!formatSets) return;
 
-			var sets = $.extend({}, formatSets['dex'][species], (formatSets['stats'] || {})[species]);
-			$setDiv.text('Sample sets: ');
-			for (var set in sets) {
-				$setDiv.append('<button name="importSmogonSet" class="button">' + BattleLog.escapeHTML(set) + '</button>');
+			var sets = $.extend({}, formatSets['dex']?.[species], formatSets['stats']?.[species]);
+			if(Object.keys(sets).length !== 0) {
+				$setDiv.text('Sample sets: ');
+				for (var set in sets) {
+					$setDiv.append('<button name="importSmogonSet" class="button">' + BattleLog.escapeHTML(set) + '</button>');
+				}
+				$setDiv.append(' <small>(<a target="_blank" href="' + this.smogdexLink(species) + '">Smogon&nbsp;analysis</a>)</small>');
 			}
-			$setDiv.append(' <small>(<a target="_blank" href="' + this.smogdexLink(species) + '">Smogon&nbsp;analysis</a>)</small>');
 
-			var userSets = $.extend({}, (formatSets['user'] || {})[species]);
-			$userSetDiv.text('User sets: ');
-			for (var set in userSets) {
-				$userSetDiv.append('<button name="importSmogonSet" class="button">' + BattleLog.escapeHTML(set) + '</button>');
+			var userSets = formatSets['user']?.[species];
+			if(userSets) {
+				$userSetDiv.text('User sets: ');
+				for (var set in userSets) {
+					$userSetDiv.append('<button name="importSmogonSet" class="button">' + BattleLog.escapeHTML(set) + '</button>');
+				}
 			}
 		},
 		importSmogonSet: function (i, button) {
@@ -1842,8 +1846,16 @@
 			var species = this.curSet.species;
 
 			var setName = this.$(button).text();
-			var smogonSet = formatSets['dex'][species][setName] || formatSets['stats'][species][setName] || formatSets['user'][species][setName];
-			var curSet = $.extend({}, smogonSet);
+			var smogonSet = formatSets['dex']?.[species]?.[setName] 
+							|| formatSets['stats']?.[species]?.[setName] 
+							|| formatSets['user']?.[species]?.[setName];
+			
+			var curSet = $.extend({}, this.curSet, smogonSet);
+
+			// never preserve current set tera, even if smogon set used default
+			if(this.curSet.gen === 9) {
+				curSet.teraType = species.forceTeraType || smogonSet?.teraType || species.types[0]
+			}
 
 			var text = Storage.exportTeam([curSet], this.curTeam.gen);
 			this.$('.teambuilder-pokemon-import .pokemonedit').val(text);

--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -104,6 +104,10 @@
 				this.curSet = null;
 				Storage.saveTeam(this.curTeam);
 			} else if (this.curTeam) {
+				var format = this.curTeam.format;
+				if(this.smogonSets?.[format]) {
+					this.smogonSets[format]['user'] = undefined;
+				}
 				this.curTeam.team = Storage.packTeam(this.curSetList);
 				this.curTeam.iconCache = '';
 				var team = this.curTeam;
@@ -1776,7 +1780,6 @@
 			var self = this;
 			this.smogonSets = this.smogonSets || {};
 			if (this.smogonSets[format] !== undefined) {
-				this.getUserSets(format);
 				this.importSetButtons();
 				return;
 			}
@@ -1792,13 +1795,12 @@
 					// in the future.
 					self.smogonSets[format] = false;
 				}
-				self.getUserSets(format);
 				self.importSetButtons();
 			}, 'text');
 		},
 		getUserSets: function (format) {
-			this.smogonSets[format] = $.extend(this.smogonSets[format], {'user': {}});
-
+			console.log("lazily fetching user sets");
+			$.extend(this.smogonSets[format], {'user': {}});
 			var duplicateNameIndices = {};
 			for(const team of teams) {
 				if(team.format === format && team.capacity === 24) {
@@ -1813,7 +1815,8 @@
 			}
 		},
 		importSetButtons: function () {
-			var formatSets = this.smogonSets[this.curTeam.format];
+			const format = this.curTeam.format;
+			var formatSets = this.smogonSets[format];
 			var species = this.curSet.species;
 
 			var $setDiv = this.$('.teambuilder-pokemon-import .teambuilder-import-smogon-sets');
@@ -1831,6 +1834,10 @@
 					$setDiv.append('<button name="importSmogonSet" class="button">' + BattleLog.escapeHTML(set) + '</button>');
 				}
 				$setDiv.append(' <small>(<a target="_blank" href="' + this.smogdexLink(species) + '">Smogon&nbsp;analysis</a>)</small>');
+			}
+
+			if(!this.smogonSets[format]?.['user']) {
+				this.getUserSets(format);
 			}
 
 			var userSets = formatSets['user']?.[species];


### PR DESCRIPTION
This is an implementation of [a suggestion to display user sample sets from boxes](https://www.smogon.com/forums/threads/teambuilder-improvement-user-sets.3730629/).

The first time a user clicks "Import/Export" in a set view of the teambuilder, this addition will scan through the teambuilder for any boxes with the appropriate format, and cache all sets as user samples. These will then be displayed as buttons. User samples with duplicate names receive a number suffix. 

The cache for a given format is cleared if the user exits a box in said format. Caching reduces repetitive scans each time the user wants to import a set.

I did a quick "performance" test by creating 5000 teams, does not cause hiccups for me at least. Tested on Firefox. The bottleneck, if any, has been the smogon samples fetched using HTTP.

Let me know if I can improve the code quality or functionality, thanks!

This is what it looks like in my test client, see the bottom of the screenshot:
![](https://github.com/smogon/pokemon-showdown-client/assets/79044321/fa04c5b1-22f5-4432-bd04-76807df22837)

This was the corresponding box:
![](https://github.com/smogon/pokemon-showdown-client/assets/79044321/4cbf209c-e47b-4441-b304-dd774724546f)