### PR TITLE
Fix Pixilate changing the type on the tooltip for z-moves

### DIFF
--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -610,6 +610,7 @@ export class BattleTooltips {
 				});
 				categoryDiff = false;
 			}
+			[moveType, category] = this.getMoveType(move, value, gmaxMove);
 		} else if (isZOrMax === 'maxmove') {
 			if (move.category === 'Status') {
 				move = this.battle.dex.moves.get('Max Guard');


### PR DESCRIPTION
Updated the movetype and category when zmove is clicked in order to check for zmove with abilities like pixelate, galvanize, etc.

This addresses the first part of https://github.com/smogon/pokemon-showdown-client/issues/2467