### PR TITLE
Replay: Add button to turn headers to go to that turn

### DIFF
--- a/play.pokemonshowdown.com/src/battle-log.ts
+++ b/play.pokemonshowdown.com/src/battle-log.ts
@@ -354,33 +354,33 @@ export class BattleLog {
 
 		case 'turn':
 			const goToTurnButton = document.createElement('button');
-            const h2elem = document.createElement('h2');
-            goToTurnButton.className = 'subtle';
-            h2elem.className = 'battle-history';
-            let turnMessage;
-            let turnNumber: number;
-            if (this.battleParser) {
-                turnMessage = this.battleParser.parseArgs(args, {}).trim();
-                if (!turnMessage.startsWith('==') || !turnMessage.endsWith('==')) {
-                    throw new Error("Turn message must be a heading.");
-                }
-                turnMessage = turnMessage.slice(2, -2).trim();
-                turnNumber = parseInt(turnMessage.split(' ')[1].trim());
-                this.battleParser.curLineSection = 'break';
-            } else {
-                turnMessage = `Turn ${args[1]}`;
-                turnNumber = parseInt(args[1].split(' ')[1].trim());
-            }
-            goToTurnButton?.addEventListener?.('click', e => {
-                e.preventDefault();
-                this.scene?.battle.seekTurn(turnNumber);
-            });
-            goToTurnButton.innerHTML = BattleLog.escapeHTML(turnMessage);
-            h2elem.appendChild(goToTurnButton);
+			const h2elem = document.createElement('h2');
+			goToTurnButton.className = 'subtle';
+			h2elem.className = 'battle-history';
+			let turnMessage;
+			let turnNumber: number;
+			if (this.battleParser) {
+				turnMessage = this.battleParser.parseArgs(args, {}).trim();
+				if (!turnMessage.startsWith('==') || !turnMessage.endsWith('==')) {
+					throw new Error("Turn message must be a heading.");
+				}
+				turnMessage = turnMessage.slice(2, -2).trim();
+				turnNumber = parseInt(turnMessage.split(' ')[1].trim());
+				this.battleParser.curLineSection = 'break';
+			} else {
+				turnMessage = `Turn ${args[1]}`;
+				turnNumber = parseInt(args[1]);
+			}
+			goToTurnButton?.addEventListener?.('click', e => {
+				e.preventDefault();
+				this.scene?.battle.seekTurn(turnNumber);
+			});
+			goToTurnButton.innerHTML = BattleLog.escapeHTML(turnMessage);
+			h2elem.appendChild(goToTurnButton);
 
-            this.addSpacer();
-            this.addNode(h2elem);
-            break;
+			this.addSpacer();
+			this.addNode(h2elem);
+			break;
 
 		default:
 			if (this.addAFDMessage(args, kwArgs)) return;

--- a/play.pokemonshowdown.com/src/battle-log.ts
+++ b/play.pokemonshowdown.com/src/battle-log.ts
@@ -353,23 +353,34 @@ export class BattleLog {
 			break;
 
 		case 'turn':
-			const h2elem = document.createElement('h2');
-			h2elem.className = 'battle-history';
-			let turnMessage;
-			if (this.battleParser) {
-				turnMessage = this.battleParser.parseArgs(args, {}).trim();
-				if (!turnMessage.startsWith('==') || !turnMessage.endsWith('==')) {
-					throw new Error("Turn message must be a heading.");
-				}
-				turnMessage = turnMessage.slice(2, -2).trim();
-				this.battleParser.curLineSection = 'break';
-			} else {
-				turnMessage = `Turn ${args[1]}`;
-			}
-			h2elem.innerHTML = BattleLog.escapeHTML(turnMessage);
-			this.addSpacer();
-			this.addNode(h2elem);
-			break;
+			const goToTurnButton = document.createElement('button');
+            const h2elem = document.createElement('h2');
+            goToTurnButton.className = 'subtle';
+            h2elem.className = 'battle-history';
+            let turnMessage;
+            let turnNumber: number;
+            if (this.battleParser) {
+                turnMessage = this.battleParser.parseArgs(args, {}).trim();
+                if (!turnMessage.startsWith('==') || !turnMessage.endsWith('==')) {
+                    throw new Error("Turn message must be a heading.");
+                }
+                turnMessage = turnMessage.slice(2, -2).trim();
+                turnNumber = parseInt(turnMessage.split(' ')[1].trim());
+                this.battleParser.curLineSection = 'break';
+            } else {
+                turnMessage = `Turn ${args[1]}`;
+                turnNumber = parseInt(args[1].split(' ')[1].trim());
+            }
+            goToTurnButton?.addEventListener?.('click', e => {
+                e.preventDefault();
+                this.scene?.battle.seekTurn(turnNumber);
+            });
+            goToTurnButton.innerHTML = BattleLog.escapeHTML(turnMessage);
+            h2elem.appendChild(goToTurnButton);
+
+            this.addSpacer();
+            this.addNode(h2elem);
+            break;
 
 		default:
 			if (this.addAFDMessage(args, kwArgs)) return;

--- a/play.pokemonshowdown.com/src/battle-log.ts
+++ b/play.pokemonshowdown.com/src/battle-log.ts
@@ -371,12 +371,25 @@ export class BattleLog {
 				turnMessage = `Turn ${args[1]}`;
 				turnNumber = parseInt(args[1]);
 			}
-			goToTurnButton?.addEventListener?.('click', e => {
-				e.preventDefault();
-				this.scene?.battle.seekTurn(turnNumber);
-			});
-			goToTurnButton.innerHTML = BattleLog.escapeHTML(turnMessage);
-			h2elem.appendChild(goToTurnButton);
+			let userId: string | undefined = undefined;
+			if (window.app?.user?.get) {
+				userId = window.app.user.get('userid');
+			}
+			if (!this.scene?.battle.isReplay && userId && [
+				this.scene?.battle.p1.id,
+				this.scene?.battle.p2.id,
+				this.scene?.battle.p3?.id,
+				this.scene?.battle.p4?.id,
+			].includes(userId)) {
+				h2elem.innerHTML = BattleLog.escapeHTML(turnMessage);
+			} else {
+				goToTurnButton.addEventListener('click', e => {
+					e.preventDefault();
+					this.scene?.battle.seekTurn(turnNumber);
+				});
+				goToTurnButton.innerHTML = BattleLog.escapeHTML(turnMessage);
+				h2elem.appendChild(goToTurnButton);
+			}
 
 			this.addSpacer();
 			this.addNode(h2elem);


### PR DESCRIPTION
The h2 element for turn headers in replays can now be clicked to go to that turn in the replay.