### PR TITLE
Teambuilder: Fix error on set import for formats without dex sets

### DIFF
--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -1840,7 +1840,7 @@
 			var $userSetDiv = this.$('.teambuilder-pokemon-import .teambuilder-import-user-sets');
 			$userSetDiv.empty();
 
-			if (smogonFormatSets) {
+			if (smogonFormatSets && smogonFormatSets['dex']) {
 				var smogonSets = $.extend({}, smogonFormatSets['dex'][species], (smogonFormatSets['stats'] || {})[species]);
 				$smogonSetDiv.text('Sample sets: ');
 				for (var set in smogonSets) {


### PR DESCRIPTION
Currently throws a console error when you click "Import/Export" on a pokemon set when building a team for a format that doesn't have sets on the smogdex (Example: Gen 4 1v1). Notably this prevents box sets from showing up for those formats