### PR TITLE
Preact Teambuilder: Fix the team textbox placeholder on Firefox

### DIFF
--- a/play.pokemonshowdown.com/style/teambuilder.css
+++ b/play.pokemonshowdown.com/style/teambuilder.css
@@ -261,7 +261,7 @@
 	resize: none;
 }
 .teamtextbox::placeholder {
-  transform: translateY(20px);
+	line-height: 60px;
 }
 .teaminnertextbox {
 	width: 320px;

--- a/play.pokemonshowdown.com/style/teambuilder.css
+++ b/play.pokemonshowdown.com/style/teambuilder.css
@@ -261,6 +261,7 @@
 	resize: none;
 }
 .teamtextbox::placeholder {
+	/* Firefox doesn't support transform, padding-top, margin-top, _or_ top... */
 	line-height: 60px;
 }
 .teaminnertextbox {


### PR DESCRIPTION
Firefox:
![Screenshot from 2025-05-21 15-55-17](https://github.com/user-attachments/assets/e4a08ed8-4da9-47d0-9423-800b8578921e)

Chromium:
![Screenshot from 2025-05-21 15-57-02](https://github.com/user-attachments/assets/8c3a9bc1-267a-402a-97b2-13d20b46d5ee)
