### PR TITLE
Fix bug with `substitute` sprite data in gen 5 battles

### DIFF
--- a/play.pokemonshowdown.com/src/battle-dex.ts
+++ b/play.pokemonshowdown.com/src/battle-dex.ts
@@ -717,6 +717,7 @@ export const Dex = new class implements ModdedDex {
 				animationArray.push([BattlePokemonSpritesBW[speciesid], 'gen5']);
 			}
 			for (const [animationData, animDir] of animationArray) {
+				if (!animationData) continue;
 				if (animationData[facing + 'f'] && options.gender === 'F') facing += 'f';
 				if (!animationData[facing]) continue;
 				if (facing.endsWith('f')) name += '-f';


### PR DESCRIPTION
I honestly did not test this but this should fix something.

Bug on live client
<img width="501" height="194" alt="Screenshot 2025-08-07 at 6 16 42 PM" src="https://github.com/user-attachments/assets/fc311823-b69e-4544-9220-9f08abecb093" />

Debugging
<img width="573" height="92" alt="Screenshot 2025-08-07 at 6 16 20 PM" src="https://github.com/user-attachments/assets/e88568bb-7f05-457c-9a28-acf36390e561" />
