### PR TITLE
Preact: Add support for hovering over roomtabs with notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ npm-debug.log
 /play.pokemonshowdown.com/js/battle*.js
 /play.pokemonshowdown.com/js/panel*.js
 /play.pokemonshowdown.com/js/replay-embed.js
+/play.pokemonshowdown.com/js/client-endload.js
 /play.pokemonshowdown.com/js/client-main.js
 /play.pokemonshowdown.com/js/client-core.js
 /play.pokemonshowdown.com/js/client-connection.js

--- a/play.pokemonshowdown.com/src/panel-topbar.tsx
+++ b/play.pokemonshowdown.com/src/panel-topbar.tsx
@@ -129,11 +129,20 @@ export class PSHeader extends preact.Component<{ style: object }> {
 		if (!room) return null;
 		const closable = (id === '' || id === 'rooms' ? '' : ' closable');
 		const cur = PS.isVisible(room) ? ' cur' : '';
-		const notifying = room.notifications.length ? ' notifying' : room.isSubtleNotifying ? ' subtle-notifying' : '';
+		let notifying = '';
+		let hoverTitle = '';
+		const notifications = room.notifications;
+		if (notifications.length) {
+			notifying = room.isSubtleNotifying ? ' subtle-notifying' : ' notifying';
+			for (const notif of notifications) {
+				if (!notif.body) continue;
+				hoverTitle += `${notif.title}\n${notif.body}\n`;
+			}
+		}
 		let className = `roomtab button${notifying}${closable}${cur}`;
 
-		let { icon, title } = PSHeader.roomInfo(room);
-		if (room.type === 'rooms' && PS.leftPanelWidth !== null) title = '';
+		let { icon, title: roomTitle } = PSHeader.roomInfo(room);
+		if (room.type === 'rooms' && PS.leftPanelWidth !== null) roomTitle = '';
 		if (room.type === 'battle') className += ' roomtab-battle';
 
 		let closeButton = null;
@@ -145,11 +154,11 @@ export class PSHeader extends preact.Component<{ style: object }> {
 		const ariaLabel = id === 'rooms' ? { "aria-label": "Join chat" } : {};
 		return <li>
 			<a
-				class={className} href={`/${id}`} draggable={true}
+				class={className} href={`/${id}`} title={hoverTitle || undefined}
 				onDragEnter={this.handleDragEnter} onDragStart={this.handleDragStart}
-				{...ariaLabel}
+				{...ariaLabel} draggable
 			>
-				{icon} <span>{title}</span>
+				{icon} <span>{roomTitle}</span>
 			</a>
 			{closeButton}
 		</li>;

--- a/play.pokemonshowdown.com/src/panel-topbar.tsx
+++ b/play.pokemonshowdown.com/src/panel-topbar.tsx
@@ -154,9 +154,9 @@ export class PSHeader extends preact.Component<{ style: object }> {
 		const ariaLabel = id === 'rooms' ? { "aria-label": "Join chat" } : {};
 		return <li>
 			<a
-				class={className} href={`/${id}`} title={hoverTitle || undefined}
+				class={className} href={`/${id}`} draggable={true} title={hoverTitle || undefined}
 				onDragEnter={this.handleDragEnter} onDragStart={this.handleDragStart}
-				{...ariaLabel} draggable
+				{...ariaLabel}
 			>
 				{icon} <span>{roomTitle}</span>
 			</a>


### PR DESCRIPTION
I have the `title` attribute set to `{hoverTitle || undefined}` so the title attribute is properly removed when there's no notifications instead of just being empty.