### PR TITLE
Teambuilder: Update minAtk logic to account for attack evs

### DIFF
--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -3458,7 +3458,7 @@
 
 			if (this.curTeam.format === 'gen7hiddentype') return;
 
-			var minAtk = true;
+			var minAtk = set.evs && !set.evs['atk'];
 			// only available through an event with 31 Atk IVs
 			if (set.ability === 'Battle Bond' || ['Koraidon', 'Miraidon'].includes(set.species)) minAtk = false;
 			var hpModulo = (this.curTeam.gen >= 6 ? 2 : 4);


### PR DESCRIPTION
This is another PR for the same thing I previously created, I think I somehow deleted it on accident.

Per this approved suggestion: https://www.smogon.com/forums/threads/fix-the-0-ivs-for-attack-stat.3682315/

In some formats/niche situations, it makes sense to have a Pokémon with no physical moves but some attack EVs. In this situation, the current teambuilder logic will set the attack IV to a minimum.

This pull request would fix this and leave attack IVs unchanged for any Pokémon with attack EVs invested.