### PR TITLE
Teambuilder: Debounce searching teams

### DIFF
--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -3241,10 +3241,7 @@
 			this.chartSet(val, selectNext);
 		},
 		searchChange: function (e) {
-			if (this.searchTimeout) clearTimeout(this.searchTimeout);
-
-			var searchVal = e.currentTarget.value;
-
+			var DEBOUNCE_THRESHOLD_TEAMS = 500;
 			function updateTeamList() {
 				// 91 for right CMD / 93 for left CMD / 17 for CTL
 				if (e.keyCode !== 91 && e.keyCode !== 93 && e.keyCode !== 17) {
@@ -3252,8 +3249,15 @@
 				}
 				this.updateTeamList();
 			}
-			// Debounced to ensure this isn't called too frequently while typing
-			this.searchTimeout = setTimeout(updateTeamList.bind(this), 400);
+
+			// If the user has a lot of teams, search is debounced to
+			// ensure this isn't called too frequently while typing
+			if (Storage.teams.length > DEBOUNCE_THRESHOLD_TEAMS) {
+				if (this.searchTimeout) clearTimeout(this.searchTimeout);
+
+				var searchVal = e.currentTarget.value;
+				this.searchTimeout = setTimeout(updateTeamList.bind(this), 400);
+			} else updateTeamList();
 
 		},
 		chartSetCustom: function (val) {

--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -138,6 +138,8 @@
 		curFolder: '',
 		curFolderKeep: '',
 		curSearchVal: '',
+		// Debounce value for searching in the teambuilder
+		searchTimeout: null,
 
 		exportMode: false,
 		formatResources: {},
@@ -3239,11 +3241,20 @@
 			this.chartSet(val, selectNext);
 		},
 		searchChange: function (e) {
-			// 91 for right CMD / 93 for left CMD / 17 for CTL
-			if (e.keyCode !== 91 && e.keyCode !== 93 && e.keyCode !== 17) {
-				this.curSearchVal = e.currentTarget.value;
+			if (this.searchTimeout) clearTimeout(this.searchTimeout);
+
+			var searchVal = e.currentTarget.value;
+
+			function updateTeamList() {
+				// 91 for right CMD / 93 for left CMD / 17 for CTL
+				if (e.keyCode !== 91 && e.keyCode !== 93 && e.keyCode !== 17) {
+					this.curSearchVal = searchVal;
+				}
 				this.updateTeamList();
 			}
+			// Debounced to ensure this isn't called too frequently while typing
+			this.searchTimeout = setTimeout(updateTeamList.bind(this), 400);
+
 		},
 		chartSetCustom: function (val) {
 			val = toID(val);


### PR DESCRIPTION
Wasn't fun having my browser frozen for half a minute every time I typed more than two letters in the teambuilder search; this PR introduces debounced calls to updateTeamList() instead of direct calls.

Tested locally on Chrome 127.0.6533.72