### PR TITLE
Display exact HP when using Exact HP Mod

### DIFF
--- a/play.pokemonshowdown.com/src/battle-animations.ts
+++ b/play.pokemonshowdown.com/src/battle-animations.ts
@@ -2862,7 +2862,7 @@ export class PokemonSprite extends Sprite {
 		if (pokemon.maxhp === 48 || this.scene.battle.hardcoreMode && pokemon.maxhp === 100) {
 			$hptext.hide();
 			$hptextborder.hide();
-		} else if (this.scene.battle.hardcoreMode) {
+		} else if (this.scene.battle.hardcoreMode || this.scene.battle.reportExactHP) {
 			$hptext.html(pokemon.hp + '/');
 			$hptext.show();
 			$hptextborder.show();

--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -843,7 +843,7 @@ class BattleTooltips {
 			} else if (pokemon.maxhp === 48) {
 				exacthp = ' <small>(' + pokemon.hp + '/' + pokemon.maxhp + ' pixels)</small>';
 			}
-			text += '<p><small>HP:</small> ' + Pokemon.getHPText(pokemon) + exacthp + (pokemon.status ? ' <span class="status ' + pokemon.status + '">' + pokemon.status.toUpperCase() + '</span>' : '');
+			text += '<p><small>HP:</small> ' + Pokemon.getHPText(pokemon, this.battle.reportExactHP) + exacthp + (pokemon.status ? ' <span class="status ' + pokemon.status + '">' + pokemon.status.toUpperCase() + '</span>' : '');
 			if (clientPokemon) {
 				if (pokemon.status === 'tox') {
 					if (pokemon.ability === 'Poison Heal' || pokemon.ability === 'Magic Guard') {

--- a/play.pokemonshowdown.com/src/battle.ts
+++ b/play.pokemonshowdown.com/src/battle.ts
@@ -582,9 +582,10 @@ export class Pokemon implements PokemonDetails, PokemonHealth {
 		return percentage * maxWidth / 100;
 	}
 	getHPText(precision = 1) {
-		return Pokemon.getHPText(this, precision);
+		return Pokemon.getHPText(this, this.side.battle.reportExactHP, precision);
 	}
-	static getHPText(pokemon: PokemonHealth, precision = 1) {
+	static getHPText(pokemon: PokemonHealth, exactHP: boolean, precision = 1) {
+    if (exactHP) return pokemon.hp + '/' + pokemon.maxhp;
 		if (pokemon.maxhp === 100) return pokemon.hp + '%';
 		if (pokemon.maxhp !== 48) return (100 * pokemon.hp / pokemon.maxhp).toFixed(precision) + '%';
 		let range = Pokemon.getPixelRange(pokemon.hp, pokemon.hpcolor);
@@ -1097,6 +1098,7 @@ export class Battle {
 	rated: string | boolean = false;
 	rules: {[ruleName: string]: 1 | 0} = {};
 	isBlitz = false;
+  reportExactHP = false;
 	endLastTurnPending = false;
 	totalTimeLeft = 0;
 	graceTimeLeft = 0;
@@ -3442,6 +3444,7 @@ export class Battle {
 				this.messageFadeTime = 40;
 				this.isBlitz = true;
 			}
+      if (ruleName === 'Exact HP Mod') this.reportExactHP = true;
 			this.rules[ruleName] = 1;
 			this.log(args);
 			break;

--- a/play.pokemonshowdown.com/src/battle.ts
+++ b/play.pokemonshowdown.com/src/battle.ts
@@ -585,7 +585,7 @@ export class Pokemon implements PokemonDetails, PokemonHealth {
 		return Pokemon.getHPText(this, this.side.battle.reportExactHP, precision);
 	}
 	static getHPText(pokemon: PokemonHealth, exactHP: boolean, precision = 1) {
-    if (exactHP) return pokemon.hp + '/' + pokemon.maxhp;
+		if (exactHP) return pokemon.hp + '/' + pokemon.maxhp;
 		if (pokemon.maxhp === 100) return pokemon.hp + '%';
 		if (pokemon.maxhp !== 48) return (100 * pokemon.hp / pokemon.maxhp).toFixed(precision) + '%';
 		let range = Pokemon.getPixelRange(pokemon.hp, pokemon.hpcolor);
@@ -1098,7 +1098,7 @@ export class Battle {
 	rated: string | boolean = false;
 	rules: {[ruleName: string]: 1 | 0} = {};
 	isBlitz = false;
-  reportExactHP = false;
+	reportExactHP = false;
 	endLastTurnPending = false;
 	totalTimeLeft = 0;
 	graceTimeLeft = 0;
@@ -3444,7 +3444,7 @@ export class Battle {
 				this.messageFadeTime = 40;
 				this.isBlitz = true;
 			}
-      if (ruleName === 'Exact HP Mod') this.reportExactHP = true;
+			if (ruleName === 'Exact HP Mod') this.reportExactHP = true;
 			this.rules[ruleName] = 1;
 			this.log(args);
 			break;


### PR DESCRIPTION
Exact HP mod sends current HP and Max HP to both the user and the opponent via server protocol messages, but displays percent regardless unless the user turns on hardcore mode, making it information almost only accessible via the console. This pull request displays the current hp in the hp bar and the current and Max HP in the pokemon's tooltips for easier accessibility.

Before:
https://github.com/user-attachments/assets/606f60bc-a4ee-4666-9144-c5432f517855

After:
https://github.com/user-attachments/assets/d103e177-005f-4132-a425-0d14e49a2008