### PR TITLE
client: escape dots in URL regex

### DIFF
--- a/play.pokemonshowdown.com/js/client.js
+++ b/play.pokemonshowdown.com/js/client.js
@@ -756,7 +756,7 @@ function toId() {
 
 			var self = this;
 			var constructSocket = function () {
-				if (location.host === 'localhost.psim.us' || /[0-9]+.[0-9]+.[0-9]+.[0-9]+\.psim\.us/.test(location.host)) {
+				if (location.host === 'localhost.psim.us' || /[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\.psim\.us/.test(location.host)) {
 					// normally we assume HTTPS means HTTPS, but make an exception for
 					// localhost and IPs which generally can't have a signed cert anyway.
 					Config.server.port = 8000;


### PR DESCRIPTION
This line looks for URLs without a port specified and sets the default port of 8000. However, in the case of IP subdomains (such as `127.0.0.1-12345.psim.us`), the port `12345` is overwritten because the `-` is ignored by the unescaped dot.

This PR escapes the dots forming the IP address and ensures the port is not being overwritten when specified.

Tested in the console's browser: 
<img width="441" alt="image" src="https://github.com/smogon/pokemon-showdown-client/assets/23153234/8364e209-27c6-4e77-9b03-7e85db941f20">
