### PR TITLE
Fix issue where 1.2x damage calculation is not showing properly

### DIFF
--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -2381,9 +2381,9 @@ class BattleTooltips {
 		}
 		if (speciesName === 'Ogerpon') {
 			const speciesForme = value.pokemon.getSpeciesForme();
-			if ((speciesForme === 'Ogerpon-Wellspring' && value.itemName === 'Wellspring Mask') ||
-				(speciesForme === 'Ogerpon-Hearthflame' && value.itemName === 'Hearthflame Mask') ||
-				(speciesForme === 'Ogerpon-Cornerstone' && value.itemName === 'Cornerstone Mask')) {
+			if ((speciesForme.startsWith('Ogerpon-Wellspring') && itemName === 'Wellspring Mask') ||
+				(speciesForme.startsWith('Ogerpon-Hearthflame') && itemName === 'Hearthflame Mask') ||
+				(speciesForme.startsWith('Ogerpon-Cornerstone') && itemName === 'Cornerstone Mask')) {
 					value.itemModify(1.2);
 					return value;
 				}

--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -2379,11 +2379,14 @@ class BattleTooltips {
 			value.itemModify(1.2);
 			return value;
 		}
-		if ((speciesName.startsWith('Ogerpon-Wellspring') && itemName === 'Wellspring Mask') ||
-			(speciesName.startsWith('Ogerpon-Hearthflame') && itemName === 'Hearthflame Mask') ||
-			(speciesName.startsWith('Ogerpon-Cornerstone') && itemName === 'Cornerstone Mask')) {
-			value.itemModify(1.2);
-			return value;
+		if (speciesName === 'Ogerpon') {
+			const speciesForme = value.pokemon.getSpeciesForme();
+			if ((speciesForme === 'Ogerpon-Wellspring' && value.itemName === 'Wellspring Mask') ||
+				(speciesForme === 'Ogerpon-Hearthflame' && value.itemName === 'Hearthflame Mask') ||
+				(speciesForme === 'Ogerpon-Cornerstone' && value.itemName === 'Cornerstone Mask')) {
+					value.itemModify(1.2);
+					return value;
+				}
 		}
 
 		// Gems


### PR DESCRIPTION
Based on the description laid out in this thread: https://www.smogon.com/forums/threads/add-the-1-2x-damage-calculation-of-ogerpon-wellspring-hearthflame-cornerstone-mask-to-move-ui.3746567/

Local testing LGTM!

Please send any feedback my way, more than willing to learn here!