### PR TITLE
Preact: Add auto-rejoin for battle rooms on reconnect

### DIFF
--- a/play.pokemonshowdown.com/src/client-connection.ts
+++ b/play.pokemonshowdown.com/src/client-connection.ts
@@ -19,6 +19,7 @@ export class PSConnection {
 	private shouldReconnect = true;
 	reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 	private worker: Worker | null = null;
+	battleRoomsToRejoin: string[] = [];
 
 	constructor() {
 		const loading = PSStorage.init();
@@ -157,9 +158,15 @@ export class PSConnection {
 		this.connected = false;
 		PS.isOffline = true;
 		this.socket = null;
+		this.battleRoomsToRejoin = [];
 		for (const roomid in PS.rooms) {
 			const room = PS.rooms[roomid]!;
-			if (room.connected === true) room.connected = 'autoreconnect';
+			if (room.connected === true) {
+				room.connected = 'autoreconnect';
+				if (room.type === 'battle' && roomid.startsWith('battle-')) {
+					this.battleRoomsToRejoin.push(roomid);
+				}
+			}
 		}
 		this.retryConnection();
 		PS.update();

--- a/play.pokemonshowdown.com/src/client-main.ts
+++ b/play.pokemonshowdown.com/src/client-main.ts
@@ -304,6 +304,14 @@ class PSPrefs extends PSStreamModel<string | null> {
 			// send even if `rooms` is empty, for server autojoins
 			PS.send(cmd);
 		}
+		
+		if (PS.connection?.battleRoomsToRejoin?.length) {
+			const battleRooms = PS.connection.battleRoomsToRejoin;
+			PS.connection.battleRoomsToRejoin = [];
+			for (const roomid of battleRooms) {
+				PS.send(`/j ${roomid}`);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This PR implements automatic rejoining of battle rooms after disconnection, as suggested by jetou.

## What it does
When spectating multiple battles and getting disconnected, users previously had to manually rejoin each battle room. This feature automatically tracks open battle rooms during disconnection and rejoins them upon reconnection.

## Why this is useful
As noted by jetou:
> when you're spectating a few battles it's very annoying to dc and have to rejoin all

This feature improves the spectator experience by removing the manual work of rejoining multiple battle rooms after network issues.