### PR TITLE
Preact: Allow muting chatrooms 

### DIFF
--- a/play.pokemonshowdown.com/src/battle-dex.ts
+++ b/play.pokemonshowdown.com/src/battle-dex.ts
@@ -717,6 +717,7 @@ export const Dex = new class implements ModdedDex {
 				animationArray.push([BattlePokemonSpritesBW[speciesid], 'gen5']);
 			}
 			for (const [animationData, animDir] of animationArray) {
+				if (!animationData) continue;
 				if (animationData[facing + 'f'] && options.gender === 'F') facing += 'f';
 				if (!animationData[facing]) continue;
 				if (facing.endsWith('f')) name += '-f';

--- a/play.pokemonshowdown.com/src/client-main.ts
+++ b/play.pokemonshowdown.com/src/client-main.ts
@@ -1056,6 +1056,8 @@ export class PSRoom extends PSStreamModel<Args | null> implements RoomOptions {
 	}
 	subtleNotify() {
 		if (PS.isVisible(this)) return;
+		const roomsettings = PS.prefs.roomsettings?.[PS.server.id]?.[this.id];
+		if (roomsettings?.newmessages === false) return;
 		this.isSubtleNotifying = true;
 		PS.update();
 	}
@@ -1603,16 +1605,20 @@ export class PSRoom extends PSStreamModel<Args | null> implements RoomOptions {
 				return;
 			}
 			const settings = roomsettings[serverId][this.id] || {};
-			settings[name] = value === 'on';
-			roomsettings[serverId][this.id] = settings;
-			PS.prefs.set('roomsettings', roomsettings);
-
 			if (name === 'muteroom') {
+				settings.highlight = value !== 'on';
+				settings.newmessages = value !== 'on';
+				settings.tournamentping = value !== 'on';
+				settings[name] = value === 'on';
+				roomsettings[serverId][this.id] = settings;
 				this.receiveLine(['', `Mute ${this.title} room: ${value === 'on' ? 'ON' : 'OFF'}`]);
 			} else {
+				settings[name] = value === 'on';
+				roomsettings[serverId][this.id] = settings;
 				this.receiveLine(['',
 					`Indicate ${nameRaw} in ${this.title} room: ${value === 'on' ? 'ON' : 'OFF'}`]);
 			}
+			PS.prefs.set('roomsettings', roomsettings);
 		},
 		'h,help'(target) {
 			switch (toID(target)) {

--- a/play.pokemonshowdown.com/src/panel-chat.tsx
+++ b/play.pokemonshowdown.com/src/panel-chat.tsx
@@ -290,6 +290,8 @@ export class ChatRoom extends PSRoom {
 		}
 		if (ChatRoom.getHighlight(message, this.id)) {
 			const mayNotify = time > lastMessageDate;
+			const roomsettings = PS.prefs.roomsettings?.[PS.server.id]?.[this.id];
+			if (roomsettings?.highlight === false) return true;
 			if (mayNotify) this.notify({
 				title: `Mentioned by ${name} in ${this.id}`,
 				body: `"${message}"`,

--- a/play.pokemonshowdown.com/src/panel-popups.tsx
+++ b/play.pokemonshowdown.com/src/panel-popups.tsx
@@ -1698,6 +1698,78 @@ class BattleOptionsPanel extends PSRoomPanel {
 		</PSPanelWrapper>;
 	}
 }
+class RoomSettingsPanel extends PSRoomPanel {
+	static readonly id = 'roomsettings';
+	static readonly routes = ['roomsettings'];
+	static readonly location = 'semimodal-popup';
+	static readonly noURL = true;
+	declare state: { isRoomMuted?: boolean };
+
+	handleAllSettings = (ev: Event) => {
+		const setting = (ev.currentTarget as HTMLInputElement).name;
+		let value = (ev.currentTarget as HTMLInputElement).checked ? 'on' : 'off';
+		const parentElem = this.props.room.parentElem as HTMLAnchorElement;
+		const roomid = PS.router.extractRoomID(parentElem.href)!;
+		const room = PS.rooms[roomid];
+		if (setting === 'Mute Room') {
+			this.setState({ isRoomMuted: value === 'on' });
+		}
+		room?.send(`/settings ${setting}, ${value}`);
+	};
+
+	override render() {
+		const room = this.props.room;
+		const parentElem = this.props.room.parentElem as HTMLAnchorElement;
+		const parentRoomid = PS.router.extractRoomID(parentElem.href)!;
+		const parentRoom = PS.rooms[parentRoomid];
+		const settingsExists = PS.prefs.roomsettings?.[PS.server.id]?.[parentRoomid];
+		const settings = settingsExists || {
+			highlight: !PS.prefs.noselfhighlight,
+			tournamentping: PS.prefs.tournaments !== 'hide',
+		};
+
+		return <PSPanelWrapper room={room} width={380}><div class="pad">
+			<p><strong>{parentRoom?.title} room settings</strong></p>
+			<p>
+				<label class="checkbox">
+					<input
+						name="New Messages" checked={settings.newmessages !== false}
+						type="checkbox" onChange={this.handleAllSettings} disabled={this.state.isRoomMuted || settings.muteroom}
+					/> Indicate new messages
+				</label>
+			</p>
+			<p>
+				<label class="checkbox">
+					<input
+						name="Highlight" checked={settings.highlight === true}
+						type="checkbox" onChange={this.handleAllSettings} disabled={this.state.isRoomMuted || settings.muteroom}
+					/> Indicate name pings
+				</label>
+			</p>
+			<p>
+				<label class="checkbox">
+					<input
+						name="Tournament Ping" checked={settings.tournamentping === true}
+						type="checkbox" onChange={this.handleAllSettings} disabled={this.state.isRoomMuted || settings.muteroom}
+					/> Ping on tournaments
+				</label>
+			</p>
+			<p>
+				<label class="checkbox">
+					<input
+						name="Mute Room" checked={settings.muteroom === true}
+						type="checkbox" onChange={this.handleAllSettings}
+					/> Mute room
+				</label>
+			</p>
+			<p class="buttonbar">
+				<button data-cmd="/close" class="button">Done</button> {}
+				<button data-cmd="/closeand /inparent /settings reset" class="button">Reset to default</button> {}
+			</p>
+		</div>
+		</PSPanelWrapper>;
+	}
+}
 
 class PopupRoom extends PSRoom {
 	returnValue: unknown = this.args?.cancelValue;
@@ -1930,5 +2002,6 @@ PS.addRoomType(
 	RoomTabListPanel,
 	BattleOptionsPanel,
 	BattleTimerPanel,
-	RulesPanel
+	RulesPanel,
+	RoomSettingsPanel
 );

--- a/play.pokemonshowdown.com/src/panel-topbar.tsx
+++ b/play.pokemonshowdown.com/src/panel-topbar.tsx
@@ -14,6 +14,7 @@ import { Config, PS, type PSRoom, type RoomID } from "./client-main";
 import { NARROW_MODE_HEADER_WIDTH, PSView, VERTICAL_HEADER_WIDTH } from "./panels";
 import type { Battle } from "./battle";
 import { BattleLog } from "./battle-log"; // optional
+import { toRoomid } from "./battle-dex";
 
 window.addEventListener('dragover', e => {
 	// this prevents the bounce-back animation
@@ -65,7 +66,7 @@ export class PSHeader extends preact.Component {
 	static handleRightClick = (e: Event) => {
 		e.preventDefault();
 		const roomid = PS.router.extractRoomID((e.currentTarget as HTMLAnchorElement).href);
-		PS.join('roomsettings' as RoomID, {
+		PS.join(`roomsettings-${roomid!}` as RoomID, {
 			parentElem: e.currentTarget as HTMLAnchorElement,
 			parentRoomid: roomid,
 		});
@@ -157,8 +158,7 @@ export class PSHeader extends preact.Component {
 				onDragEnter={this.handleDragEnter} onDragStart={this.handleDragStart}
 				{...aria}
 			>
-				{icon}
-				{roomTitle}
+				{icon} {roomTitle}
 			</a>
 			{closeButton}
 		</li>;
@@ -325,6 +325,7 @@ export class PSMiniHeader extends preact.Component {
 			if (miniNotifications?.length) notificationsCount++;
 		}
 		const { icon, title } = PSHeader.roomInfo(PS.panel);
+		const roomid = toRoomid(title);
 		const userColor = window.BattleLog && `color:${BattleLog.usernameColor(PS.user.userid)}`;
 		const showMenuButton = PSView.narrowMode;
 		const notifying = (
@@ -348,6 +349,10 @@ export class PSMiniHeader extends preact.Component {
 			<button data-href="options" class="mini-header-right" aria-label="Options">
 				{PS.user.named ? <strong style={userColor}>{PS.user.name}</strong> : <i class="fa fa-cog" aria-hidden></i>}
 			</button>
+			{PS.rooms[roomid]?.type === 'chat' &&
+				<button class="mini-header-right" data-href={`roomsettings-${roomid}`} aria-label="Room Settings">
+					<i class="fa fa-gear" aria-hidden></i>
+				</button>}
 		</div>;
 	}
 }

--- a/play.pokemonshowdown.com/src/panel-topbar.tsx
+++ b/play.pokemonshowdown.com/src/panel-topbar.tsx
@@ -62,6 +62,14 @@ export class PSHeader extends preact.Component {
 
 		PS.dragging = { type: 'room', roomid };
 	};
+	static handleRightClick = (e: Event) => {
+		e.preventDefault();
+		const roomid = PS.router.extractRoomID((e.currentTarget as HTMLAnchorElement).href);
+		PS.join('roomsettings' as RoomID, {
+			parentElem: e.currentTarget as HTMLAnchorElement,
+			parentRoomid: roomid,
+		});
+	};
 	static roomInfo(room: PSRoom) {
 		const RoomType = PS.roomTypes[room.type];
 		let icon = RoomType?.icon || <i class="fa fa-file-text-o" aria-hidden></i>;
@@ -143,7 +151,7 @@ export class PSHeader extends preact.Component {
 		if (id === 'rooms') aria['aria-label'] = "Join chat";
 		return <li class={id === '' ? 'home-li' : ''} key={id}>
 			<a
-				class={className} href={`/${id}`} draggable={true} title={hoverTitle || undefined}
+				class={className} href={`/${id}`} onContextMenu={this.handleRightClick} draggable={true} title={hoverTitle || undefined}
 				onDragEnter={this.handleDragEnter} onDragStart={this.handleDragStart}
 				{...aria}
 			>

--- a/play.pokemonshowdown.com/src/panel-topbar.tsx
+++ b/play.pokemonshowdown.com/src/panel-topbar.tsx
@@ -120,6 +120,7 @@ export class PSHeader extends preact.Component {
 		let notifying = room.isSubtleNotifying ? ' subtle-notifying' : '';
 		let hoverTitle = '';
 		let notifications = room.notifications;
+		const roomsettings = PS.prefs.roomsettings?.[PS.server.id]?.[id] || {};
 		if (id === '') {
 			for (const roomid of PS.miniRoomList) {
 				const miniNotifications = PS.rooms[roomid]?.notifications;
@@ -136,6 +137,7 @@ export class PSHeader extends preact.Component {
 		let className = `roomtab button${notifying}${closable}${cur}`;
 
 		let { icon, title: roomTitle } = PSHeader.roomInfo(room);
+		if (roomsettings.muteroom) icon = <i class="fa fa-bell-slash-o" aria-hidden></i>;
 		if (room.type === 'rooms' && PS.leftPanelWidth !== null) roomTitle = '';
 		if (room.type === 'battle') className += ' roomtab-battle';
 
@@ -155,7 +157,8 @@ export class PSHeader extends preact.Component {
 				onDragEnter={this.handleDragEnter} onDragStart={this.handleDragStart}
 				{...aria}
 			>
-				{icon} {roomTitle}
+				{icon}
+				{roomTitle}
 			</a>
 			{closeButton}
 		</li>;


### PR DESCRIPTION
Implements suggestions: Do not HL in certain rooms, [Allow muting chatrooms](https://www.smogon.com/forums/threads/muting-ps-chatrooms.3675505/)

- added client side command `/settings`, ` /roomsettings`  is already a server side command used to change certain permissions in a room by staff
- `/settings [name], [on OR off]` to toggle a room setting
- available settings `newmessages, highlight, tournamentping, muteroom`.
- use `/settings reset` to reset the room settings and match with global settings (from options menu)
- right click on room header tab to open the menu

Room settings menu
<img width="393" height="355" alt="image" src="https://github.com/user-attachments/assets/f01b31b5-95b7-4649-83dd-40c987ba2dbb" />

Room muted icon
<img width="360" height="246" alt="image" src="https://github.com/user-attachments/assets/47f6001c-2bcd-4caa-9f5b-d7265c443f56" />

Surely we can add more to this menu.
 
(Edit: help me pick better names for the settings)