### PR TITLE
Don't force Tera types because of Hackmons

### DIFF
--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -1343,7 +1343,7 @@
 					}
 				}
 				if (this.curTeam.gen === 9) {
-					buf += '<span class="detailcell"><label>Tera Type</label>' + (set.teraType || species.forceTeraType || species.types[0]) + '</span>';
+					buf += '<span class="detailcell"><label>Tera Type</label>' + (set.teraType || species.requiredTeraType || species.types[0]) + '</span>';
 				}
 			}
 			buf += '</button></div></div>';
@@ -1880,7 +1880,7 @@
 
 			// never preserve current set tera, even if smogon set used default
 			if (this.curSet.gen === 9) {
-				curSet.teraType = sampleSet.teraType || species.forceTeraType || species.types[0];
+				curSet.teraType = sampleSet.teraType || species.requiredTeraType || species.types[0];
 			}
 
 			var text = Storage.exportTeam([curSet], this.curTeam.gen);
@@ -2913,7 +2913,7 @@
 				buf += '<div class="formrow"><label class="formlabel" title="Tera Type">Tera Type:</label><div>';
 				buf += '<select name="teratype" class="button">';
 				var types = Dex.types.all();
-				var teraType = set.teraType || species.forceTeraType || species.types[0];
+				var teraType = set.teraType || species.requiredTeraType || species.types[0];
 				for (var i = 0; i < types.length; i++) {
 					buf += '<option value="' + types[i].name + '"' + (teraType === types[i].name ? ' selected="selected"' : '') + '>' + types[i].name + '</option>';
 				}
@@ -3028,7 +3028,7 @@
 					}
 				}
 				if (this.curTeam.gen === 9) {
-					buf += '<span class="detailcell"><label>Tera Type</label>' + (set.teraType || species.forceTeraType || species.types[0]) + '</span>';
+					buf += '<span class="detailcell"><label>Tera Type</label>' + (set.teraType || species.requiredTeraType || species.types[0]) + '</span>';
 				}
 			}
 			this.$('button[name=details]').html(buf);

--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -1343,7 +1343,7 @@
 					}
 				}
 				if (this.curTeam.gen === 9) {
-					buf += '<span class="detailcell"><label>Tera Type</label>' + (species.forceTeraType || set.teraType || species.types[0]) + '</span>';
+					buf += '<span class="detailcell"><label>Tera Type</label>' + (set.teraType || species.forceTeraType || species.types[0]) + '</span>';
 				}
 			}
 			buf += '</button></div></div>';
@@ -1880,7 +1880,7 @@
 
 			// never preserve current set tera, even if smogon set used default
 			if (this.curSet.gen === 9) {
-				curSet.teraType = species.forceTeraType || sampleSet.teraType || species.types[0];
+				curSet.teraType = sampleSet.teraType || species.forceTeraType || species.types[0];
 			}
 
 			var text = Storage.exportTeam([curSet], this.curTeam.gen);
@@ -2911,18 +2911,13 @@
 
 			if (this.curTeam.gen === 9) {
 				buf += '<div class="formrow"><label class="formlabel" title="Tera Type">Tera Type:</label><div>';
-				if (species.forceTeraType) {
-					buf += species.forceTeraType;
-				} else {
-					buf += '<select name="teratype" class="button">';
-					var types = Dex.types.all();
-					var teraType = set.teraType || species.types[0];
-					for (var i = 0; i < types.length; i++) {
-						buf += '<option value="' + types[i].name + '"' + (teraType === types[i].name ? ' selected="selected"' : '') + '>' + types[i].name + '</option>';
-					}
-					buf += '</select>';
+				buf += '<select name="teratype" class="button">';
+				var types = Dex.types.all();
+				var teraType = set.teraType || species.forceTeraType || species.types[0];
+				for (var i = 0; i < types.length; i++) {
+					buf += '<option value="' + types[i].name + '"' + (teraType === types[i].name ? ' selected="selected"' : '') + '>' + types[i].name + '</option>';
 				}
-				buf += '</div></div>';
+				buf += '</select></div></div>';
 			}
 
 			buf += '</form>';
@@ -3033,7 +3028,7 @@
 					}
 				}
 				if (this.curTeam.gen === 9) {
-					buf += '<span class="detailcell"><label>Tera Type</label>' + (species.forceTeraType || set.teraType || species.types[0]) + '</span>';
+					buf += '<span class="detailcell"><label>Tera Type</label>' + (set.teraType || species.forceTeraType || species.types[0]) + '</span>';
 				}
 			}
 			this.$('button[name=details]').html(buf);

--- a/play.pokemonshowdown.com/js/storage.js
+++ b/play.pokemonshowdown.com/js/storage.js
@@ -1420,7 +1420,7 @@ Storage.exportTeam = function (team, gen, hidestats) {
 		}
 		if (gen === 9) {
 			var species = Dex.species.get(curSet.species);
-			text += 'Tera Type: ' + (species.forceTeraType || curSet.teraType || species.types[0]) + "  \n";
+			text += 'Tera Type: ' + (curSet.teraType || species.forceTeraType || species.types[0]) + "  \n";
 		}
 		if (!hidestats) {
 			var first = true;

--- a/play.pokemonshowdown.com/js/storage.js
+++ b/play.pokemonshowdown.com/js/storage.js
@@ -1420,7 +1420,7 @@ Storage.exportTeam = function (team, gen, hidestats) {
 		}
 		if (gen === 9) {
 			var species = Dex.species.get(curSet.species);
-			text += 'Tera Type: ' + (curSet.teraType || species.forceTeraType || species.types[0]) + "  \n";
+			text += 'Tera Type: ' + (curSet.teraType || species.requiredTeraType || species.types[0]) + "  \n";
 		}
 		if (!hidestats) {
 			var first = true;

--- a/play.pokemonshowdown.com/src/battle-dex-data.ts
+++ b/play.pokemonshowdown.com/src/battle-dex-data.ts
@@ -1498,7 +1498,7 @@ class Species implements Effect {
 	readonly isPrimal: boolean;
 	readonly canGigantamax: boolean;
 	readonly cannotDynamax: boolean;
-	readonly forceTeraType: TypeName;
+	readonly requiredTeraType: TypeName;
 	readonly battleOnly: string | string[] | undefined;
 	readonly isNonstandard: string | null;
 	readonly unreleasedHidden: boolean | 'Past';
@@ -1553,7 +1553,7 @@ class Species implements Effect {
 		this.isPrimal = !!(this.forme && this.formeid === '-primal');
 		this.canGigantamax = !!data.canGigantamax;
 		this.cannotDynamax = !!data.cannotDynamax;
-		this.forceTeraType = data.forceTeraType || '';
+		this.requiredTeraType = data.requiredTeraType || '';
 		this.battleOnly = data.battleOnly || (this.isMega ? this.baseSpecies : undefined);
 		this.isNonstandard = data.isNonstandard || null;
 		this.unreleasedHidden = data.unreleasedHidden || false;

--- a/play.pokemonshowdown.com/src/battle-dex.ts
+++ b/play.pokemonshowdown.com/src/battle-dex.ts
@@ -1200,7 +1200,7 @@ const Teams = new class {
 			}
 			if (gen === 9) {
 				const species = Dex.species.get(curSet.species);
-				text += 'Tera Type: ' + (curSet.teraType || species.forceTeraType || species.types[0]) + "  \n";
+				text += 'Tera Type: ' + (curSet.teraType || species.requiredTeraType || species.types[0]) + "  \n";
 			}
 			if (!hidestats) {
 				let first = true;

--- a/play.pokemonshowdown.com/src/battle-dex.ts
+++ b/play.pokemonshowdown.com/src/battle-dex.ts
@@ -1200,7 +1200,7 @@ const Teams = new class {
 			}
 			if (gen === 9) {
 				const species = Dex.species.get(curSet.species);
-				text += 'Tera Type: ' + (species.forceTeraType || curSet.teraType || species.types[0]) + "  \n";
+				text += 'Tera Type: ' + (curSet.teraType || species.forceTeraType || species.types[0]) + "  \n";
 			}
 			if (!hidestats) {
 				let first = true;


### PR DESCRIPTION
In the cartrige, any Ogerpon form is able to Terastallize into Fire, Grass, Rock or Water types, while Terapagos is able to Terastallize into any type. Currently, the server does not support changing the Tera types of these Pokémon, so adding that functionality is crucial for metagames like Hackmons.

This PR should be merged together with [this server PR](https://github.com/smogon/pokemon-showdown/pull/10814), that it will correctly handle those transformations.

Closes #2314