### PR TITLE
Add undo button for individual selections during the team previev

### DIFF
--- a/play.pokemonshowdown.com/src/panel-battle.tsx
+++ b/play.pokemonshowdown.com/src/panel-battle.tsx
@@ -341,7 +341,15 @@ class BattlePanel extends PSRoomPanel<BattleRoom> {
 			choices.current.tera = checkbox.checked;
 			break;
 		}
-		this.props.room.update(null);
+		this.forceUpdate();
+	};
+	undoLastChoice = (e: Event) => {
+		e.preventDefault();
+		const choices = this.props.room.choices;
+		if (!choices) return;
+		if (choices.undoLastChoice()) {
+			this.forceUpdate();
+		}
 	};
 	override componentDidMount() {
 		const room = this.props.room;
@@ -783,7 +791,7 @@ class BattlePanel extends PSRoomPanel<BattleRoom> {
 			return this.renderPokemonButton({
 				pokemon: serverPokemon,
 				cmd: `/switch ${slot}`,
-				disabled: true,
+				disabled: false,
 				tooltip: `switchpokemon|${slot - 1}`,
 			});
 		});
@@ -794,7 +802,7 @@ class BattlePanel extends PSRoomPanel<BattleRoom> {
 		if (choices.isEmpty()) return null;
 
 		let buf: preact.ComponentChild[] = [
-			<button data-cmd="/cancel" class="button"><i class="fa fa-chevron-left" aria-hidden></i> Back</button>, ' ',
+			<button onClick={this.undoLastChoice} class="button"><i class="fa fa-chevron-left" aria-hidden></i> Back</button>, ' ',
 		];
 		if (choices.isDone() && choices.noCancel) {
 			buf = ['Waiting for opponent...', <br />];
@@ -946,7 +954,9 @@ class BattlePanel extends PSRoomPanel<BattleRoom> {
 			return <div class="controls">
 				<div class="whatdo">
 					{choices.alreadySwitchingIn.length > 0 ? (
-						[<button data-cmd="/cancel" class="button"><i class="fa fa-chevron-left" aria-hidden></i> Back</button>,
+						[<button onClick={this.undoLastChoice} class="button"><i class="fa fa-undo" aria-hidden></i> Undo</button>,
+							" ",
+							<button data-cmd="/cancel" class="button"><i class="fa fa-times" aria-hidden></i> Cancel</button>,
 							" What about the rest of your team? "]
 					) : (
 						"How will you start the battle? "


### PR DESCRIPTION
# Add Undo button functionality for battle move/switch selection

Adds an "Undo" button that allows players to step backwards through their choices during battle, one action at a time, instead of canceling everything with the "Cancel" button. Especially useful in doubles/multi battles and Team Preview , allows correcting recent mistakes without restarting entire turn selection.

## Changes

### `battle-choices.ts`
- Added `undoLastChoice()` method to `BattleChoiceBuilder` that:
  - Clears partial move target selection first if selecting a target
  - Otherwise removes the last completed choice from the choices array
  - Updates tracking arrays (`alreadySwitchingIn`, mega/z/max/tera flags)
  - Refills passes for remaining slots

### `panel-battle.tsx`
- Updated battle controls UI to use "Back" button with undo functionality:
  - "Back" button now undoes one step at a time instead of full cancel
  - Works for moves, switches, and team preview selections
  - Team preview has separate "Undo" and "Cancel" buttons for better control

**Example workflow:**
- Pick Pokémon 1 → Move 1 → Target 1
- Pick Pokémon 2 → Move 2
- Click "Back" → Returns to Pokémon 2's move selection (not all the way to Pokémon 1)

<img width="628" height="176" alt="image" src="https://github.com/user-attachments/assets/67613707-b3d6-4ab0-aa94-1283e6a2e9ec" />
<img width="648" height="265" alt="image" src="https://github.com/user-attachments/assets/f3a72b4c-9d48-479b-acff-acd351889652" />
<img width="637" height="228" alt="image" src="https://github.com/user-attachments/assets/db524782-9f1a-4a12-b4f2-08d2cf915aa4" />

