### PR TITLE
Teambuilder: Show everything legal for custom game format

### DIFF
--- a/play.pokemonshowdown.com/src/battle-dex-search.ts
+++ b/play.pokemonshowdown.com/src/battle-dex-search.ts
@@ -742,9 +742,8 @@ abstract class BattleTypedSearch<T extends SearchType> {
 			}
 			this.baseIllegalResults = [];
 			this.illegalReasons = {};
-
 			for (const id in this.getTable()) {
-				if (!(id in legalityFilter)) {
+				if (!(id in legalityFilter) && this.format !== 'customgame') {
 					this.baseIllegalResults.push([this.searchType, id as ID]);
 					this.illegalReasons[id] = 'Illegal';
 				}

--- a/play.pokemonshowdown.com/src/battle-dex-search.ts
+++ b/play.pokemonshowdown.com/src/battle-dex-search.ts
@@ -742,6 +742,7 @@ abstract class BattleTypedSearch<T extends SearchType> {
 			}
 			this.baseIllegalResults = [];
 			this.illegalReasons = {};
+
 			for (const id in this.getTable()) {
 				if (!(id in legalityFilter) && this.format !== 'customgame') {
 					this.baseIllegalResults.push([this.searchType, id as ID]);


### PR DESCRIPTION
on preact, it is now possible to select Custom game as format in teambuilder but it still shows legalities of OU format.

this fixes it.

(also when no format is selected the dex search assumes its custom game so by default all mons are legal)