### PR TITLE
Chat: Support nameless /html messages

### DIFF
--- a/play.pokemonshowdown.com/js/client-mainmenu.js
+++ b/play.pokemonshowdown.com/js/client-mainmenu.js
@@ -1196,6 +1196,9 @@
 			case 'error':
 				return '<div class="chat message-error">' + BattleLog.escapeHTML(target) + '</div>';
 			case 'html':
+				if (!name) {
+					return {message: '<div class="chat' + hlClass + '">' + timestamp + '<em>' + BattleLog.sanitizeHTML(target) + '</em></div>', noNotify: isNotPM};
+				}
 				return {message: '<div class="chat chatmessage-' + toID(name) + hlClass + mineClass + '">' + timestamp + '<strong style="' + color + '">' + clickableName + ':</strong> <em>' + BattleLog.sanitizeHTML(target) + '</em></div>', noNotify: isNotPM};
 			case 'uhtml':
 			case 'uhtmlchange':

--- a/play.pokemonshowdown.com/src/battle-log.ts
+++ b/play.pokemonshowdown.com/src/battle-log.ts
@@ -689,6 +689,12 @@ export class BattleLog {
 		case 'error':
 			return ['chat message-error', formatText(target, true)];
 		case 'html':
+			if (!name) {
+				return [
+					'chat' + hlClass,
+					`${timestamp}<em>${BattleLog.sanitizeHTML(target)}</em>`,
+				];
+			}
 			return [
 				'chat chatmessage-' + toID(name) + hlClass + mineClass,
 				`${timestamp}<strong${colorStyle}>${clickableName}:</strong> <em>${BattleLog.sanitizeHTML(target)}</em>`,


### PR DESCRIPTION
Currently, if you send an `/html` message with `&` as the identity, it treats `&` as a username and shows it before the message with a colon.
<img width="443" alt="image" src="https://github.com/user-attachments/assets/e2cd0f70-d7c7-4da2-9792-fadb16d1ad75">
This change should allow the message to look like this instead
<img width="442" alt="image" src="https://github.com/user-attachments/assets/dbf430f1-4648-4aed-9456-bcdf300cf409">
I would like this feature for the auctions plugin so that I can send messages with username colors without sacrificing the timestamp like I would be doing by sending `/raw`.