### PR TITLE
Implement Flame/Toxic orb texts

### DIFF
--- a/play.pokemonshowdown.com/src/battle-text-parser.ts
+++ b/play.pokemonshowdown.com/src/battle-text-parser.ts
@@ -761,6 +761,10 @@ export class BattleTextParser {
 		case '-status': {
 			const [, pokemon, status] = args;
 			const line1 = this.maybeAbility(kwArgs.from, kwArgs.of || pokemon);
+			if (kwArgs.from?.startsWith('item:')) {
+				const template = this.template('startFromItem', status);
+				return line1 + template.replace('[POKEMON]', this.pokemon(pokemon)).replace('[ITEM]', this.effect(kwArgs.from));
+			}
 			if (BattleTextParser.effectId(kwArgs.from) === 'rest') {
 				const template = this.template('startFromRest', status);
 				return line1 + template.replace('[POKEMON]', this.pokemon(pokemon));


### PR DESCRIPTION
https://www.smogon.com/forums/threads/wrong-text-for-flame-orb.3762624/

Apparently the templates already exist server side and are just not implemented? Better late than never I guess.