### PR TITLE
Replays: Fix More Replays button on mobile

### DIFF
--- a/replay.pokemonshowdown.com/src/replays-battle.tsx
+++ b/replay.pokemonshowdown.com/src/replays-battle.tsx
@@ -494,7 +494,7 @@ export class BattlePanel extends preact.Component<{id: string}> {
         {/* {} <code>{this.keyCode}</code> */}
       </p> : <p>&nbsp;</p>}
       {!PSRouter.showingLeft() && <p>
-        <a href={`./${PSRouter.leftLoc || ''}`} class="button"><i class="fa fa-caret-left"></i> More replays</a>
+        <a href={PSRouter.leftLoc || '.'} class="button"><i class="fa fa-caret-left"></i> More replays</a>
       </p>}
     </div>;
   }

--- a/replay.pokemonshowdown.com/src/replays-battle.tsx
+++ b/replay.pokemonshowdown.com/src/replays-battle.tsx
@@ -494,7 +494,7 @@ export class BattlePanel extends preact.Component<{id: string}> {
         {/* {} <code>{this.keyCode}</code> */}
       </p> : <p>&nbsp;</p>}
       {!PSRouter.showingLeft() && <p>
-        <a href="." class="button"><i class="fa fa-caret-left"></i> More replays</a>
+        <a href={`./${PSRouter.leftLoc || ''}`} class="button"><i class="fa fa-caret-left"></i> More replays</a>
       </p>}
     </div>;
   }


### PR DESCRIPTION
Currently, the `‹ More Replays` button that is shown on mobile always takes you back to the main replays page. This change should preserve the original search query.