### PR TITLE
Preact: Fix auto-show spoilers

### DIFF
--- a/play.pokemonshowdown.com/src/battle-log.ts
+++ b/play.pokemonshowdown.com/src/battle-log.ts
@@ -1310,7 +1310,7 @@ export class BattleLog {
 			str = str.replace(/<a[^>]*>/g, '<u>').replace(/<\/a>/g, '</u>');
 		}
 		if (options.hidespoiler) {
-			str = str.replace(/<span class="spoiler">/g, '<span class="spoiler spoiler-shown">');
+			str = str.replace(/<span class="spoiler">/g, '<span class="spoiler-shown">');
 		}
 		if (options.hidegreentext) {
 			str = str.replace(/<span class="greentext">/g, '<span>');

--- a/play.pokemonshowdown.com/src/panels.tsx
+++ b/play.pokemonshowdown.com/src/panels.tsx
@@ -365,17 +365,6 @@ export class PSView extends preact.Component {
 					elem.className = 'spoiler';
 				}
 
-				if (elem.className === 'datasearch') {
-					const target = $(elem).closest('[class=datasearch]')[0];
-					const button = target.querySelector('button');
-					const results = target.querySelectorAll<HTMLElement>('[class=datasearch-body]');
-					if (!button || !results || results.length < 2) return;
-					button.innerHTML = button.innerHTML === '[-]' ? '[+]' : '[-]';
-					for (const result of results) {
-						result.style.display = result.style.display === 'none' ? 'block' : 'none';
-					}
-				}
-
 				if (` ${elem.className} `.includes(' username ')) {
 					const name = elem.getAttribute('data-name') || elem.innerText;
 					const userid = toID(name);

--- a/play.pokemonshowdown.com/src/panels.tsx
+++ b/play.pokemonshowdown.com/src/panels.tsx
@@ -371,9 +371,8 @@ export class PSView extends preact.Component {
 					const results = target.querySelectorAll<HTMLElement>('[class=datasearch-body]');
 					if (!button || !results || results.length < 2) return;
 					button.innerHTML = button.innerHTML === '[-]' ? '[+]' : '[-]';
-					for (var i = 0; i < results.length; i++) {
-						console.log(results[i]);
-						results[i].style.display = results[i].style.display === 'none' ? 'block' : 'none';
+					for (const result of results) {
+						result.style.display = result.style.display === 'none' ? 'block' : 'none';
 					}
 				}
 

--- a/play.pokemonshowdown.com/src/panels.tsx
+++ b/play.pokemonshowdown.com/src/panels.tsx
@@ -365,6 +365,18 @@ export class PSView extends preact.Component {
 					elem.className = 'spoiler';
 				}
 
+				if (elem.className === 'datasearch') {
+					const target = $(elem).closest('[class=datasearch]')[0];
+					const button = target.querySelector('button');
+					const results = target.querySelectorAll<HTMLElement>('[class=datasearch-body]');
+					if (!button || !results || results.length < 2) return;
+					button.innerHTML = button.innerHTML === '[-]' ? '[+]' : '[-]';
+					for (var i = 0; i < results.length; i++) {
+						console.log(results[i]);
+						results[i].style.display = results[i].style.display === 'none' ? 'block' : 'none';
+					}
+				}
+
 				if (` ${elem.className} `.includes(' username ')) {
 					const name = elem.getAttribute('data-name') || elem.innerText;
 					const userid = toID(name);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "lib": ["dom", "es6", "es2016.array.include", "es2017.object"],
+        "lib": ["dom", "dom.iterable", "es6", "es2016.array.include", "es2017.object"],
         "noEmit": true,
         "target": "esnext",
         "module": "None",


### PR DESCRIPTION
Auto-show spoilers causing spoilers to always show isn't Preact-exclusive as far as I can tell, but collapsible datasearches haven't been implemented on Preact yet. I just copied the existing code from the old client.

Regarding collapsible datasearches, someone reported that it's [hard to copy and paste dexsearch results](https://www.smogon.com/forums/threads/bug-report-unsure.3763470/) as a result of this new feature. This PR doesn't address the bug report and mainly serves to add the functionality to Preact, but I figured it's worth noting for another fix.