### PR TITLE
Preact: Teambuilder fix HTML entities in Pokémon name on invalid search

### DIFF
--- a/play.pokemonshowdown.com/src/battle-team-editor.tsx
+++ b/play.pokemonshowdown.com/src/battle-team-editor.tsx
@@ -251,6 +251,9 @@ class TeamEditorState extends PSModel {
 				return this.dex.moves.get(moveid).name + '|' + slot;
 			}
 			return this.dex.moves.get(result[1]).name;
+		case 'html':
+		case 'header':
+			return '';
 		default:
 			return result[1];
 		}


### PR DESCRIPTION
When searching for a non-existing Pokémon in the Preact teambuilder and pressing Enter, the Pokémon name field would display HTML entities like `&lt;em&gt;No exact match found. The closest matche...` instead of remaining empty or showing a proper error.

This happened because the search results include an 'html' type row with the error message when no exact match is found. The `getResultValue` method was returning this raw HTML string, which was then set as the Pokémon name.

**Changes:**
- Modified `getResultValue` in `battle-team-editor.tsx` to return an empty string for 'html' and 'header' type search results
- This prevents HTML content from being incorrectly used as a Pokémon name value

**To reproduce the bug (before this fix):**
1. Open the teambuilder
2. Search for a non-existing Pokémon (e.g., "houifdshquifodsqf")
3. Press Enter
4. The Pokémon name becomes `&lt;em&gt;No exact match found. The closest matche...`

**After this fix:**
The field remains empty when selecting an HTML/header result, allowing the user to continue searching or select a valid Pokémon from the suggestions.