### PR TITLE
Add nickname toggle button to replay controls

### DIFF
--- a/replay.pokemonshowdown.com/src/replays-battle.tsx
+++ b/replay.pokemonshowdown.com/src/replays-battle.tsx
@@ -334,6 +334,12 @@ export class BattlePanel extends preact.Component<{ id: string }> {
 		this.battle?.setMute(!BattleSound.muted);
 		this.forceUpdate();
 	}
+	toggleIgnoreNicks = () => {
+		if (!this.battle) return;
+		this.battle.ignoreNicks = !this.battle.ignoreNicks;
+		this.battle.resetToCurrentTurn();
+		this.forceUpdate();
+	};
 	changeSound = (e: Event) => {
 		const muted = (e.target as HTMLSelectElement).value;
 		this.battle?.setMute(muted === 'off');
@@ -497,6 +503,12 @@ export class BattlePanel extends preact.Component<{ id: string }> {
 					<button onClick={this.switchViewpoint} name="viewpoint" class={this.battle ? 'button' : 'button disabled'}>
 						{(this.battle?.viewpointSwitched ? this.result?.players[1] : this.result?.players[0] || "Player")} {}
 						<i class="fa fa-random" aria-hidden aria-label="Switch viewpoint"></i>
+					</button>
+				</label> {}
+				<label class="optgroup">
+					Nicknames:<br />
+					<button onClick={this.toggleIgnoreNicks} name="ignorenicks" class={this.battle ? 'button' : 'button disabled'}>
+						{this.battle?.ignoreNicks ? 'Hidden' : 'Shown'}
 					</button>
 				</label> {}
 				<label class="optgroup">


### PR DESCRIPTION
Link to issue is [here](https://www.smogon.com/forums/threads/add-option-to-ignore-pokemon-nicknames-in-replays.3773899/)

Added a toggle when watching replays to show/hide nicknames. Nickname show/hide was already a feature in battling but not replays, used same logic. Nicknames are shown by default. 

<img width="1107" height="498" alt="Screenshot 2025-12-03 at 6 05 47 PM" src="https://github.com/user-attachments/assets/3be91075-fa46-44f4-af4d-247b9d61f0e0" />
<img width="1111" height="493" alt="Screenshot 2025-12-03 at 6 06 00 PM" src="https://github.com/user-attachments/assets/8b0b7741-06a2-46c5-9be7-4107bde2bc5e" />
