### PR TITLE
Make LGPE formes not appear as illegal in BH builder

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -437,7 +437,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 				}
 				if (isGen9BH) {
 					if ((species.natDexTier === 'Illegal' || species.forme.includes('Totem')) &&
-						!['Floette-Eternal', 'Greninja-Ash', 'Xerneas-Neutral'].includes(species.name)) {
+						!['Eevee-Starter', 'Floette-Eternal', 'Greninja-Ash', 'Pikachu-Starter', 'Xerneas-Neutral'].includes(species.name)) {
 						return 'Illegal';
 					}
 					if ((species.name === 'Xerneas' || species.battleOnly || species.forme === 'Eternamax') &&


### PR DESCRIPTION
For this https://github.com/smogon/pokemon-showdown/pull/11018
Was not able to figure out how to also do it for the OM Formemons.