### PR TITLE
Add a volume slider to Replays

### DIFF
--- a/replay.pokemonshowdown.com/index.template.php
+++ b/replay.pokemonshowdown.com/index.template.php
@@ -140,6 +140,7 @@ https://replay.pokemonshowdown.com/gen7randomdoublesbattle-865046831.log
 		display: inline-block;
 		line-height: 22px;
 		font-size: 10pt;
+		vertical-align: top;
 	}
 	.optgroup .button {
 		height: 25px;

--- a/replay.pokemonshowdown.com/src/replays-battle.tsx
+++ b/replay.pokemonshowdown.com/src/replays-battle.tsx
@@ -341,6 +341,14 @@ export class BattlePanel extends preact.Component<{ id: string }> {
 		BattleSound.setBgmVolume(muted === 'musicoff' ? 0 : 65.88125800126558);
 		this.forceUpdate();
 	};
+	changeVolume = (e: Event) => {
+		const volume = Number((e.target as HTMLSelectElement).value);
+		BattleSound.setBgmVolume(volume);
+		BattleSound.setEffectVolume(volume);
+		this.battle?.setMute(true);
+		this.battle?.setMute(false);
+		this.forceUpdate();
+	};
 	changeDarkMode = (e: Event) => {
 		const darkmode = (e.target as HTMLSelectElement).value as 'dark';
 		PSReplays.darkMode = darkmode;
@@ -490,6 +498,10 @@ export class BattlePanel extends preact.Component<{ id: string }> {
 						{(this.battle?.viewpointSwitched ? this.result?.players[1] : this.result?.players[0] || "Player")} {}
 						<i class="fa fa-random" aria-label="Switch viewpoint"></i>
 					</button>
+				</label> {}
+				<label class="optgroup">
+					Volume:<br />
+					<input type="range" onInput={this.changeVolume} />
 				</label>
 			</p>
 			{this.result ? <h1>

--- a/replay.pokemonshowdown.com/testclient.html
+++ b/replay.pokemonshowdown.com/testclient.html
@@ -25,6 +25,7 @@
 		display: inline-block;
 		line-height: 22px;
 		font-size: 10pt;
+		vertical-align: top;
 	}
 	.optgroup .button {
 		height: 25px;


### PR DESCRIPTION
Added a volume slider to the replay client, updated the `.optgroup` class to adjust the look.

![image](https://github.com/user-attachments/assets/d05251c4-ae10-4282-bc96-a20dad0eda14)
