### PR TITLE
Mirror sprites automatically

### DIFF
--- a/play.pokemonshowdown.com/src/battle-animations.ts
+++ b/play.pokemonshowdown.com/src/battle-animations.ts
@@ -865,7 +865,7 @@ export class BattleScene implements BattleSceneStub {
 				textBuf += pokemon.speciesForme;
 				let url = spriteData.url;
 				// if (this.paused) url.replace('/xyani', '/xy').replace('.gif', '.png');
-				buf += `<img src="${url}" width="${spriteData.w}" height="${spriteData.h}" style="position:absolute;top:${Math.floor(y - spriteData.h / 2)}px;left:${Math.floor(x - spriteData.w / 2)}px" />`;
+				buf += `<img src="${url}" width="${spriteData.w}" height="${spriteData.h}" style="position:absolute;top:${Math.floor(y - spriteData.h / 2)}px;left:${Math.floor(x - spriteData.w / 2)}px${spriteData.mirror ? ';transform: scaleX(-1)' : ''}" />`;
 				buf2 += `<div style="position:absolute;top:${y + 45}px;left:${x - 40}px;width:80px;font-size:10px;text-align:center;color:#FFF;">`;
 				const gender = pokemon.gender;
 				if (gender === 'M' || gender === 'F') {
@@ -1736,7 +1736,7 @@ export class Sprite {
 		if (spriteData) {
 			sp = spriteData;
 			let rawHTML = sp.rawHTML ||
-				`<img src="${sp.url!}" style="display:none;position:absolute"${sp.pixelated ? ' class="pixelated"' : ''} />`;
+				`<img src="${sp.url!}" style="display:none;position:absolute${sp.mirror ? ';transform: scaleX(-1)' : ''}"${sp.pixelated ? ' class="pixelated"' : ''} />`;
 			this.$el = $(rawHTML);
 		} else {
 			sp = {
@@ -2132,7 +2132,7 @@ export class PokemonSprite extends Sprite {
 		if (this.$el) {
 			this.$el.stop(true, false);
 			this.$el.remove();
-			const $newEl = $(`<img src="${this.sp.url!}" style="display:none;position:absolute"${this.sp.pixelated ? ' class="pixelated"' : ''} />`);
+			const $newEl = $(`<img src="${this.sp.url!}" style="display:none;position:absolute${this.sp.mirror ? ';transform: scaleX(-1)' : ''}"${this.sp.pixelated ? ' class="pixelated"' : ''} />`);
 			this.$el = $newEl;
 		}
 
@@ -2569,7 +2569,7 @@ export class PokemonSprite extends Sprite {
 			}
 		}
 		// Constructing here gives us 300ms extra time to preload the new sprite
-		let $newEl = $('<img src="' + sp.url + '" style="display:block;opacity:0;position:absolute"' + (sp.pixelated ? ' class="pixelated"' : '') + ' />');
+		let $newEl = $('<img src="' + sp.url + `" style="display:block;opacity:0;position:absolute${this.sp.mirror ? ';transform: scaleX(-1)' : ''}"` + (sp.pixelated ? ' class="pixelated"' : '') + ' />');
 		$newEl.css(this.scene.pos({
 			x: this.x,
 			y: this.y,

--- a/play.pokemonshowdown.com/src/battle-dex.ts
+++ b/play.pokemonshowdown.com/src/battle-dex.ts
@@ -710,8 +710,7 @@ export const Dex = new class implements ModdedDex {
 		}
 
 		const possibleSprites: AnyObject[] = [];
-		for (const possibleFacing of ['back', 'front']) {
-			if (facing === 'front' && possibleFacing === 'back') continue;
+		for (const possibleFacing of facing === 'front' ? ['front'] : ['back', 'front']) {
 			const mirror = facing === 'back' && possibleFacing === 'front';
 			if (!Dex.prefs('noanim') && !Dex.prefs('nogif') && spriteData.gen >= 5) {
 				if (baseDir === '' && window.BattlePokemonSprites) {

--- a/play.pokemonshowdown.com/src/battle-dex.ts
+++ b/play.pokemonshowdown.com/src/battle-dex.ts
@@ -710,15 +710,16 @@ export const Dex = new class implements ModdedDex {
 		}
 
 		const possibleSprites: AnyObject[] = [];
-		for (const possibleFacing of ['back']) {
+		for (const possibleFacing of ['back', 'front']) {
 			if (facing === 'front' && possibleFacing === 'back') continue;
 			const mirror = facing === 'back' && possibleFacing === 'front';
 			if (!Dex.prefs('noanim') && !Dex.prefs('nogif') && spriteData.gen >= 5) {
-				if (baseDir === '' && window.BattlePokemonSprites && !mirror) {
+				if (baseDir === '' && window.BattlePokemonSprites) {
 					possibleSprites.push({
 						spriteData: BattlePokemonSprites[speciesid],
 						dir: 'ani',
 						facing: possibleFacing,
+						mirror,
 					});
 				}
 				if (window.BattlePokemonSpritesBW) {


### PR DESCRIPTION
Read this first: https://github.com/smogon/pokemon-showdown-client/pull/2495#issuecomment-3168687478

---

Everything seems to be working, but `battle-animations.ts` needs a second check, as I’m not sure if all the locations are correct.
Of course, this would require @Marty-D to delete the mirrored static Gen 5 back sprites.

Here, you can see the result, modded to force front sprites.

https://github.com/user-attachments/assets/46cc80b1-db08-4bd0-ae78-0d20c102ee2e