### PR TITLE
Add National Dex Ubers UU teambuilder support

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -465,7 +465,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 			tierTable[tier].push(id);
 
 			if (genNum === 9) {
-				const ubersUU = Dex.formats.get(gen + 'ubersuu');
+				const ubersUU = Dex.formats.get(gen + (isNatDex ? 'nationaldex' : '') + 'ubersuu');
 				if (ubersUU.exists && Dex.formats.getRuleTable(ubersUU).isBannedSpecies(species)) {
 					ubersUUBans[species.id] = 1;
 				}
@@ -498,6 +498,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 			BattleTeambuilderTable['gen' + genNum + 'natdex'].overrideTier = overrideTier;
 			BattleTeambuilderTable['gen' + genNum + 'natdex'].items = items;
 			BattleTeambuilderTable['gen' + genNum + 'natdex'].ndDoublesBans = ndDoublesBans;
+			BattleTeambuilderTable['gen' + genNum + 'natdex'].ubersUUBans = ubersUUBans;
 			BattleTeambuilderTable['gen' + genNum + 'natdex'].monotypeBans = monotypeBans;
 			BattleTeambuilderTable['gen' + genNum + 'natdex'].formatSlices = formatSlices;
 		} else if (isMetBattle) {


### PR DESCRIPTION
It seems the only thing actually necessary to make this work was to make sure `ubersUUBans` was generated for Natdex as well. No other file changes seem to be necessary.

Tested locally, note the absence of Mega Mewtwo Y.
![image](https://github.com/user-attachments/assets/a3db101d-db5c-466b-adda-6534e599b0fd)
