### PR TITLE
Properly type `Item.naturalGift`

### DIFF
--- a/play.pokemonshowdown.com/src/battle-dex-data.ts
+++ b/play.pokemonshowdown.com/src/battle-dex-data.ts
@@ -1113,7 +1113,7 @@ export class Item implements Effect {
 	readonly onMemory: TypeName;
 	readonly onDrive: TypeName;
 	readonly fling: any;
-	readonly naturalGift: any;
+	readonly naturalGift: { basePower: number, type: TypeName };
 	readonly isPokeball: boolean;
 	readonly itemUser?: readonly string[];
 


### PR DESCRIPTION
I'm not sure why the type of `type` in the server's code is `string`; it should probably just be `TypeName`.

Edit: it's because `TypeName` doesn't exist in the server.