### PR TITLE
Make team box height flexible

### DIFF
--- a/play.pokemonshowdown.com/style/client.css
+++ b/play.pokemonshowdown.com/style/client.css
@@ -2251,7 +2251,8 @@ p.or:after {
 	color: transparent;
 }
 .teamlist .team.pc-box {
-	height: 139px;
+	min-height: 139px;
+	height: auto;
 }
 
 .teamedit {


### PR DESCRIPTION
I use boxes as a way to store a lot of Pokémon with different sets, and they always end up overlapping.
Personally, I’d prefer not to have a minimum height and let the box adjust automatically, but I understand it's meant to indicate the maximum number of Pokémon in a team.
That said, it still wouldn't allow someone to manually add more than 24 Pokémon to a box.