### PR TITLE
Preact: Support autojoining minimized rooms

### DIFF
--- a/play.pokemonshowdown.com/src/client-main.ts
+++ b/play.pokemonshowdown.com/src/client-main.ts
@@ -2656,7 +2656,7 @@ export const PS = new class extends PSModel {
 		if (!PS.server.registered) return;
 		let autojoins: string[] = [];
 		let autojoinCount = 0;
-		let rooms = this.rightRoomList;
+		let rooms = [...this.rightRoomList, ...this.leftRoomList, ...this.miniRoomList];
 		for (let roomid of rooms) {
 			let room = PS.rooms[roomid] as ChatRoom;
 			if (!room) return;

--- a/play.pokemonshowdown.com/src/client-main.ts
+++ b/play.pokemonshowdown.com/src/client-main.ts
@@ -1694,7 +1694,6 @@ export class PSRoom extends PSStreamModel<Args | null> implements RoomOptions {
 		this.sendDirect(msg);
 	}
 	sendDirect(msg: string) {
-		if (this.connected === 'expired') return this.add(`This room has expired (you can't chat in it anymore)`);
 		PS.send(msg, this.id);
 	}
 	destroy() {

--- a/play.pokemonshowdown.com/src/client-main.ts
+++ b/play.pokemonshowdown.com/src/client-main.ts
@@ -1694,6 +1694,7 @@ export class PSRoom extends PSStreamModel<Args | null> implements RoomOptions {
 		this.sendDirect(msg);
 	}
 	sendDirect(msg: string) {
+		if (this.connected === 'expired') return this.add(`This room has expired (you can't chat in it anymore)`);
 		PS.send(msg, this.id);
 	}
 	destroy() {


### PR DESCRIPTION
Fixes:
-  Any rooms opened on the left panel are removed from the autojoin list
-  Rooms minimised into a DM box are also not added to autojoin 