### PR TITLE
Fix formatting of Glicko-1 on ladder page

### DIFF
--- a/pokemonshowdown.com/ladder.php
+++ b/pokemonshowdown.com/ladder.php
@@ -191,7 +191,7 @@ if (!$formatid) {
 				<th width="60" style="text-align:center"><abbr title="Elo rating">Elo</abbr></th>
 				<th width="50" style="text-align:center"><abbr title="user's percentage chance of winning a random battle (aka GLIXARE)">GXE</abbr></th>
 				<!--th width="50" style="text-align:center"><abbr title="Win Chance vs Average Opponent">WCAO</abbr></th-->
-				<th width="80" style="text-align:center"><abbr title="Glicko-1 rating: rating&#177;deviation">Glicko-1</abbr></th>
+				<th width="90" style="text-align:center"><abbr title="Glicko-1 rating: rating&#177;deviation">Glicko-1</abbr></th>
 				<th width="50"><abbr title="A special rating used for suspect tests.">COIL</abbr></th>
 			</tr>
 <?php


### PR DESCRIPTION
Before:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/deffcdcf-d7a4-434e-8d18-d55533ba7829">
After:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/22aeb800-c010-4ea6-b39e-09c34b9278b4">

Is there a reason that the widths are even specified though? Getting rid of all the width values also makes the table keep everything on one line.