### PR TITLE
Remove Flying Gem from Popular Items

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -850,8 +850,6 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 				} else if (item.name.endsWith(" Gem") && item.name !== "Normal Gem") {
 					if (genNum >= 6) {
 						unreleasedItems.push(id);
-					} else if (item.name === "Flying Gem") {
-						greatItems.push(id);
 					} else {
 						goodItems.push(id);
 					}


### PR DESCRIPTION
Approved Forum Suggestion: https://www.smogon.com/forums/threads/gen-5-ou-gems.3706516/

I can't replicate this locally. Whatever script is used for build indexes code to be compiled into the teambuilder table isn't there in the client repo clone. and while making direct changes to the teambuilder table file does work locally, that's not how it's supposed to be edited. This is a pretty trivial change so I figured it's worth the PR anyways even if my clone can't replicate this.

The logic here is removing the if else statement for flying gem, will push it out of great items (popular items), and the line under that pushes all gem's to good items, will then include Flying Gem since it's specific if else statement will be removed.