### PR TITLE
Move room owners above admins once again

### DIFF
--- a/play.pokemonshowdown.com/js/client.js
+++ b/play.pokemonshowdown.com/js/client.js
@@ -2650,13 +2650,13 @@ function toId() {
 	});
 
 	Config.groups = Config.groups || {
-		'~': {
-			name: "Administrator (~)",
+		'#': {
+			name: "Room Owner (#)",
 			type: 'leadership',
 			order: 10001
 		},
-		'#': {
-			name: "Room Owner (#)",
+		'~': {
+			name: "Administrator (~)",
 			type: 'leadership',
 			order: 10002
 		},

--- a/play.pokemonshowdown.com/src/client-main.ts
+++ b/play.pokemonshowdown.com/src/client-main.ts
@@ -340,13 +340,13 @@ class PSServer {
 	prefix = '/showdown';
 	protocol: 'http' | 'https' = Config.defaultserver.httpport ? 'https' : 'http';
 	groups: { [symbol: string]: PSGroup } = {
-		'~': {
-			name: "Administrator (~)",
+		'#': {
+			name: "Room Owner (#)",
 			type: 'leadership',
 			order: 101,
 		},
-		'#': {
-			name: "Room Owner (#)",
+		'~': {
+			name: "Administrator (~)",
 			type: 'leadership',
 			order: 102,
 		},


### PR DESCRIPTION
Regression from the transition back to ~ for admin symbol; see https://github.com/smogon/pokemon-showdown-client/pull/1618