### PR TITLE
Use only current line in tab-completing commands

### DIFF
--- a/play.pokemonshowdown.com/js/client-chat.js
+++ b/play.pokemonshowdown.com/js/client-chat.js
@@ -361,11 +361,6 @@
 				var cmds = this.tabComplete.commands;
 				var textboxLines = prefix.split('\n');
 				var currentLine = textboxLines.pop();
-				var prefixLength = 0;
-				for (var line of textboxLines) {
-					prefixLength += line.length + 1;
-				}
-				this.tabComplete.prefixLength = prefixLength;
 				var shouldSearchCommands = !cmds || (cmds.length ? !!cmds.length && !cmds.filter(function (x) {
 					return x.startsWith(currentLine);
 				}).length : prefix != this.tabComplete.prefix);
@@ -454,7 +449,7 @@
 			if (!substituteUser) return true;
 			var name = typeof substituteUser === 'object' ? substituteUser.name : substituteUser;
 			name = Dex.getShortName(name);
-			let prefixIndex = this.tabComplete.isCommand ? this.tabComplete.prefixLength : candidate[1];
+			var prefixIndex = this.tabComplete.isCommand ? prefix.lastIndexOf('\n') + 1 : candidate[1];
 			var fullPrefix = this.tabComplete.prefix.substr(0, prefixIndex) + name;
 			$textbox.val(fullPrefix + text.substr(idx));
 			var pos = fullPrefix.length;

--- a/play.pokemonshowdown.com/js/client-chat.js
+++ b/play.pokemonshowdown.com/js/client-chat.js
@@ -359,12 +359,11 @@
 				var m2 = /^([\s\S!/]*?)([A-Za-z0-9][^, \n]* [^, ]*)$/.exec(prefix);
 				if (!m1 && !m2) return true;
 				var cmds = this.tabComplete.commands;
-				var textboxLines = prefix.split('\n');
-				var currentLine = textboxLines.pop();
+				var currentLine = prefix.substr(prefix.lastIndexOf('\n') + 1);
 				var shouldSearchCommands = !cmds || (cmds.length ? !!cmds.length && !cmds.filter(function (x) {
 					return x.startsWith(currentLine);
 				}).length : prefix != this.tabComplete.prefix);
-				var isCommandSearch = ((currentLine.startsWith('/') && !currentLine.startsWith('//')) || currentLine.startsWith('!')) && currentLine.indexOf(' ') < 0;
+				var isCommandSearch = (currentLine.startsWith('/') && !currentLine.startsWith('//')) || currentLine.startsWith('!');
 				var resultsExist = this.tabComplete.lastSearch === text && this.tabComplete.commands;
 				if (isCommandSearch && shouldSearchCommands && !resultsExist) {
 					if (this.tabComplete.searchPending) return true; // wait
@@ -392,39 +391,39 @@
 				var spaceprefix = (m2 ? m2[2].replace(/[^A-Za-z0-9 ]+/g, '').toLowerCase() : '');
 				var candidates = []; // array of [candidate userid, prefix length]
 
-				if (!this.tabComplete.isCommand) {
-					// don't include command names in autocomplete
-					if (m2 && (m2[0] === '/' || m2[0] === '!')) spaceprefix = '';
+				// don't include command names in autocomplete
+				if (m2 && (m2[0] === '/' || m2[0] === '!')) spaceprefix = '';
 
-					for (var i in users) {
-						if (spaceprefix && users[i].name.replace(/[^A-Za-z0-9 ]+/g, '').toLowerCase().substr(0, spaceprefix.length) === spaceprefix) {
-							candidates.push([i, m2[1].length]);
-						} else if (idprefix && i.substr(0, idprefix.length) === idprefix) {
-							candidates.push([i, m1[1].length]);
-						}
+				for (var i in users) {
+					if (spaceprefix && users[i].name.replace(/[^A-Za-z0-9 ]+/g, '').toLowerCase().substr(0, spaceprefix.length) === spaceprefix) {
+						candidates.push([i, m2[1].length]);
+					} else if (idprefix && i.substr(0, idprefix.length) === idprefix) {
+						candidates.push([i, m1[1].length]);
 					}
+				}
 
-					// Sort by most recent to speak in the chat, or, in the case of a tie,
-					// in alphabetical order.
-					var self = this;
-					candidates.sort(function (a, b) {
-						if (a[1] !== b[1]) {
-							// shorter prefix length comes first
-							return a[1] - b[1];
+				// Sort by most recent to speak in the chat, or, in the case of a tie,
+				// in alphabetical order.
+				var self = this;
+				candidates.sort(function (a, b) {
+					if (a[1] !== b[1]) {
+						// shorter prefix length comes first
+						return a[1] - b[1];
+					}
+					var aidx = self.userActivity.indexOf(a[0]);
+					var bidx = self.userActivity.indexOf(b[0]);
+					if (aidx !== -1) {
+						if (bidx !== -1) {
+							return bidx - aidx;
 						}
-						var aidx = self.userActivity.indexOf(a[0]);
-						var bidx = self.userActivity.indexOf(b[0]);
-						if (aidx !== -1) {
-							if (bidx !== -1) {
-								return bidx - aidx;
-							}
-							return -1; // a comes first
-						} else if (bidx != -1) {
-							return 1; // b comes first
-						}
-						return (a[0] < b[0]) ? -1 : 1; // alphabetical order
-					});
-				} else {
+						return -1; // a comes first
+					} else if (bidx != -1) {
+						return 1; // b comes first
+					}
+					return (a[0] < b[0]) ? -1 : 1; // alphabetical order
+				});
+
+				if (this.tabComplete.isCommand) {
 					this.tabComplete.commands.sort(function (a, b) {
 						return a.length < b.length ? 1 : -1;
 					});
@@ -449,7 +448,7 @@
 			if (!substituteUser) return true;
 			var name = typeof substituteUser === 'object' ? substituteUser.name : substituteUser;
 			name = Dex.getShortName(name);
-			var prefixIndex = this.tabComplete.isCommand ? prefix.lastIndexOf('\n') + 1 : candidate[1];
+			var prefixIndex = candidate[1].toString().charAt(0) === '/' ? prefix.lastIndexOf('\n') + 1 : candidate[1];
 			var fullPrefix = this.tabComplete.prefix.substr(0, prefixIndex) + name;
 			$textbox.val(fullPrefix + text.substr(idx));
 			var pos = fullPrefix.length;


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-report.3749269/

At this point, it's a bit more than a bug fix. It seems intuitive that attempting to perform a tab-complete on one line should search for commands on that line, but it doesn't because it's searching for commands using the entire text box, which was also causing the issue of sending lines into chat.

Besides that, I also reverted the behavior of both commands and usernames being able to be candidates of the same autocomplete, while retaining the ability to autocomplete usernames if placed after the command; I'm not sure how it was helpful to go between commands and usernames.