### PR TITLE
Fix past gen tooltips

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -322,7 +322,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 	const LC = GENS.map(num => num + 0.7);
 	const STADIUM = [2.04, 1.04];
 	const NATDEX = [9.1, 8.1];
-	const OTHER = [9.9, 9.6, 9.411, 9.41, 9.401, 9.4, 9.2, -9.4, -9.401, 8.6, 8.4, 8.2, 8.1, -8.4, -8.6, 7.1];
+	const OTHER = [9.9, 9.411, 9.41, 9.401, 9.4, 9.2, -9.4, -9.401, 8.6, 8.4, 8.2, 8.1, -8.4, -8.6, 7.1];
 
 	// process.stdout.write("\n  ");
 	for (const genIdent of [...GENS, ...DOUBLES, ...VGC, ...NFE, ...STADIUM, ...OTHER, ...NATDEX, ...LC]) {
@@ -339,7 +339,6 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 		const isDoubles = (genIdent < 0);
 		const isVGC = ('' + genIdent).endsWith('.5');
 		const isGen9BH = genIdent === 9.9;
-		const isSSB = genIdent === 9.6;
 		const genNum = Math.floor(isDoubles ? -genIdent : genIdent);
 		const gen = (() => {
 			let genStr = 'gen' + genNum;
@@ -349,7 +348,6 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 			if (isPreDLC) genStr += 'predlc';
 			if (isSVDLC1) genStr += 'dlc1';
 			if (isStadium) genStr += 'stadium' + (genNum > 1 ? genNum : '');
-			if (isSSB) genStr += 'ssb';
 			return genStr;
 		})();
 		// process.stdout.write("" + gen + (isDoubles ? " doubles" : "") + "... ");
@@ -545,11 +543,6 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 			BattleTeambuilderTable['bh'].tiers = tiers;
 			BattleTeambuilderTable['bh'].overrideTier = overrideTier;
 			BattleTeambuilderTable['bh'].formatSlices = formatSlices;
-		} else if (isSSB) {
-			BattleTeambuilderTable['gen9ssb'] = {};
-			BattleTeambuilderTable['gen9ssb'].tiers = tiers;
-			BattleTeambuilderTable['gen9ssb'].overrideTier = overrideTier;
-			BattleTeambuilderTable['gen9ssb'].formatSlices = formatSlices;
 		} else if (gen === 'gen9') {
 			BattleTeambuilderTable.tiers = tiers;
 			BattleTeambuilderTable.items = items;
@@ -1155,7 +1148,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 	// Mods
 	//
 
-	for (const mod of ['gen7letsgo', 'gen8bdsp', 'gen9ssb']) {
+	for (const mod of ['gen7letsgo', 'gen8bdsp']) {
 		const modDex = Dex.mod(mod);
 		const modData = modDex.data;
 		const parentDex = Dex.forGen(modDex.gen);

--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -322,7 +322,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 	const LC = GENS.map(num => num + 0.7);
 	const STADIUM = [2.04, 1.04];
 	const NATDEX = [9.1, 8.1];
-	const OTHER = [9.9, 9.411, 9.41, 9.401, 9.4, 9.2, -9.4, -9.401, 8.6, 8.4, 8.2, 8.1, -8.4, -8.6, 7.1];
+	const OTHER = [9.9, 9.6, 9.411, 9.41, 9.401, 9.4, 9.2, -9.4, -9.401, 8.6, 8.4, 8.2, 8.1, -8.4, -8.6, 7.1];
 
 	// process.stdout.write("\n  ");
 	for (const genIdent of [...GENS, ...DOUBLES, ...VGC, ...NFE, ...STADIUM, ...OTHER, ...NATDEX, ...LC]) {
@@ -339,6 +339,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 		const isDoubles = (genIdent < 0);
 		const isVGC = ('' + genIdent).endsWith('.5');
 		const isGen9BH = genIdent === 9.9;
+		const isSSB = genIdent === 9.6;
 		const genNum = Math.floor(isDoubles ? -genIdent : genIdent);
 		const gen = (() => {
 			let genStr = 'gen' + genNum;
@@ -348,6 +349,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 			if (isPreDLC) genStr += 'predlc';
 			if (isSVDLC1) genStr += 'dlc1';
 			if (isStadium) genStr += 'stadium' + (genNum > 1 ? genNum : '');
+			if (isSSB) genStr += 'ssb';
 			return genStr;
 		})();
 		// process.stdout.write("" + gen + (isDoubles ? " doubles" : "") + "... ");
@@ -543,6 +545,11 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 			BattleTeambuilderTable['bh'].tiers = tiers;
 			BattleTeambuilderTable['bh'].overrideTier = overrideTier;
 			BattleTeambuilderTable['bh'].formatSlices = formatSlices;
+		} else if (isSSB) {
+			BattleTeambuilderTable['gen9ssb'] = {};
+			BattleTeambuilderTable['gen9ssb'].tiers = tiers;
+			BattleTeambuilderTable['gen9ssb'].overrideTier = overrideTier;
+			BattleTeambuilderTable['gen9ssb'].formatSlices = formatSlices;
 		} else if (gen === 'gen9') {
 			BattleTeambuilderTable.tiers = tiers;
 			BattleTeambuilderTable.items = items;
@@ -1148,7 +1155,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 	// Mods
 	//
 
-	for (const mod of ['gen7letsgo', 'gen8bdsp']) {
+	for (const mod of ['gen7letsgo', 'gen8bdsp', 'gen9ssb']) {
 		const modDex = Dex.mod(mod);
 		const modData = modDex.data;
 		const parentDex = Dex.forGen(modDex.gen);

--- a/play.pokemonshowdown.com/src/battle-animations.ts
+++ b/play.pokemonshowdown.com/src/battle-animations.ts
@@ -122,7 +122,6 @@ export class BattleScene implements BattleSceneStub {
 		}
 		this.numericId = numericId;
 		this.tooltips = new BattleTooltips(battle);
-		if (this.battle.id.includes('superstaffbros')) this.tooltips.dex = Dex.mod('gen9ssb' as ID);
 		this.tooltips.listen($frame[0]);
 
 		this.preloadEffects();

--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -25,11 +25,11 @@ class ModifiableValue {
 		this.pokemon = pokemon;
 		this.serverPokemon = serverPokemon;
 
-		this.itemName = Dex.items.get(serverPokemon.item).name;
+		this.itemName = this.battle.dex.items.get(serverPokemon.item).name;
 		const ability = serverPokemon.ability || pokemon?.ability || serverPokemon.baseAbility;
-		this.abilityName = Dex.abilities.get(ability).name;
-		this.weatherName = battle.weather === 'snow' ? 'Snow' : Dex.moves.get(battle.weather).exists ?
-			Dex.moves.get(battle.weather).name : Dex.abilities.get(battle.weather).name;
+		this.abilityName = this.battle.dex.abilities.get(ability).name;
+		this.weatherName = battle.weather === 'snow' ? 'Snow' : this.battle.dex.moves.get(battle.weather).exists ?
+			this.battle.dex.moves.get(battle.weather).name : this.battle.dex.abilities.get(battle.weather).name;
 	}
 	reset(value = 0, isAccuracy?: boolean) {
 		this.value = value;
@@ -525,10 +525,10 @@ class BattleTooltips {
 
 	getMaxMoveFromType(type: TypeName, gmaxMove?: string | Move) {
 		if (gmaxMove) {
-			gmaxMove = Dex.moves.get(gmaxMove);
+			if (typeof gmaxMove === 'string') gmaxMove = this.battle.dex.moves.get(gmaxMove);
 			if (type === gmaxMove.type) return gmaxMove;
 		}
-		return Dex.moves.get(BattleTooltips.maxMoveTable[type]);
+		return this.battle.dex.moves.get(BattleTooltips.maxMoveTable[type]);
 	}
 
 	showMoveTooltip(move: Move, isZOrMax: string, pokemon: Pokemon, serverPokemon: ServerPokemon, gmaxMove?: Move) {
@@ -873,10 +873,10 @@ class BattleTooltips {
 			let itemEffect = '';
 			if (clientPokemon?.prevItem) {
 				item = 'None';
-				let prevItem = Dex.items.get(clientPokemon.prevItem).name;
+				let prevItem = this.battle.dex.items.get(clientPokemon.prevItem).name;
 				itemEffect += clientPokemon.prevItemEffect ? prevItem + ' was ' + clientPokemon.prevItemEffect : 'was ' + prevItem;
 			}
-			if (serverPokemon.item) item = Dex.items.get(serverPokemon.item).name;
+			if (serverPokemon.item) item = this.battle.dex.items.get(serverPokemon.item).name;
 			if (itemEffect) itemEffect = ' (' + itemEffect + ')';
 			if (item) itemText = '<small>Item:</small> ' + item + itemEffect;
 		} else if (clientPokemon) {
@@ -885,10 +885,10 @@ class BattleTooltips {
 			if (clientPokemon.prevItem) {
 				item = 'None';
 				if (itemEffect) itemEffect += '; ';
-				let prevItem = Dex.items.get(clientPokemon.prevItem).name;
+				let prevItem = this.battle.dex.items.get(clientPokemon.prevItem).name;
 				itemEffect += clientPokemon.prevItemEffect ? prevItem + ' was ' + clientPokemon.prevItemEffect : 'was ' + prevItem;
 			}
-			if (pokemon.item) item = Dex.items.get(pokemon.item).name;
+			if (pokemon.item) item = this.battle.dex.items.get(pokemon.item).name;
 			if (itemEffect) itemEffect = ' (' + itemEffect + ')';
 			if (item) itemText = '<small>Item:</small> ' + item + itemEffect;
 		}
@@ -911,7 +911,7 @@ class BattleTooltips {
 			text += `<p class="tooltip-section">`;
 			const battlePokemon = clientPokemon || this.battle.findCorrespondingPokemon(pokemon);
 			for (const moveid of serverPokemon.moves) {
-				const move = Dex.moves.get(moveid);
+				const move = this.battle.dex.moves.get(moveid);
 				let moveName = `&#8226; ${move.name}`;
 				if (battlePokemon?.moveTrack) {
 					for (const row of battlePokemon.moveTrack) {
@@ -1053,7 +1053,7 @@ class BattleTooltips {
 			item = '' as ID;
 		}
 
-		const species = Dex.species.get(serverPokemon.speciesForme).baseSpecies;
+		const species = this.battle.dex.species.get(serverPokemon.speciesForme).baseSpecies;
 		const isTransform = clientPokemon?.volatiles.transform;
 		const speciesName = isTransform && clientPokemon?.volatiles.formechange?.[1] && this.battle.gen <= 4 ?
 			this.battle.dex.species.get(clientPokemon.volatiles.formechange[1]).baseSpecies : species;
@@ -1519,7 +1519,7 @@ class BattleTooltips {
 			moveType = pokemonTypes[0];
 		}
 		// Moves that require an item to change their type.
-		let item = Dex.items.get(value.itemName);
+		let item = this.battle.dex.items.get(value.itemName);
 		if (move.id === 'multiattack' && item.onMemory) {
 			if (value.itemModify(0)) moveType = item.onMemory;
 		}
@@ -2002,7 +2002,7 @@ class BattleTooltips {
 		}
 		// Moves which have base power changed due to items
 		if (serverPokemon.item) {
-			let item = Dex.items.get(serverPokemon.item);
+			let item = this.battle.dex.items.get(serverPokemon.item);
 			if (move.id === 'fling' && item.fling) {
 				value.itemModify(item.fling.basePower);
 			}
@@ -2430,13 +2430,13 @@ class BattleTooltips {
 	}
 	getAllyAbility(ally: Pokemon) {
 		// this will only be available if the ability announced itself in some way
-		let allyAbility = Dex.abilities.get(ally.ability).name;
+		let allyAbility = this.battle.dex.abilities.get(ally.ability).name;
 		// otherwise fall back on the original set data sent from the server
 		if (!allyAbility) {
 			if (this.battle.myAllyPokemon) { // multi battle ally
-				allyAbility = Dex.abilities.get(this.battle.myAllyPokemon[ally.slot].ability).name;
+				allyAbility = this.battle.dex.abilities.get(this.battle.myAllyPokemon[ally.slot].ability || '').name;
 			} else if (this.battle.myPokemon) {
-				allyAbility = Dex.abilities.get(this.battle.myPokemon[ally.slot].ability).name;
+				allyAbility = this.battle.dex.abilities.get(this.battle.myPokemon[ally.slot].ability || '').name;
 			}
 		}
 		return allyAbility;
@@ -2489,12 +2489,12 @@ class BattleTooltips {
 		if (!isActive) {
 			// for switch tooltips, only show the original ability
 			const ability = abilityData.baseAbility || abilityData.ability;
-			if (ability) text = '<small>Ability:</small> ' + Dex.abilities.get(ability).name;
+			if (ability) text = '<small>Ability:</small> ' + this.battle.dex.abilities.get(ability).name;
 		} else {
 			if (abilityData.ability) {
-				const abilityName = Dex.abilities.get(abilityData.ability).name;
+				const abilityName = this.battle.dex.abilities.get(abilityData.ability).name;
 				text = '<small>Ability:</small> ' + abilityName;
-				const baseAbilityName = Dex.abilities.get(abilityData.baseAbility).name;
+				const baseAbilityName = this.battle.dex.abilities.get(abilityData.baseAbility).name;
 				if (baseAbilityName && baseAbilityName !== abilityName) text += ' (base: ' + baseAbilityName + ')';
 			}
 		}

--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -13,7 +13,6 @@ class ModifiableValue {
 	maxValue = 0;
 	comment: string[];
 	battle: Battle;
-	dex: ModdedDex;
 	pokemon: Pokemon;
 	serverPokemon: ServerPokemon;
 	itemName: string;
@@ -23,15 +22,14 @@ class ModifiableValue {
 	constructor(battle: Battle, pokemon: Pokemon, serverPokemon: ServerPokemon) {
 		this.comment = [];
 		this.battle = battle;
-		this.dex = this.battle.dex;
 		this.pokemon = pokemon;
 		this.serverPokemon = serverPokemon;
 
-		this.itemName = this.dex.items.get(serverPokemon.item).name;
+		this.itemName = Dex.items.get(serverPokemon.item).name;
 		const ability = serverPokemon.ability || pokemon?.ability || serverPokemon.baseAbility;
-		this.abilityName = this.dex.abilities.get(ability).name;
-		this.weatherName = battle.weather === 'snow' ? 'Snow' : this.dex.moves.get(battle.weather).exists ?
-			this.dex.moves.get(battle.weather).name : this.dex.abilities.get(battle.weather).name;
+		this.abilityName = Dex.abilities.get(ability).name;
+		this.weatherName = battle.weather === 'snow' ? 'Snow' : Dex.moves.get(battle.weather).exists ?
+			Dex.moves.get(battle.weather).name : Dex.abilities.get(battle.weather).name;
 	}
 	reset(value = 0, isAccuracy?: boolean) {
 		this.value = value;
@@ -108,8 +106,6 @@ class ModifiableValue {
 		if (name) this.comment.push(` (${this.round(factor)}&times; from ${name})`);
 		this.value *= factor;
 		if (!(name === 'Technician' && this.maxValue > 60)) this.maxValue *= factor;
-		if (this.battle.tier.includes('Super Staff Bros') &&
-			!(name === 'Confirmed Town' && this.maxValue > 60)) this.maxValue *= factor;
 		return true;
 	}
 	set(value: number, reason?: string) {
@@ -143,11 +139,9 @@ class ModifiableValue {
 
 class BattleTooltips {
 	battle: Battle;
-	dex: ModdedDex;
 
 	constructor(battle: Battle) {
 		this.battle = battle;
-		this.dex = this.battle.dex;
 	}
 
 	// tooltips
@@ -274,21 +268,18 @@ class BattleTooltips {
 		 * cover up buttons above the hovered button.
 		 */
 		let ownHeight = !!elem.dataset.ownheight;
-		if (this.battle.id.includes('superstaffbros')) {
-			this.dex = Dex.mod('gen9ssb' as ID);
-		}
 
 		let buf: string;
 		switch (type) {
 		case 'move':
 		case 'zmove':
 		case 'maxmove': { // move|MOVE|ACTIVEPOKEMON|[GMAXMOVE]
-			let move = this.dex.moves.get(args[1]);
+			let move = this.battle.dex.moves.get(args[1]);
 			let teamIndex = parseInt(args[2], 10);
 			let pokemon = this.battle.nearSide.active[
 				teamIndex + this.battle.pokemonControlled * Math.floor(this.battle.mySide.n / 2)
 			];
-			let gmaxMove = args[3] ? this.dex.moves.get(args[3]) : undefined;
+			let gmaxMove = args[3] ? this.battle.dex.moves.get(args[3]) : undefined;
 			if (!pokemon) return false;
 			let serverPokemon = this.battle.myPokemon![teamIndex];
 			buf = this.showMoveTooltip(move, type, pokemon, serverPokemon, gmaxMove);
@@ -532,10 +523,10 @@ class BattleTooltips {
 
 	getMaxMoveFromType(type: TypeName, gmaxMove?: string | Move) {
 		if (gmaxMove) {
-			if (typeof gmaxMove === 'string') gmaxMove = this.dex.moves.get(gmaxMove);
+			gmaxMove = Dex.moves.get(gmaxMove);
 			if (type === gmaxMove.type) return gmaxMove;
 		}
-		return this.dex.moves.get(BattleTooltips.maxMoveTable[type]);
+		return Dex.moves.get(BattleTooltips.maxMoveTable[type]);
 	}
 
 	showMoveTooltip(move: Move, isZOrMax: string, pokemon: Pokemon, serverPokemon: ServerPokemon, gmaxMove?: Move) {
@@ -543,16 +534,13 @@ class BattleTooltips {
 
 		let zEffect = '';
 		let foeActive = pokemon.side.foe.active;
-		if (this.battle.id.includes('superstaffbros')) {
-			this.dex = Dex.mod('gen9ssb' as ID);
-		}
 		if (this.battle.gameType === 'freeforall') {
 			foeActive = [...foeActive, ...pokemon.side.active].filter(active => active !== pokemon);
 		}
 		// TODO: move this somewhere it makes more sense
 		if (pokemon.ability === '(suppressed)') serverPokemon.ability = '(suppressed)';
 		let ability = toID(serverPokemon.ability || pokemon.ability || serverPokemon.baseAbility);
-		let item = this.dex.items.get(serverPokemon.item);
+		let item = this.battle.dex.items.get(serverPokemon.item);
 
 		let value = new ModifiableValue(this.battle, pokemon, serverPokemon);
 		let [moveType, category] = this.getMoveType(move, value, gmaxMove || isZOrMax === 'maxmove');
@@ -560,7 +548,7 @@ class BattleTooltips {
 
 		if (isZOrMax === 'zmove') {
 			if (item.zMoveFrom === move.name) {
-				move = this.dex.moves.get(item.zMove as string);
+				move = this.battle.dex.moves.get(item.zMove as string);
 			} else if (move.category === 'Status') {
 				move = new Move(move.id, "", {
 					...move,
@@ -569,28 +557,28 @@ class BattleTooltips {
 				zEffect = this.getStatusZMoveEffect(move);
 			} else {
 				let moveName = BattleTooltips.zMoveTable[item.zMoveType as TypeName];
-				let zMove = this.dex.moves.get(moveName);
+				let zMove = this.battle.dex.moves.get(moveName);
 				let movePower = move.zMove!.basePower;
 				// the different Hidden Power types don't have a Z power set, fall back on base move
 				if (!movePower && move.id.startsWith('hiddenpower')) {
-					movePower = this.dex.moves.get('hiddenpower').zMove!.basePower;
+					movePower = this.battle.dex.moves.get('hiddenpower').zMove!.basePower;
 				}
 				if (move.id === 'weatherball') {
 					switch (this.battle.weather) {
 					case 'sunnyday':
 					case 'desolateland':
-						zMove = this.dex.moves.get(BattleTooltips.zMoveTable['Fire']);
+						zMove = this.battle.dex.moves.get(BattleTooltips.zMoveTable['Fire']);
 						break;
 					case 'raindance':
 					case 'primordialsea':
-						zMove = this.dex.moves.get(BattleTooltips.zMoveTable['Water']);
+						zMove = this.battle.dex.moves.get(BattleTooltips.zMoveTable['Water']);
 						break;
 					case 'sandstorm':
-						zMove = this.dex.moves.get(BattleTooltips.zMoveTable['Rock']);
+						zMove = this.battle.dex.moves.get(BattleTooltips.zMoveTable['Rock']);
 						break;
 					case 'hail':
 					case 'snow':
-						zMove = this.dex.moves.get(BattleTooltips.zMoveTable['Ice']);
+						zMove = this.battle.dex.moves.get(BattleTooltips.zMoveTable['Ice']);
 						break;
 					}
 				}
@@ -603,7 +591,7 @@ class BattleTooltips {
 			}
 		} else if (isZOrMax === 'maxmove') {
 			if (move.category === 'Status') {
-				move = this.dex.moves.get('Max Guard');
+				move = this.battle.dex.moves.get('Max Guard');
 			} else {
 				let maxMove = this.getMaxMoveFromType(moveType, gmaxMove);
 				const basePower = ['gmaxdrumsolo', 'gmaxfireball', 'gmaxhydrosnipe'].includes(maxMove.id) ?
@@ -683,7 +671,7 @@ class BattleTooltips {
 				// In gen 3 it calls Swift, so it retains its normal typing.
 				calls = 'Swift';
 			}
-			let calledMove = this.dex.moves.get(calls);
+			let calledMove = this.battle.dex.moves.get(calls);
 			text += 'Calls ' + Dex.getTypeIcon(this.getMoveType(calledMove, value)[0]) + ' ' + calledMove.name;
 		}
 
@@ -883,10 +871,10 @@ class BattleTooltips {
 			let itemEffect = '';
 			if (clientPokemon?.prevItem) {
 				item = 'None';
-				let prevItem = this.dex.items.get(clientPokemon.prevItem).name;
+				let prevItem = Dex.items.get(clientPokemon.prevItem).name;
 				itemEffect += clientPokemon.prevItemEffect ? prevItem + ' was ' + clientPokemon.prevItemEffect : 'was ' + prevItem;
 			}
-			if (serverPokemon.item) item = this.dex.items.get(serverPokemon.item).name;
+			if (serverPokemon.item) item = Dex.items.get(serverPokemon.item).name;
 			if (itemEffect) itemEffect = ' (' + itemEffect + ')';
 			if (item) itemText = '<small>Item:</small> ' + item + itemEffect;
 		} else if (clientPokemon) {
@@ -895,10 +883,10 @@ class BattleTooltips {
 			if (clientPokemon.prevItem) {
 				item = 'None';
 				if (itemEffect) itemEffect += '; ';
-				let prevItem = this.dex.items.get(clientPokemon.prevItem).name;
+				let prevItem = Dex.items.get(clientPokemon.prevItem).name;
 				itemEffect += clientPokemon.prevItemEffect ? prevItem + ' was ' + clientPokemon.prevItemEffect : 'was ' + prevItem;
 			}
-			if (pokemon.item) item = this.dex.items.get(pokemon.item).name;
+			if (pokemon.item) item = Dex.items.get(pokemon.item).name;
 			if (itemEffect) itemEffect = ' (' + itemEffect + ')';
 			if (item) itemText = '<small>Item:</small> ' + item + itemEffect;
 		}
@@ -921,7 +909,7 @@ class BattleTooltips {
 			text += `<p class="tooltip-section">`;
 			const battlePokemon = clientPokemon || this.battle.findCorrespondingPokemon(pokemon);
 			for (const moveid of serverPokemon.moves) {
-				const move = this.dex.moves.get(moveid);
+				const move = Dex.moves.get(moveid);
 				let moveName = `&#8226; ${move.name}`;
 				if (battlePokemon?.moveTrack) {
 					for (const row of battlePokemon.moveTrack) {
@@ -942,7 +930,7 @@ class BattleTooltips {
 			}
 			if (clientPokemon.moveTrack.filter(([moveName]) => {
 				if (moveName.charAt(0) === '*') return false;
-				const move = this.dex.moves.get(moveName);
+				const move = this.battle.dex.moves.get(moveName);
 				return !move.isZ && !move.isMax && move.name !== 'Mimic';
 			}).length > 4) {
 				text += `(More than 4 moves is usually a sign of Illusion Zoroark/Zorua.) `;
@@ -1006,11 +994,6 @@ class BattleTooltips {
 				if (statName === 'def') sourceStatName = 'atk';
 			}
 			stats[statName] = serverPokemon.stats[sourceStatName];
-			// SSB
-			if (this.battle.tier.includes("Super Staff Bros") && clientPokemon?.volatiles['ok']) {
-				if (statName === 'spa') stats[statName] += Math.floor(stats.atk / 10);
-				if (statName === 'spe') stats[statName] += Math.floor(stats.atk * 9 / 10);
-			}
 			if (!clientPokemon) continue;
 
 			const clientStatName = clientPokemon.boosts.spc && (statName === 'spa' || statName === 'spd') ? 'spc' : statName;
@@ -1063,10 +1046,10 @@ class BattleTooltips {
 			item = '' as ID;
 		}
 
-		const species = this.dex.species.get(serverPokemon.speciesForme).baseSpecies;
+		const species = Dex.species.get(serverPokemon.speciesForme).baseSpecies;
 		const isTransform = clientPokemon?.volatiles.transform;
 		const speciesName = isTransform && clientPokemon?.volatiles.formechange?.[1] && this.battle.gen <= 4 ?
-			this.dex.species.get(clientPokemon.volatiles.formechange[1]).baseSpecies : species;
+			this.battle.dex.species.get(clientPokemon.volatiles.formechange[1]).baseSpecies : species;
 
 		let speedModifiers = [];
 
@@ -1185,14 +1168,14 @@ class BattleTooltips {
 		if (ability === 'marvelscale' && pokemon.status) {
 			stats.def = Math.floor(stats.def * 1.5);
 		}
-		const isNFE = this.dex.species.get(serverPokemon.speciesForme).evos?.some(evo => {
-			const evoSpecies = this.dex.species.get(evo);
+		const isNFE = this.battle.dex.species.get(serverPokemon.speciesForme).evos?.some(evo => {
+			const evoSpecies = this.battle.dex.species.get(evo);
 			return !evoSpecies.isNonstandard ||
-					evoSpecies.isNonstandard === this.dex.species.get(serverPokemon.speciesForme)?.isNonstandard ||
+					evoSpecies.isNonstandard === this.battle.dex.species.get(serverPokemon.speciesForme)?.isNonstandard ||
 					// Pokemon with Hisui evolutions
 					evoSpecies.isNonstandard === "Unobtainable";
 		});
-		if (item === 'eviolite' && (isNFE || this.dex.species.get(serverPokemon.speciesForme).id === 'dipplin')) {
+		if (item === 'eviolite' && (isNFE || this.battle.dex.species.get(serverPokemon.speciesForme).id === 'dipplin')) {
 			stats.def = Math.floor(stats.def * 1.5);
 			stats.spd = Math.floor(stats.spd * 1.5);
 		}
@@ -1266,86 +1249,6 @@ class BattleTooltips {
 				stats.spd = Math.floor(stats.spd * 0.75);
 			}
 		}
-
-		// SSB
-		if (this.battle.tier.includes("Super Staff Bros")) {
-			if (ability === 'misspelled') {
-				stats.spa = Math.floor(stats.spa * 1.5);
-			}
-			if (ability === 'fortifyingfrost' && weather === 'snow') {
-				stats.spa = Math.floor(stats.spa * 1.5);
-				stats.spd = Math.floor(stats.spd * 1.5);
-			}
-			if (weather === 'deserteddunes' && this.pokemonHasType(pokemon, 'Rock')) {
-				stats.spd = Math.floor(stats.spd * 1.5);
-			}
-			if (pokemon.status && ability === 'fortifiedmetal') {
-				stats.atk = Math.floor(stats.atk * 1.5);
-			}
-			if (ability === 'grassyemperor' && this.battle.hasPseudoWeather('Grassy Terrain')) {
-				stats.atk = Math.floor(stats.atk * 1.3333);
-			}
-			if (ability === 'magicalmysterycharge' && this.battle.hasPseudoWeather('Electric Terrain')) {
-				stats.spd = Math.floor(stats.spd * 1.5);
-			}
-			if (ability === 'youkaiofthedusk' || ability === 'galeguard') {
-				stats.def *= 2;
-			}
-			if (ability === 'climatechange') {
-				if (weather === 'snow') {
-					stats.def = Math.floor(stats.def * 1.5);
-					stats.spd = Math.floor(stats.spd * 1.5);
-				}
-				if (weather === 'sunnyday' || weather === 'desolateland') stats.spa = Math.floor(stats.spa * 1.5);
-			}
-			if (item !== 'utilityumbrella' && ability === 'ridethesun' &&
-				(weather === 'sunnyday' || weather === 'desolateland')) {
-				speedModifiers.push(2);
-			}
-			if (ability === 'soulsurfer' && this.battle.hasPseudoWeather('Electric Terrain')) {
-				speedModifiers.push(2);
-			}
-			if (item === 'eviolite' && this.dex.species.get(serverPokemon.speciesForme).id === 'pichuspikyeared') {
-				stats.def = Math.floor(stats.def * 1.5);
-				stats.spd = Math.floor(stats.spd * 1.5);
-			}
-			if (this.battle.abilityActive('quagofruin')) {
-				if (ability !== 'quagofruin') {
-					stats.def = Math.floor(stats.def * 0.85);
-				}
-			}
-			if (this.battle.abilityActive('clodofruin')) {
-				if (ability !== 'clodofruin') {
-					stats.atk = Math.floor(stats.atk * 0.85);
-				}
-			}
-			if (this.battle.abilityActive('blitzofruin')) {
-				if (ability !== 'blitzofruin') {
-					speedModifiers.push(0.75);
-				}
-			}
-			if (this.battle.hasPseudoWeather('Anfield Atmosphere') && ability === 'youllneverwalkalone') {
-				stats.atk = Math.floor(stats.atk * 1.25);
-				stats.def = Math.floor(stats.def * 1.25);
-				stats.spd = Math.floor(stats.spd * 1.25);
-				speedModifiers.push(1.25);
-			}
-			if (clientPokemon) {
-				if (clientPokemon.volatiles['boiled']) {
-					stats.spa = Math.floor(stats.spa * 1.5);
-				}
-				for (const statName of Dex.statNamesExceptHP) {
-					if (clientPokemon.volatiles['ultramystik']) {
-						if (statName === 'spe') {
-							speedModifiers.push(1.5);
-						} else {
-							stats[statName] = Math.floor(stats[statName] * 1.5);
-						}
-					}
-				}
-			}
-		}
-
 		const sideConditions = this.battle.mySide.sideConditions;
 		if (sideConditions['tailwind']) {
 			speedModifiers.push(2);
@@ -1426,10 +1329,10 @@ class BattleTooltips {
 		let maxpp;
 		if (moveName.charAt(0) === '*') {
 			// Transformed move
-			move = this.dex.moves.get(moveName.substr(1));
+			move = this.battle.dex.moves.get(moveName.substr(1));
 			maxpp = 5;
 		} else {
-			move = this.dex.moves.get(moveName);
+			move = this.battle.dex.moves.get(moveName);
 			maxpp = (move.pp === 1 || move.noPPBoosts ? move.pp : move.pp * 8 / 5);
 			if (this.battle.gen < 3) maxpp = Math.min(61, maxpp);
 		}
@@ -1467,7 +1370,7 @@ class BattleTooltips {
 			if (baseSpe > 255) baseSpe = 255;
 		}
 		if (rules['Frantic Fusions Mod']) {
-			const fusionSpecies = this.dex.species.get(pokemon.name);
+			const fusionSpecies = this.battle.dex.species.get(pokemon.name);
 			if (fusionSpecies.exists && fusionSpecies.name !== species.name) {
 				baseSpe = baseSpe + tr(fusionSpecies.baseStats.spe / 4);
 				if (baseSpe < 1) baseSpe = 1;
@@ -1529,7 +1432,7 @@ class BattleTooltips {
 			moveType = pokemonTypes[0];
 		}
 		// Moves that require an item to change their type.
-		let item = this.dex.items.get(value.itemName);
+		let item = Dex.items.get(value.itemName);
 		if (move.id === 'multiattack' && item.onMemory) {
 			if (value.itemModify(0)) moveType = item.onMemory;
 		}
@@ -1655,54 +1558,6 @@ class BattleTooltips {
 			const stats = this.calculateModifiedStats(pokemon, serverPokemon, true);
 			if (stats.atk > stats.spa) category = 'Physical';
 		}
-
-		// SSB
-		if (this.battle.tier.includes("Super Staff Bros")) {
-			if (allowTypeOverride && category !== "Status" && !move.isZ && !move.id.startsWith('hiddenpower')) {
-				if (value.abilityModify(0, 'Acetosa')) moveType = 'Grass';
-				if (value.abilityModify(0, 'I Can Hear The Heart Beating As One') && moveType === 'Normal') moveType = 'Fairy';
-			}
-			if (move.id === 'tsignore' || move.id === 'o') {
-				const stats = this.calculateModifiedStats(pokemon, serverPokemon, true);
-				if (stats.atk > stats.spa) category = 'Physical';
-			}
-			if (move.id === 'tsignore' && pokemon.getSpeciesForme().startsWith('Meloetta') &&
-				pokemon.terastallized) {
-				moveType = 'Stellar';
-			}
-			if (move.id === 'weatherball' && value.weatherModify(0)) {
-				if (this.battle.weather === 'stormsurge') moveType = 'Water';
-				if (this.battle.weather === 'deserteddunes') moveType = 'Rock';
-			}
-			if (move.id === 'o' || move.id === 'worriednoises') {
-				moveType = pokemonTypes[0];
-			}
-			if (move.id === 'dillydally') {
-				moveType = pokemonTypes[pokemonTypes.length - 1];
-			}
-			if (move.id === 'magicalfocus') {
-				if (this.battle.turn % 3 === 1) {
-					moveType = 'Fire';
-				} else if (this.battle.turn % 3 === 2) {
-					moveType = 'Electric';
-				} else {
-					moveType = 'Ice';
-				}
-			}
-			if (move.id === 'hydrostatics' && pokemon.terastallized) {
-				moveType = 'Water';
-			}
-			if (move.id === 'asongoficeandfire' && pokemon.getSpeciesForme() === 'Volcarona') moveType = 'Ice';
-			if (this.battle.abilityActive('dynamictyping')) {
-				moveType = '???';
-			}
-			if (move.id === 'alting') {
-				moveType = '???';
-				if (pokemon.shiny) {
-					category = 'Special';
-				}
-			}
-		}
 		return [moveType, category];
 	}
 
@@ -1778,38 +1633,6 @@ class BattleTooltips {
 		if (value.tryItem('Wide Lens')) {
 			accuracyModifiers.push(4505);
 			value.itemModify(1.1, "Wide Lens");
-		}
-
-		// SSB
-		if (this.battle.tier.includes("Super Staff Bros")) {
-			if (move.id === 'alting' && pokemon.shiny) {
-				value.set(100);
-			}
-			if (move.flags['wind'] && this.battle.weather === 'stormsurge') {
-				value.weatherModify(0, 'Storm Surge');
-			}
-			if (value.tryAbility('Misspelled') && move.category === 'Special') {
-				accuracyModifiers.push(3277);
-				value.abilityModify(0.8, "Misspelled");
-			}
-			if (value.tryAbility('Hydrostatic Positivity') && ['Electric', 'Water'].includes(move.type)) {
-				accuracyModifiers.push(5325);
-				value.abilityModify(1.3, "Hydrostatic Positivity");
-			}
-			if (value.tryAbility('Hardcore Hustle')) {
-				for (let i = 1; i <= 5 && i <= pokemon.side.faintCounter; i++) {
-					if (pokemon.volatiles[`fallen${i}`]) {
-						value.abilityModify([1, 0.95, 0.90, 0.85, 0.80, 0.75][i], "Hardcore Hustle");
-					}
-				}
-			}
-			if (value.tryAbility('See No Evil, Hear No Evil, Speak No Evil') &&
-				pokemon.getSpeciesForme().includes('Wellspring')) {
-				value.abilityModify(0, 'See No Evil, Hear No Evil, Speak No Evil');
-			}
-			value.abilityModify(0, 'Sure Hit Sorcery');
-			value.abilityModify(0, 'Eyes of Eternity');
-			if (!value.value) return value;
 		}
 
 		// Chaining modifiers
@@ -2012,7 +1835,7 @@ class BattleTooltips {
 		}
 		// Moves which have base power changed due to items
 		if (serverPokemon.item) {
-			let item = this.dex.items.get(serverPokemon.item);
+			let item = Dex.items.get(serverPokemon.item);
 			if (move.id === 'fling' && item.fling) {
 				value.itemModify(item.fling.basePower);
 			}
@@ -2226,88 +2049,6 @@ class BattleTooltips {
 			value.set(0, 'no Terrain');
 		}
 
-		// SSB
-		if (this.battle.tier.includes("Super Staff Bros")) {
-			this.dex = Dex.mod('gen9ssb' as ID);
-			if (move.id === 'bodycount') {
-				value.set(50 + 50 * pokemon.side.faintCounter,
-					pokemon.side.faintCounter > 0
-						? `${pokemon.side.faintCounter} teammate${pokemon.side.faintCounter > 1 ? 's' : ''} KOed`
-						: undefined);
-			}
-			// Base power based on times hit
-			if (move.id === 'vengefulmood') {
-				value.set(Math.min(140, 60 + 20 * pokemon.timesAttacked),
-					pokemon.timesAttacked > 0
-						? `Hit ${pokemon.timesAttacked} time${pokemon.timesAttacked > 1 ? 's' : ''}`
-						: undefined);
-			}
-			if (move.id === 'alting' && pokemon.shiny) {
-				value.set(69, 'Shiny');
-			}
-			if (move.id === 'darkmooncackle') {
-				let boostCount = 0;
-				for (const boost of Object.values(pokemon.boosts)) {
-					if (boost > 0) boostCount += boost;
-				}
-				value.set(30 + 20 * boostCount);
-			}
-			if (move.id === 'buildingcharacter' && target?.terastallized) {
-				value.modify(2, 'Terastallized target');
-			}
-			if (move.id === 'mysticalbonfire' && target?.status) {
-				value.modify(2, 'Mystical Bonfire + status');
-			}
-			if (move.id === 'adaptivebeam' && target) {
-				let boostCount = 0;
-				let targetBoostCount = 0;
-				for (const boost of Object.values(pokemon.boosts)) {
-					if (boost > 0) boostCount += boost;
-				}
-				for (const boost of Object.values(target.boosts)) {
-					if (boost > 0) targetBoostCount += boost;
-				}
-				if (targetBoostCount >= boostCount) value.modify(2, "Target has more boosts");
-			}
-			if (value.value <= 60) {
-				value.abilityModify(1.5, "Confirmed Town");
-			}
-			if (move.category !== 'Status' && allowTypeOverride && !move.isZ &&
-				!move.isMax && !move.id.startsWith('hiddenpower')) {
-				if (moveType === 'Normal') value.abilityModify(this.battle.gen > 6 ? 1.2 : 1.3, "I Can Hear The Heart Beating As One");
-				value.abilityModify(this.battle.gen > 6 ? 1.2 : 1.3, "Acetosa");
-			}
-			if (move.flags['sound']) {
-				value.abilityModify(1.5, "Cacophony");
-			}
-			if (move.flags['punch']) {
-				value.abilityModify(1.3, "Harambe Hit");
-			}
-			if (move.flags['slicing']) {
-				value.abilityModify(1.5, "I Can Hear The Heart Beating As One");
-			}
-			if (move.priority > 0) {
-				value.abilityModify(2, "Full Bloom");
-			}
-			if (move.recoil || move.hasCrashDamage) {
-				value.abilityModify(1.2, 'Hogwash');
-				if (pokemon.name === "Billo") {
-					value.modify(1.2);
-				}
-			}
-			if (target?.gender === "M" && pokemon.getSpeciesForme().includes("Hearthflame")) {
-				value.abilityModify(1.3, 'See No Evil, Hear No Evil, Speak No Evil');
-			}
-			for (let i = 1; i <= 5 && i <= pokemon.side.faintCounter; i++) {
-				if (pokemon.volatiles[`fallen${i}`]) {
-					value.abilityModify([1, 1.15, 1.3, 1.45, 1.6, 1.75][i], "Hardcore Hustle");
-				}
-			}
-			let timeDilationBPMod = 1 + (0.1 * Math.floor(this.battle.turn / 10));
-			if (timeDilationBPMod > 2) timeDilationBPMod = 2;
-			value.abilityModify(timeDilationBPMod, "Time Dilation");
-		}
-
 		return value;
 	}
 
@@ -2364,13 +2105,13 @@ class BattleTooltips {
 		'Water Pledge',
 	];
 	getItemBoost(move: Move, value: ModifiableValue, moveType: TypeName) {
-		let item = this.dex.items.get(value.serverPokemon.item);
+		let item = this.battle.dex.items.get(value.serverPokemon.item);
 		let itemName = item.name;
 		let moveName = move.name;
-		let species = this.dex.species.get(value.serverPokemon.speciesForme);
+		let species = this.battle.dex.species.get(value.serverPokemon.speciesForme);
 		let isTransform = value.pokemon.volatiles.transform;
 		let speciesName = isTransform && value.pokemon.volatiles.formechange?.[1] && this.battle.gen <= 4 ?
-			this.dex.species.get(value.pokemon.volatiles.formechange[1]).baseSpecies : species.baseSpecies;
+			this.battle.dex.species.get(value.pokemon.volatiles.formechange[1]).baseSpecies : species.baseSpecies;
 
 		// Plates
 		if (item.onPlate === moveType && !item.zMove) {
@@ -2427,7 +2168,7 @@ class BattleTooltips {
 	}
 	getPokemonTypes(pokemon: Pokemon | ServerPokemon, preterastallized = false): ReadonlyArray<TypeName> {
 		if (!(pokemon as Pokemon).getTypes) {
-			return this.dex.species.get(pokemon.speciesForme).types;
+			return this.battle.dex.species.get(pokemon.speciesForme).types;
 		}
 
 		return (pokemon as Pokemon).getTypeList(undefined, preterastallized);
@@ -2441,13 +2182,13 @@ class BattleTooltips {
 	}
 	getAllyAbility(ally: Pokemon) {
 		// this will only be available if the ability announced itself in some way
-		let allyAbility = this.dex.abilities.get(ally.ability).name;
+		let allyAbility = Dex.abilities.get(ally.ability).name;
 		// otherwise fall back on the original set data sent from the server
 		if (!allyAbility) {
 			if (this.battle.myAllyPokemon) { // multi battle ally
-				allyAbility = this.dex.abilities.get(this.battle.myAllyPokemon[ally.slot].ability || '').name;
+				allyAbility = Dex.abilities.get(this.battle.myAllyPokemon[ally.slot].ability).name;
 			} else if (this.battle.myPokemon) {
-				allyAbility = this.dex.abilities.get(this.battle.myPokemon[ally.slot].ability || '').name;
+				allyAbility = Dex.abilities.get(this.battle.myPokemon[ally.slot].ability).name;
 			}
 		}
 		return allyAbility;
@@ -2464,14 +2205,14 @@ class BattleTooltips {
 				}
 			} else {
 				const speciesForme = clientPokemon.getSpeciesForme() || serverPokemon?.speciesForme || '';
-				const species = this.dex.species.get(speciesForme);
+				const species = this.battle.dex.species.get(speciesForme);
 				if (species.exists && species.abilities) {
 					abilityData.possibilities = [species.abilities['0']];
 					if (species.abilities['1']) abilityData.possibilities.push(species.abilities['1']);
 					if (species.abilities['H']) abilityData.possibilities.push(species.abilities['H']);
 					if (species.abilities['S']) abilityData.possibilities.push(species.abilities['S']);
 					if (this.battle.rules['Frantic Fusions Mod']) {
-						const fusionSpecies = this.dex.species.get(clientPokemon.name);
+						const fusionSpecies = this.battle.dex.species.get(clientPokemon.name);
 						if (fusionSpecies.exists && fusionSpecies.name !== species.name) {
 							abilityData.possibilities = Array.from(
 								new Set(abilityData.possibilities.concat(Object.values(fusionSpecies.abilities)))
@@ -2500,12 +2241,12 @@ class BattleTooltips {
 		if (!isActive) {
 			// for switch tooltips, only show the original ability
 			const ability = abilityData.baseAbility || abilityData.ability;
-			if (ability) text = '<small>Ability:</small> ' + this.dex.abilities.get(ability).name;
+			if (ability) text = '<small>Ability:</small> ' + Dex.abilities.get(ability).name;
 		} else {
 			if (abilityData.ability) {
-				const abilityName = this.dex.abilities.get(abilityData.ability).name;
+				const abilityName = Dex.abilities.get(abilityData.ability).name;
 				text = '<small>Ability:</small> ' + abilityName;
-				const baseAbilityName = this.dex.abilities.get(abilityData.baseAbility).name;
+				const baseAbilityName = Dex.abilities.get(abilityData.baseAbility).name;
 				if (baseAbilityName && baseAbilityName !== abilityName) text += ' (base: ' + baseAbilityName + ')';
 			}
 		}

--- a/play.pokemonshowdown.com/src/battle.ts
+++ b/play.pokemonshowdown.com/src/battle.ts
@@ -3381,9 +3381,6 @@ export class Battle {
 			if (this.tier.includes(`Let's Go`)) {
 				this.dex = Dex.mod('gen7letsgo' as ID);
 			}
-			if (this.tier.includes(`Super Staff Bros`)) {
-				this.dex = Dex.mod('gen9ssb' as ID);
-			}
 			this.log(args);
 			break;
 		}
@@ -3696,21 +3693,6 @@ export class Battle {
 		}
 		case 'controlshtml': {
 			this.scene.setControlsHTML(BattleLog.sanitizeHTML(args[1]));
-			break;
-		}
-		case 'custom': {
-			// Style is always |custom|-subprotocol|pokemon|additional info
-			if (args[1] === '-endterastallize') {
-				let poke = this.getPokemon(args[2])!;
-				poke.removeVolatile('terastallize' as ID);
-				poke.teraType = '';
-				poke.terastallized = '';
-				poke.details = poke.details.replace(/, tera:[a-z]+/i, '');
-				poke.searchid = poke.searchid.replace(/, tera:[a-z]+/i, '');
-				this.scene.animTransform(poke);
-				this.scene.resetStatbar(poke);
-				this.log(args, kwArgs);
-			}
 			break;
 		}
 		default: {

--- a/play.pokemonshowdown.com/src/battle.ts
+++ b/play.pokemonshowdown.com/src/battle.ts
@@ -3381,6 +3381,9 @@ export class Battle {
 			if (this.tier.includes(`Let's Go`)) {
 				this.dex = Dex.mod('gen7letsgo' as ID);
 			}
+			if (this.tier.includes('Super Staff Bros')) {
+				this.dex = Dex.mod('gen9ssb' as ID);
+			}
 			this.log(args);
 			break;
 		}
@@ -3693,6 +3696,21 @@ export class Battle {
 		}
 		case 'controlshtml': {
 			this.scene.setControlsHTML(BattleLog.sanitizeHTML(args[1]));
+			break;
+		}
+		case 'custom': {
+			// Style is always |custom|-subprotocol|pokemon|additional info
+			if (args[1] === '-endterastallize') {
+				let poke = this.getPokemon(args[2])!;
+				poke.removeVolatile('terastallize' as ID);
+				poke.teraType = '';
+				poke.terastallized = '';
+				poke.details = poke.details.replace(/, tera:[a-z]+/i, '');
+				poke.searchid = poke.searchid.replace(/, tera:[a-z]+/i, '');
+				this.scene.animTransform(poke);
+				this.scene.resetStatbar(poke);
+				this.log(args, kwArgs);
+			}
 			break;
 		}
 		default: {


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-report-client.3742657/

The reason it broke is because the tooltips object is created before the client receives the `gen`/`tier` protocol that updates the battle dex, so the tooltips were always using the latest dex. I reverted the change that gave tooltips its own `dex` property, because it doesn't make much sense to double up on the logic to determine what dex to use.