### PR TITLE
Fix missing spikes visual glitch in replays

### DIFF
--- a/play.pokemonshowdown.com/src/battle.ts
+++ b/play.pokemonshowdown.com/src/battle.ts
@@ -3830,6 +3830,7 @@ export class Battle {
 		if (turn === 0) {
 			this.seeking = null;
 			this.resetStep();
+			this.scene.resetSideConditions();
 			this.scene.animationOn();
 			if (this.paused) this.subscription?.('paused');
 			return;


### PR DESCRIPTION
This fixes a pretty well known visual glitch in replays where spikes don't show up on second viewing (after restarting the replay). The issue is that on a second viewing, [this condition](https://github.com/smogon/pokemon-showdown-client/blob/dd392d9fa9216cb4e4d3d8ee75e053188e2f27bf/play.pokemonshowdown.com/src/battle-animations.ts#L1300) doesn't trigger because `sideConditions` (and `spikeArray`) still had the old values.

Reproduction Steps:
1. Load a replay and watch until spikes are set
2. Click "First turn"
3. Watch until spikes are set again. They don't show up.

[Example replay](https://replay.pokemonshowdown.com/gen3randombattle-2166967126)
json:
```
{"id":"gen3randombattle-2166967126","format":"[Gen 3] Random Battle","players":["SandyEggo","test92011"],"log":"|j|\u2606SandyEggo\n|j|\u2606test92011\n|t:|1721874943\n|gametype|singles\n|player|p1|SandyEggo|infielder|1079\n|player|p2|test92011|265|1000\n|teamsize|p1|6\n|teamsize|p2|6\n|gen|3\n|tier|[Gen 3] Random Battle\n|rated|\n|rule|Sleep Clause Mod: Limit one foe put to sleep\n|rule|Switch Priority Clause Mod: Faster Pok\u00e9mon switch first\n|rule|Species Clause: Limit one of each Pok\u00e9mon\n|rule|OHKO Clause: OHKO moves are banned\n|rule|Evasion Items Clause: Evasion items are banned\n|rule|Evasion Moves Clause: Evasion moves are banned\n|rule|Endless Battle Clause: Forcing endless battles is banned\n|rule|HP Percentage Mod: HP is shown in percentages\n|\n|t:|1721874943\n|start\n|switch|p1a: Omastar|Omastar, L84, F|255\/255\n|switch|p2a: Nosepass|Nosepass, L99, F|219\/219\n|turn|1\n|\n|t:|1721874981\n|switch|p2a: Venomoth|Venomoth, L87, F|264\/264\n|move|p1a: Omastar|Spikes|p2a: Venomoth\n|-sidestart|p2: test92011|Spikes\n|\n|upkeep\n|turn|2\n|\n|t:|1721874994\n|switch|p2a: Sceptile|Sceptile, L82, F|248\/248\n|-damage|p2a: Sceptile|217\/248|[from] Spikes\n|move|p1a: Omastar|Ice Beam|p2a: Sceptile\n|-supereffective|p2a: Sceptile\n|-damage|p2a: Sceptile|63\/248\n|\n|upkeep\n|turn|3\n|-message|test92011 forfeited.\n|\n|win|SandyEggo\n|raw|SandyEggo's rating: 1079 &rarr; <strong>1101<\/strong><br \/>(+22 for winning)\n|raw|test92011's rating: 1000 &rarr; <strong>1000<\/strong><br \/>(+0 for losing)\n|l|\u2606SandyEggo\n|player|p1|\n","inputlog":">version e8361dfa7636e84b87e7a2c993580ab47c51022d\n>start {\"formatid\":\"gen3randombattle\",\"seed\":[30081,30710,14067,46028],\"rated\":\"Rated battle\"}\n>player p1 {\"name\":\"SandyEggo\",\"avatar\":\"infielder\",\"rating\":1079,\"seed\":[7885,256,580,44900]}\n>player p2 {\"name\":\"test92011\",\"avatar\":\"265\",\"rating\":1000,\"seed\":[63505,18517,15246,49288]}\n>p1 move spikes\n>p2 switch 6\n>p1 move icebeam\n>p2 switch 5\n>forcelose p2","uploadtime":1721875043,"views":4,"formatid":"gen3randombattle","rating":1000,"private":0,"password":null}
```