### PR TITLE
Preact: Add automatic open team sheet requests

### DIFF
--- a/play.pokemonshowdown.com/src/client-main.ts
+++ b/play.pokemonshowdown.com/src/client-main.ts
@@ -118,6 +118,7 @@ class PSPrefs extends PSStreamModel<string | null> {
 	ignorespects: boolean | null = null;
 	ignoreopp: boolean | null = null;
 	autotimer: boolean | null = null;
+	autoopenteamsheets: boolean | null = null;
 	rightpanelbattles: boolean | null = null;
 	disallowspectators: boolean | null = null;
 	starredformats: { [formatid: string]: true | undefined } | null = null;

--- a/play.pokemonshowdown.com/src/panel-battle.tsx
+++ b/play.pokemonshowdown.com/src/panel-battle.tsx
@@ -414,7 +414,8 @@ class BattlePanel extends PSRoomPanel<BattleRoom> {
 			this.send('/timer on');
 			room.autoTimerActivated = true;
 		}
-		if (PS.prefs.autoopenteamsheets) {
+    const formatName = room.battle.id.split("-")[1]?.toLowerCase();
+		if (PS.prefs.autoopenteamsheets && formatName?.includes("vgc")) {
 			this.send('/acceptopenteamsheets');
 		}
 

--- a/play.pokemonshowdown.com/src/panel-battle.tsx
+++ b/play.pokemonshowdown.com/src/panel-battle.tsx
@@ -201,6 +201,7 @@ class TimerButton extends preact.Component<{ room: BattleRoom }> {
 		const room = this.props.room;
 		if (!this.timerInterval && room.battle.kickingInactive) {
 			this.timerInterval = setInterval(() => {
+				if (room.choices?.isDone()) return;
 				if (typeof room.battle.kickingInactive === 'number' && room.battle.kickingInactive > 1) {
 					room.battle.kickingInactive--;
 					if (room.battle.graceTimeLeft) room.battle.graceTimeLeft--;
@@ -412,6 +413,9 @@ class BattlePanel extends PSRoomPanel<BattleRoom> {
 		if (PS.prefs.autotimer && !room.battle.kickingInactive && !room.autoTimerActivated) {
 			this.send('/timer on');
 			room.autoTimerActivated = true;
+		}
+		if (PS.prefs.autoopenteamsheets) {
+			this.send('/acceptopenteamsheets');
 		}
 
 		BattleChoiceBuilder.fixRequest(request, room.battle);

--- a/play.pokemonshowdown.com/src/panel-battle.tsx
+++ b/play.pokemonshowdown.com/src/panel-battle.tsx
@@ -201,7 +201,6 @@ class TimerButton extends preact.Component<{ room: BattleRoom }> {
 		const room = this.props.room;
 		if (!this.timerInterval && room.battle.kickingInactive) {
 			this.timerInterval = setInterval(() => {
-				if (room.choices?.isDone()) return;
 				if (typeof room.battle.kickingInactive === 'number' && room.battle.kickingInactive > 1) {
 					room.battle.kickingInactive--;
 					if (room.battle.graceTimeLeft) room.battle.graceTimeLeft--;

--- a/play.pokemonshowdown.com/src/panel-battle.tsx
+++ b/play.pokemonshowdown.com/src/panel-battle.tsx
@@ -414,7 +414,7 @@ class BattlePanel extends PSRoomPanel<BattleRoom> {
 			this.send('/timer on');
 			room.autoTimerActivated = true;
 		}
-    const formatName = room.battle.id.split("-")[1]?.toLowerCase();
+		const formatName = room.battle.id.split("-")[1]?.toLowerCase();
 		if (PS.prefs.autoopenteamsheets && formatName?.includes("vgc")) {
 			this.send('/acceptopenteamsheets');
 		}

--- a/play.pokemonshowdown.com/src/panel-popups.tsx
+++ b/play.pokemonshowdown.com/src/panel-popups.tsx
@@ -1591,6 +1591,13 @@ class BattleOptionsPanel extends PSRoomPanel {
 			PS.mainmenu.disallowSpectators = value;
 			break;
 		}
+		case 'auto-ots': {
+			PS.prefs.set('autoopenteamsheets', value);
+			if (value) {
+				room?.send('/acceptopenteamsheets');
+			}
+			break;
+		}
 		}
 	};
 	getBattleRoom() {
@@ -1678,6 +1685,14 @@ class BattleOptionsPanel extends PSRoomPanel {
 						name="autotimer" checked={PS.prefs.autotimer || false}
 						type="checkbox" onChange={this.handleAllSettings}
 					/> Automatically start timer
+				</label>
+			</p>
+			<p>
+				<label class="checkbox">
+					<input
+						name="auto-ots" checked={PS.prefs.autoopenteamsheets || false}
+						type="checkbox" onChange={this.handleAllSettings}
+					/> Auto-request open team sheets(VGC only)
 				</label>
 			</p>
 			{!PS.prefs.onepanel && document.body.offsetWidth >= 800 && <p>


### PR DESCRIPTION
Fixes a visual glitch where the timer in battles would visually continue to count down even after the user has made their choice.
Also adds the option to automatically request for open team sheets in vgc battles(does not do anything for singles).