### PR TITLE
Support blank target in -item message

### DIFF
--- a/play.pokemonshowdown.com/src/battle.ts
+++ b/play.pokemonshowdown.com/src/battle.ts
@@ -2225,10 +2225,24 @@ export class Battle {
 			break;
 		}
 		case '-item': {
-			let poke = this.getPokemon(args[1])!;
+			let poke = this.getPokemon(args[1]);
 			let item = Dex.items.get(args[2]);
 			let effect = Dex.getEffect(kwArgs.from);
 			let ofpoke = this.getPokemon(kwArgs.of);
+			if (!poke) {
+				if (effect.id === 'frisk') {
+					const possibleTargets = ofpoke!.side.foe.active.filter(p => p !== null);
+					if (possibleTargets.length === 1) {
+						poke = possibleTargets[0];
+					} else {
+						this.activateAbility(ofpoke!, "Frisk");
+						this.log(args, kwArgs);
+						break;
+					}
+				} else {
+					throw new Error('No Pokemon in -item message');
+				}
+			}
 			poke.item = item.name;
 			poke.itemEffect = '';
 			poke.removeVolatile('airballoon' as ID);

--- a/play.pokemonshowdown.com/src/battle.ts
+++ b/play.pokemonshowdown.com/src/battle.ts
@@ -2233,7 +2233,7 @@ export class Battle {
 				if (effect.id === 'frisk') {
 					const possibleTargets = ofpoke!.side.foe.active.filter(p => p !== null);
 					if (possibleTargets.length === 1) {
-						poke = possibleTargets[0];
+						poke = possibleTargets[0]!;
 					} else {
 						this.activateAbility(ofpoke!, "Frisk");
 						this.log(args, kwArgs);

--- a/play.pokemonshowdown.com/src/battle.ts
+++ b/play.pokemonshowdown.com/src/battle.ts
@@ -2225,7 +2225,7 @@ export class Battle {
 			break;
 		}
 		case '-item': {
-			let poke = this.getPokemon(args[1]);
+			let poke = this.getPokemon(args[1])!;
 			let item = Dex.items.get(args[2]);
 			let effect = Dex.getEffect(kwArgs.from);
 			let ofpoke = this.getPokemon(kwArgs.of);


### PR DESCRIPTION
For Gen 4-5 Frisk. If no target is sent with an -item message, the client first checks if there is exactly 1 possible target, and updates its item.