### PR TITLE
Preact: Fix instant replay not showing controls in battles

### DIFF
--- a/play.pokemonshowdown.com/src/panel-battle.tsx
+++ b/play.pokemonshowdown.com/src/panel-battle.tsx
@@ -141,6 +141,7 @@ class BattleRoom extends ChatRoom {
 			if (this.battle.atQueueEnd) {
 				this.battle.reset();
 			}
+			this.request = null;
 			this.battle.play();
 			this.update(null);
 			return true;


### PR DESCRIPTION
After clicking "Instant Replay" it shows the moves menu instead of the replay control menu. 
this fixes it.

Steps to reproduce:
1. start a battle
2. forfeit
3. press rematch
4. go back to that battle
5. click Instant Replay