### PR TITLE
Collapsible Datasearches

### DIFF
--- a/play.pokemonshowdown.com/js/client-chat.js
+++ b/play.pokemonshowdown.com/js/client-chat.js
@@ -12,6 +12,7 @@
 			if (!this.events['focus textarea']) this.events['focus textarea'] = 'focusText';
 			if (!this.events['blur textarea']) this.events['blur textarea'] = 'blurText';
 			if (!this.events['click .spoiler']) this.events['click .spoiler'] = 'clickSpoiler';
+			if (!this.events['click .datasearch']) this.events['click .datasearch'] = 'clickDatasearchResults';
 			if (!this.events['click .message-pm i']) this.events['click .message-pm i'] = 'openPM';
 
 			this.initializeTabComplete();
@@ -107,6 +108,16 @@
 		},
 		clickSpoiler: function (e) {
 			$(e.currentTarget).toggleClass('spoiler-shown');
+		},
+
+		clickDatasearchResults: function (e) {
+			if ($(e.target).href) return;
+			var target = $(e.currentTarget).closest('[class=datasearch]')[0];
+			var button = target.querySelector('button');
+			var results = target.querySelectorAll('[class=datasearch-body]');
+			if (!button || !results || results.length < 2) return;
+			button.innerHTML = button.innerHTML === '[-]' ? '[+]' : '[-]';
+			for (body of results) body.style.display = body.style.display === 'none' ? 'block' : 'none';
 		},
 
 		login: function () {

--- a/play.pokemonshowdown.com/js/client-chat.js
+++ b/play.pokemonshowdown.com/js/client-chat.js
@@ -111,7 +111,7 @@
 		},
 
 		clickDatasearchResults: function (e) {
-			if ($(e.target).href) return;
+			if ($(e.target)[0].href) return;
 			var target = $(e.currentTarget).closest('[class=datasearch]')[0];
 			var button = target.querySelector('button');
 			var results = target.querySelectorAll('[class=datasearch-body]');

--- a/play.pokemonshowdown.com/js/client-chat.js
+++ b/play.pokemonshowdown.com/js/client-chat.js
@@ -117,7 +117,9 @@
 			var results = target.querySelectorAll('[class=datasearch-body]');
 			if (!button || !results || results.length < 2) return;
 			button.innerHTML = button.innerHTML === '[-]' ? '[+]' : '[-]';
-			for (body of results) body.style.display = body.style.display === 'none' ? 'block' : 'none';
+			for (var i = 0; i < results.length; i++) {
+				results[i].style.display = results[i].style.display === 'none' ? 'block' : 'none';
+			}
 		},
 
 		login: function () {

--- a/play.pokemonshowdown.com/js/client-mainmenu.js
+++ b/play.pokemonshowdown.com/js/client-mainmenu.js
@@ -661,7 +661,7 @@
 		},
 
 		clickDatasearchResults: function (e) {
-			if ($(e.target).href) return;
+			if ($(e.target)[0].href) return;
 			var target = $(e.currentTarget).closest('[class=datasearch]')[0];
 			var button = target.querySelector('button');
 			var results = target.querySelectorAll('[class=datasearch-body]');

--- a/play.pokemonshowdown.com/js/client-mainmenu.js
+++ b/play.pokemonshowdown.com/js/client-mainmenu.js
@@ -18,6 +18,7 @@
 			'focus textarea': 'onFocusPM',
 			'blur textarea': 'onBlurPM',
 			'click .spoiler': 'clickSpoiler',
+			'click .datasearch': 'clickDatasearchResults',
 			'click button.formatselect': 'selectFormat',
 			'click button.teamselect': 'selectTeam',
 			'click button[name=partnersubmit]': 'selectTeammate'
@@ -657,6 +658,16 @@
 		},
 		clickSpoiler: function (e) {
 			$(e.currentTarget).toggleClass('spoiler-shown');
+		},
+
+		clickDatasearchResults: function (e) {
+			if ($(e.target).href) return;
+			var target = $(e.currentTarget).closest('[class=datasearch]')[0];
+			var button = target.querySelector('button');
+			var results = target.querySelectorAll('[class=datasearch-body]');
+			if (!button || !results || results.length < 2) return;
+			button.innerHTML = button.innerHTML === '[-]' ? '[+]' : '[-]';
+			for (body of results) body.style.display = body.style.display === 'none' ? 'block' : 'none';
 		},
 
 		// support for buttons that can be sent by the server:

--- a/play.pokemonshowdown.com/js/client-mainmenu.js
+++ b/play.pokemonshowdown.com/js/client-mainmenu.js
@@ -667,7 +667,9 @@
 			var results = target.querySelectorAll('[class=datasearch-body]');
 			if (!button || !results || results.length < 2) return;
 			button.innerHTML = button.innerHTML === '[-]' ? '[+]' : '[-]';
-			for (body of results) body.style.display = body.style.display === 'none' ? 'block' : 'none';
+			for (var i = 0; i < results.length; i++) {
+				results[i].style.display = results[i].style.display === 'none' ? 'block' : 'none';
+			}
 		},
 
 		// support for buttons that can be sent by the server:


### PR DESCRIPTION
Implements [Improve how !ds all displays](https://www.smogon.com/forums/threads/improve-how-ds-all-displays.3654308/)

Supports the server-side changes from [this PR ](https://github.com/smogon/pokemon-showdown/pull/10995)

Backing javascript for toggling the display of datasearch results. This would have been implemented using the existing readmore option which uses the `<details><summary>` tags with an inline display, but Chrome creates a linebreak after the summary results preventing them from properly joining together with the rest of the results. 