### PR TITLE
Preact: Support forfeiting battles

### DIFF
--- a/play.pokemonshowdown.com/src/panel-popups.tsx
+++ b/play.pokemonshowdown.com/src/panel-popups.tsx
@@ -623,9 +623,9 @@ class BattleForfeitPanel extends PSRoomPanel {
 				</p>
 				<p>
 					<button onClick={this.handleForfeit} class="button"><strong>Forfeit</strong></button> {}
-					<button type="button" value={battleRoom.id} data-href="replaceplayer" class="button">
+					{ !battleRoom.battle.rated && <button type="button" value={battleRoom.id} data-href="replaceplayer" class="button">
 						Replace player
-					</button> {}
+					</button> } {}
 					<button type="button" name="close" data-cmd="/close" class="button autofocus">
 						Cancel
 					</button>

--- a/play.pokemonshowdown.com/src/panel-popups.tsx
+++ b/play.pokemonshowdown.com/src/panel-popups.tsx
@@ -669,8 +669,7 @@ class ReplacePlayerPanel extends PSRoomPanel {
 					<input name="newplayer" class="textbox autofocus" />
 				</p>
 				<p>
-					<button type="submit" class="button"><strong>Replace</strong></button>
-
+					<button type="submit" class="button"><strong>Replace</strong></button> {}
 					<button type="button" data-cmd="/close" class="button autofocus">
 						Cancel
 					</button>

--- a/play.pokemonshowdown.com/src/panel-popups.tsx
+++ b/play.pokemonshowdown.com/src/panel-popups.tsx
@@ -631,7 +631,6 @@ class BattleForfeitPanel extends PSRoomPanel {
 					</button>
 				</p>
 			</form>
-
 		</div></PSPanelWrapper>;
 	}
 }

--- a/play.pokemonshowdown.com/src/panel-popups.tsx
+++ b/play.pokemonshowdown.com/src/panel-popups.tsx
@@ -622,10 +622,10 @@ class BattleForfeitPanel extends PSRoomPanel {
 						forfeiting</label>
 				</p>
 				<p>
-					<button onClick={this.handleForfeit} class="button"><strong>Forfeit</strong></button>
+					<button onClick={this.handleForfeit} class="button"><strong>Forfeit</strong></button> {}
 					<button type="button" value={battleRoom.id} data-href="replaceplayer" class="button">
 						Replace player
-					</button>
+					</button> {}
 					<button type="button" name="close" data-cmd="/close" class="button autofocus">
 						Cancel
 					</button>

--- a/play.pokemonshowdown.com/src/panel-popups.tsx
+++ b/play.pokemonshowdown.com/src/panel-popups.tsx
@@ -701,4 +701,11 @@ class PopupPanel extends PSRoomPanel {
 	}
 }
 
-PS.addRoomType(UserPanel, VolumePanel, OptionsPanel, LoginPanel, AvatarsPanel, BattleForfeitPanel, ReplacePlayerPanel, PopupPanel);
+PS.addRoomType(UserPanel,
+	VolumePanel,
+	OptionsPanel,
+	LoginPanel,
+	AvatarsPanel,
+	BattleForfeitPanel,
+	ReplacePlayerPanel,
+	PopupPanel);

--- a/play.pokemonshowdown.com/src/panel-popups.tsx
+++ b/play.pokemonshowdown.com/src/panel-popups.tsx
@@ -640,6 +640,7 @@ class ReplacePlayerPanel extends PSRoomPanel {
 	static readonly id = 'replaceplayer';
 	static readonly routes = ['replaceplayer'];
 	static readonly location = 'semimodal-popup';
+	static readonly noURL = true;
 
 	handleReplacePlayer = (ev: Event) => {
 		const elem = this.props.room.parentElem;

--- a/play.pokemonshowdown.com/src/panel-popups.tsx
+++ b/play.pokemonshowdown.com/src/panel-popups.tsx
@@ -663,13 +663,13 @@ class ReplacePlayerPanel extends PSRoomPanel {
 		const room = this.props.room;
 
 		return <PSPanelWrapper room={room} width={480}><div class="pad">
-			<form>
+			<form onSubmit={this.handleReplacePlayer}>
 				<p>Replacement player's name:</p>
 				<p>
 					<input name="newplayer" autofocus></input>
 				</p>
 				<p>
-					<button onClick={this.handleReplacePlayer} class="button"><strong>Replace</strong></button>
+					<button type="submit" class="button"><strong>Replace</strong></button>
 
 					<button type="button" data-cmd="/close" class="button autofocus">
 						Cancel

--- a/play.pokemonshowdown.com/src/panel-popups.tsx
+++ b/play.pokemonshowdown.com/src/panel-popups.tsx
@@ -676,7 +676,6 @@ class ReplacePlayerPanel extends PSRoomPanel {
 					</button>
 				</p>
 			</form>
-
 		</div></PSPanelWrapper>;
 	}
 }

--- a/play.pokemonshowdown.com/src/panel-popups.tsx
+++ b/play.pokemonshowdown.com/src/panel-popups.tsx
@@ -623,9 +623,9 @@ class BattleForfeitPanel extends PSRoomPanel {
 				</p>
 				<p>
 					<button onClick={this.handleForfeit} class="button"><strong>Forfeit</strong></button> {}
-					{ !battleRoom.battle.rated && <button type="button" value={battleRoom.id} data-href="replaceplayer" class="button">
+					{!battleRoom.battle.rated && <button type="button" value={battleRoom.id} data-href="replaceplayer" class="button">
 						Replace player
-					</button> } {}
+					</button>} {}
 					<button type="button" name="close" data-cmd="/close" class="button autofocus">
 						Cancel
 					</button>

--- a/play.pokemonshowdown.com/src/panel-popups.tsx
+++ b/play.pokemonshowdown.com/src/panel-popups.tsx
@@ -626,7 +626,7 @@ class BattleForfeitPanel extends PSRoomPanel {
 					{!battleRoom.battle.rated && <button type="button" value={battleRoom.id} data-href="replaceplayer" class="button">
 						Replace player
 					</button>} {}
-					<button type="button" name="close" data-cmd="/close" class="button autofocus">
+					<button type="button" name="close" data-cmd="/close" class="button">
 						Cancel
 					</button>
 				</p>

--- a/play.pokemonshowdown.com/src/panel-popups.tsx
+++ b/play.pokemonshowdown.com/src/panel-popups.tsx
@@ -590,6 +590,7 @@ class BattleForfeitPanel extends PSRoomPanel {
 	static readonly id = 'forfeit';
 	static readonly routes = ['forfeitbattle'];
 	static readonly location = 'semimodal-popup';
+	static readonly noURL = true;
 
 	handleForfeit = (ev: Event) => {
 		const elem = this.props.room.parentElem;

--- a/play.pokemonshowdown.com/src/panel-popups.tsx
+++ b/play.pokemonshowdown.com/src/panel-popups.tsx
@@ -666,7 +666,7 @@ class ReplacePlayerPanel extends PSRoomPanel {
 			<form onSubmit={this.handleReplacePlayer}>
 				<p>Replacement player's name:</p>
 				<p>
-					<input name="newplayer" autofocus></input>
+					<input name="newplayer" class="textbox autofocus" />
 				</p>
 				<p>
 					<button type="submit" class="button"><strong>Replace</strong></button>

--- a/play.pokemonshowdown.com/src/panel-popups.tsx
+++ b/play.pokemonshowdown.com/src/panel-popups.tsx
@@ -670,7 +670,7 @@ class ReplacePlayerPanel extends PSRoomPanel {
 				</p>
 				<p>
 					<button type="submit" class="button"><strong>Replace</strong></button> {}
-					<button type="button" data-cmd="/close" class="button autofocus">
+					<button type="button" data-cmd="/close" class="button">
 						Cancel
 					</button>
 				</p>

--- a/play.pokemonshowdown.com/src/panels.tsx
+++ b/play.pokemonshowdown.com/src/panels.tsx
@@ -16,6 +16,7 @@ import type { Args } from "./battle-text-parser";
 import { BattleTooltips } from "./battle-tooltips";
 import type { PSStreamModel, PSSubscription } from "./client-core";
 import { PS, type PSRoom, type RoomID } from "./client-main";
+import type { BattleRoom } from "./panel-battle";
 import { PSHeader, PSMiniHeader } from "./panel-topbar";
 
 export class PSRouter {
@@ -515,10 +516,17 @@ export class PSMain extends preact.Component {
 	};
 	handleButtonClick(elem: HTMLButtonElement) {
 		switch (elem.name) {
-		case 'closeRoom':
+		case 'closeRoom': {
 			const roomid = elem.value as RoomID || PS.getRoom(elem)?.id || '' as RoomID;
+			const room = PS.rooms[roomid];
+			const battle = (room as BattleRoom).battle;
+			if (room?.type === "battle" && !battle.ended && battle.mySide.id === PS.user.userid) {
+				PS.join("forfeitbattle" as RoomID, { parentElem: elem });
+				return true;
+			}
 			PS.leave(roomid);
 			return true;
+		}
 		case 'joinRoom':
 			PS.join(elem.value as RoomID, {
 				parentElem: elem,


### PR DESCRIPTION
Everything is almost same as the regular client **except**:

When you open the forfeit popup and refresh the page, youre still at href='/forfeitbattle' so instead of opening and focusing the battle room it tries to add the forfeit popup as a chatroom (see attached screenshot). 
maybe we can fix this by manually adding the popup id to ``PS.routes`` 
OR
maybe whenever the page is reloaded we can skip loading semimodal popup rooms by adding a check in ``subscribeHash`` and ``subscribeHistory``.

or maybe i just missed something, please let me know what you think.
![Screenshot 2025-04-15 185002](https://github.com/user-attachments/assets/7722fd96-1c25-4af6-8107-79032b57a92f)
