### PR TITLE
Fixed a case of endless loop

### DIFF
--- a/play.pokemonshowdown.com/js/storage.js
+++ b/play.pokemonshowdown.com/js/storage.js
@@ -1107,7 +1107,7 @@ Storage.unpackTeam = function (buf) {
 			set.dynamaxLevel = (misc[4] ? Number(misc[4]) : 10);
 			set.teraType = misc[5];
 		}
-		if (j < 0) break;
+		if (j < 0 || buf.indexOf('|', j) < 0) break;
 		i = j + 1;
 	}
 


### PR DESCRIPTION
It was possible to freeze the tab by importing a team/set containing `]` with no `|` after.

(only if the whole import is 1 line or 2 lines with the 2nd one being blank - this leads to the importer using `Storage.unpackTeam()` which is intended functionality.)

I took care to not conflict with #2222 . hopefully we can discuss rewriting the packed team format after these prs are resolved ...

credit for finding this bug: https://github.com/smogon/pokemon-showdown-client/pull/2283#issuecomment-2370371178