### PR TITLE
Preact: Low height screen battle handling

### DIFF
--- a/play.pokemonshowdown.com/src/panel-battle.tsx
+++ b/play.pokemonshowdown.com/src/panel-battle.tsx
@@ -925,8 +925,9 @@ class BattlePanel extends PSRoomPanel<BattleRoom> {
 			}
 
 			const canShift = room.battle.gameType === 'triples' && index !== 1;
-			const showMoves = !this.overlayMode || this.controlsMode === 'move';
-			const showSwitches = !this.overlayMode || this.controlsMode === 'switch';
+			const useOverlayToggles = this.overlayMode;
+			const showMoves = !useOverlayToggles || this.controlsMode === 'move';
+			const showSwitches = !useOverlayToggles || this.controlsMode === 'switch';
 			const overlayClass = (this.overlayMode && this.controlsMode) ? ` ${this.controlsMode}-controls` : '';
 
 			return <div class={`controls${overlayClass}`}>
@@ -935,13 +936,15 @@ class BattlePanel extends PSRoomPanel<BattleRoom> {
 					What will <strong>{pokemon.name}</strong> do?
 				</div>
 				<div class="movecontrols">
-					<button
-						type="button"
-						class="moveselect"
-						onClick={() => { this.controlsMode = 'move'; this.forceUpdate(); }}
-					>
-						Attack
-					</button>
+					{useOverlayToggles ? (
+						<button
+							type="button"
+							class="moveselect"
+							onClick={() => { this.controlsMode = 'move'; this.forceUpdate(); }}
+						>
+							Attack
+						</button>
+					) : <h3 class="moveselect">Attack</h3>}
 					{showMoves && this.renderMoveMenu(choices)}
 				</div>
 				<div class="switchcontrols">
@@ -949,13 +952,15 @@ class BattlePanel extends PSRoomPanel<BattleRoom> {
 						<h3 class="shiftselect">Shift</h3>,
 						<button data-cmd="/shift">Move to center</button>,
 					]}
-					<button
-						type="button"
-						class="switchselect"
-						onClick={() => { this.controlsMode = 'switch'; this.forceUpdate(); }}
-					>
-						Switch
-					</button>
+					{useOverlayToggles ? (
+						<button
+							type="button"
+							class="switchselect"
+							onClick={() => { this.controlsMode = 'switch'; this.forceUpdate(); }}
+						>
+							Switch
+						</button>
+					) : <h3 class="switchselect">Switch</h3>}
 					{showSwitches && this.renderSwitchMenu(request, choices)}
 				</div>
 			</div>;

--- a/play.pokemonshowdown.com/style/client2.css
+++ b/play.pokemonshowdown.com/style/client2.css
@@ -1886,6 +1886,91 @@ pre.textbox.textbox-empty[placeholder]:before {
 	background: #009AA4;
 }
 
+@media (max-height:570px) and (min-width: 440px) {
+	/*
+	 * Black move/switch menu for low-res screens (parity with client1)
+	 */
+	.controls {
+		position: absolute;
+		bottom: 10px;
+		left: 0;
+		right: 0;
+		width: auto;
+		background: #444444;
+		background: rgba(40,40,40,.85);
+		color: #FFFFFF;
+		padding: 4px 8px;
+	}
+	.battle-controls .whatdo {
+		color: #FFFFFF;
+		padding-bottom: 50px;
+	}
+	.battle-controls .whatdo small.weak {
+		color: #DDDD55;
+		border-color: #DDDD55;
+	}
+	.battle-controls .whatdo small.critical {
+		color: #FF7766;
+		border-color: #FF7766;
+	}
+	.battle-controls .movecontrols, .battle-controls .shiftcontrols, .battle-controls .switchcontrols {
+		max-width: 640px;
+	}
+	.movemenu {
+		display: none;
+		padding: 0 75px 0 85px;
+	}
+	.allyparty,
+	.switchmenu {
+		display: none;
+		max-width: 325px;
+		padding: 0 75px 0 85px;
+		margin: 0 0 0 auto;
+	}
+	.moveselect {
+		position: absolute;
+		left: 20px;
+		bottom: 20px;
+	}
+	.allyTeam,
+	.switchselect {
+		position: absolute;
+		right: 20px;
+		bottom: 20px;
+	}
+	.shiftselect {
+		position: absolute;
+		right: 150px;
+		bottom: 20px;
+	}
+	.moveselect button, .switchselect button, .shiftselect button {
+		padding: 4px 8px;
+		border-radius: 6px;
+		background: #E5E5E5;
+	}
+	.megaevo-box {
+		text-align: left;
+	}
+	.battle-controls .move-controls .whatdo,
+	.battle-controls .switch-controls .whatdo {
+		padding-bottom: 5px;
+	}
+	.move-controls .movemenu,
+	.switch-controls .switchmenu {
+		display: block;
+		margin-right: 0;
+	}
+	.move-controls .moveselect button,
+	.switch-controls .switchselect button,
+	.shiftselect button {
+		background: #BBBBBB;
+	}
+	.controls .timer {
+		float: right;
+		margin-top: -25px;
+	}
+}
+
 .movebutton {
 	float: left;
 	display: block;


### PR DESCRIPTION
When the client window is in a smaller screen, the battle screen will match the original handling with attack and switch buttons
<img width="1080" height="538" alt="image" src="https://github.com/user-attachments/assets/1bd88d30-cf3f-4911-8647-2b018a86bf04" />

Client rewrite issue: https://github.com/orgs/smogon/projects/2?pane=issue&itemId=111984798