### PR TITLE
Don't guess spreads when there are empty moves

### DIFF
--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -2612,9 +2612,10 @@ class BattleStatGuesser {
 
 		if (set.moves.length < 1) return '?';
 		let needsFourMoves = !['unown', 'ditto'].includes(species.id);
+		let hasFourValidMoves = (set.moves.length >= 4) && !set.moves.includes('');
 		let moveids = set.moves.map(toID);
 		if (moveids.includes('lastresort' as ID)) needsFourMoves = false;
-		if (set.moves.length < 4 && needsFourMoves && !this.formatid.includes('metronomebattle')) {
+		if (!hasFourValidMoves && needsFourMoves && !this.formatid.includes('metronomebattle')) {
 			return '?';
 		}
 

--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -2612,7 +2612,7 @@ class BattleStatGuesser {
 
 		if (set.moves.length < 1) return '?';
 		let needsFourMoves = !['unown', 'ditto'].includes(species.id);
-		let hasFourValidMoves = (set.moves.length >= 4) && !set.moves.includes('');
+		let hasFourValidMoves = set.moves.length >= 4 && !set.moves.includes('');
 		let moveids = set.moves.map(toID);
 		if (moveids.includes('lastresort' as ID)) needsFourMoves = false;
 		if (!hasFourValidMoves && needsFourMoves && !this.formatid.includes('metronomebattle')) {


### PR DESCRIPTION
Currently, when the teambuilder supplies a guessed spread, it will consider moves with the empty string for its check. This prevents the teambuilder from guessing spreads after the user only puts in 3 moves.

I'm not sure if the correct fix is here or in some way deleting the empty string move from ``set.moves`` altogether at some other point.