### PR TITLE
Add a check to get rid of unneeded Ubers header

### DIFF
--- a/play.pokemonshowdown.com/src/battle-dex-search.ts
+++ b/play.pokemonshowdown.com/src/battle-dex-search.ts
@@ -1176,14 +1176,63 @@ class BattlePokemonSearch extends BattleTypedSearch<'pokemon'> {
 						'calyrexshadow' in table.metagameBans[format] &&
 						type === 'header' && id === 'AG'
 					) return false;
+					const gen9ubers = [
+					'annihilape', 'arceus', 'arceusbug', 'arceusdark', 'arceusdragon', 'arceuselectric', 'arceusfairy',
+					'arceusfighting', 'arceusfire', 'arceusflying', 'arceusghost', 'arceusgrass', 'arceusground', 'arceusice',
+					'arceuspoison', 'arceuspsychic', 'arceusrock', 'arceussteel', 'arceuswater', 'archaludon', 'baxcalibur',
+					'calyrexice', 'chiyu', 'chienpao', 'deoxys', 'dialga', 'dialgaorigin', 'espathra', 'eternatus', 'fluttermane',
+					'giratina', 'giratinaorigin', 'gougingfire', 'groudon',	'hooh', 'ironbundle', 'koraidon', 'kyogre', 'kyuremblack',
+					'kyuremwhite', 'landorus', 'lugia', 'lunala', 'magearna', 'mewtwo', 'necrozmadawnwings', 'necrozmaduskmane',
+					'ogerponhearthflame', 'palafin', 'palkia', 'palkiaorigin', 'rayquaza', 'regieleki', 'reshiram', 'roaringmoon', 
+					'shayminsky', 'sneasler', 'solgaleo', 'spectrier', 'terapagos', 'ursalunabloodmoon', 'urshifu', 'urshifurapidstrike',
+					'volcarona', 'zacian', 'zaciancrowned', 'zamazentacrowned', 'zekrom',
+					];
+					if (!this.formatType && dex.gen === 9 && gen9ubers.every(uber => uber in table.metagameBans[format] 
+						&& type === 'header' && id === 'Uber')
+					) return false;	
 					if (!this.formatType && dex.gen === 8 &&
 						'zacian' in table.metagameBans[format] &&
 						'zaciancrowned' in table.metagameBans[format] &&
 						type === 'header' && id === 'AG'
 					) return false;
+					const gen8ubers = [
+					'calyrexice', 'calyrexshadow', 'cinderace', 'darmanitangalar', 'dialga', 'dracovish', 'eternatus', 'genesect',
+					'giratina', 'giratinaorigin', 'groudon', 'hooh', 'kyogre', 'kyurem', 'kyuremblack', 'kyuremwhite', 'landorus',
+					'lugia', 'lunala', 'magearna', 'marshadow', 'mewtwo', 'naganadel', 'necrozmaduskmane', 'necrozmadawnwings',
+					'palkia', 'pheromosa', 'rayquaza', 'reshiram', 'solgaleo', 'spectrier', 'urshifu', 'xerneas', 'yveltal',
+					'zamazenta', 'zamazentacrowned', 'zekrom', 'zygarde',
+					];
+					if (!this.formatType && dex.gen === 8 && gen8ubers.every(uber => uber in table.metagameBans[format] 
+						&& type === 'header' && id === 'Uber')
+					) return false;
 					if ((dex.gen === 7 || dex.gen === 6) &&
 						(id === 'AG' || id === 'rayquazamega') &&
 						'megarayquazaclause' in table.metagameBans[format]
+					) return false;
+					const gen7ubers = [
+					'aegislash', 'arceus', 'arceusbug', 'arceusdark', 'arceusdragon', 'arceuselectric', 'arceusfairy',
+					'arceusfighting', 'arceusfire', 'arceusflying', 'arceusghost', 'arceusgrass', 'arceusground', 'arceusice',
+					'arceuspoison', 'arceuspsychic', 'arceusrock', 'arceussteel', 'arceuswater', 'blaziken', 'darkrai',
+					'deoxys', 'deoxysattack', 'deoxysdefense', 'deoxysspeed', 'dialga', 'genesect', 'giratina', 'giratinaorigin',
+					'groudon', 'hooh', 'kyogre', 'kyuremwhite', 'landorus', 'lugia', 'lunala', 'marshadow', 'mewtwo', 'naganadel',
+					'necrozmadawnwings', 'necrozmaduskmane', 'palkia', 'pheromosa', 'rayquaza', 'reshiram', 'shayminsky',
+					'solgaleo', 'xerneas', 'yveltal', 'zekrom', 'zygarde', 'gengarmega', 'kangaskhanmega', 'lucariomega',
+					'metagrossmega', 'necrozmaultra', 'salamencemega',
+					];
+					if (!this.formatType && dex.gen === 7 && gen7ubers.every(uber => uber in table.metagameBans[format] 
+						&& type === 'header' && id === 'Uber')
+					) return false;
+					const gen6ubers = [
+					'aegislash', 'arceus', 'arceusbug', 'arceusdark', 'arceusdragon', 'arceuselectric', 'arceusfairy',
+					'arceusfighting', 'arceusfire', 'arceusflying', 'arceusghost', 'arceusgrass', 'arceusground', 'arceusice',
+					'arceuspoison', 'arceuspsychic', 'arceusrock', 'arceussteel', 'arceuswater', 'blaziken', 'darkrai',
+					'deoxys', 'deoxysattack', 'deoxysdefense', 'deoxysspeed', 'dialga', 'genesect', 'giratina', 'giratinaorigin',
+					'greninja', 'groudon', 'hooh', 'hoopaunbound', 'kyogre', 'kyuremwhite', 'landorus', 'lugia', 'mewtwo',
+					'palkia', 'rayquaza', 'reshiram', 'shayminsky', 'xerneas', 'yveltal', 'zekrom', 'gengarmega', 'kangaskhanmega',
+					'lucariomega', 'mawilemega', 'sableyemega', 'salamencemega',
+					];
+					if (!this.formatType && dex.gen === 6 && gen6ubers.every(uber => uber in table.metagameBans[format] 
+						&& type === 'header' && id === 'Uber')
 					) return false;
 					return true;
 				});

--- a/play.pokemonshowdown.com/src/battle-dex-search.ts
+++ b/play.pokemonshowdown.com/src/battle-dex-search.ts
@@ -1171,72 +1171,18 @@ class BattlePokemonSearch extends BattleTypedSearch<'pokemon'> {
 				tierSet = tierSet.filter(([type, id]) => {
 					if (id in table.metagameBans[format]) return false;
 					if (this.formatType === 'natdex' && id in table.metagameBans['nationaldex' + format]) return false;
-					if (!this.formatType && dex.gen === 9 &&
-						'miraidon' in table.metagameBans[format] &&
-						'calyrexshadow' in table.metagameBans[format] &&
-						type === 'header' && id === 'AG'
-					) return false;
-					const gen9ubers = [
-					'annihilape', 'arceus', 'arceusbug', 'arceusdark', 'arceusdragon', 'arceuselectric', 'arceusfairy',
-					'arceusfighting', 'arceusfire', 'arceusflying', 'arceusghost', 'arceusgrass', 'arceusground', 'arceusice',
-					'arceuspoison', 'arceuspsychic', 'arceusrock', 'arceussteel', 'arceuswater', 'archaludon', 'baxcalibur',
-					'calyrexice', 'chiyu', 'chienpao', 'deoxys', 'dialga', 'dialgaorigin', 'espathra', 'eternatus', 'fluttermane',
-					'giratina', 'giratinaorigin', 'gougingfire', 'groudon',	'hooh', 'ironbundle', 'koraidon', 'kyogre', 'kyuremblack',
-					'kyuremwhite', 'landorus', 'lugia', 'lunala', 'magearna', 'mewtwo', 'necrozmadawnwings', 'necrozmaduskmane',
-					'ogerponhearthflame', 'palafin', 'palkia', 'palkiaorigin', 'rayquaza', 'regieleki', 'reshiram', 'roaringmoon', 
-					'shayminsky', 'sneasler', 'solgaleo', 'spectrier', 'terapagos', 'ursalunabloodmoon', 'urshifu', 'urshifurapidstrike',
-					'volcarona', 'zacian', 'zaciancrowned', 'zamazentacrowned', 'zekrom',
-					];
-					if (!this.formatType && dex.gen === 9 && gen9ubers.every(uber => uber in table.metagameBans[format] 
-						&& type === 'header' && id === 'Uber')
-					) return false;	
-					if (!this.formatType && dex.gen === 8 &&
-						'zacian' in table.metagameBans[format] &&
-						'zaciancrowned' in table.metagameBans[format] &&
-						type === 'header' && id === 'AG'
-					) return false;
-					const gen8ubers = [
-					'calyrexice', 'calyrexshadow', 'cinderace', 'darmanitangalar', 'dialga', 'dracovish', 'eternatus', 'genesect',
-					'giratina', 'giratinaorigin', 'groudon', 'hooh', 'kyogre', 'kyurem', 'kyuremblack', 'kyuremwhite', 'landorus',
-					'lugia', 'lunala', 'magearna', 'marshadow', 'mewtwo', 'naganadel', 'necrozmaduskmane', 'necrozmadawnwings',
-					'palkia', 'pheromosa', 'rayquaza', 'reshiram', 'solgaleo', 'spectrier', 'urshifu', 'xerneas', 'yveltal',
-					'zamazenta', 'zamazentacrowned', 'zekrom', 'zygarde',
-					];
-					if (!this.formatType && dex.gen === 8 && gen8ubers.every(uber => uber in table.metagameBans[format] 
-						&& type === 'header' && id === 'Uber')
-					) return false;
 					if ((dex.gen === 7 || dex.gen === 6) &&
 						(id === 'AG' || id === 'rayquazamega') &&
 						'megarayquazaclause' in table.metagameBans[format]
 					) return false;
-					const gen7ubers = [
-					'aegislash', 'arceus', 'arceusbug', 'arceusdark', 'arceusdragon', 'arceuselectric', 'arceusfairy',
-					'arceusfighting', 'arceusfire', 'arceusflying', 'arceusghost', 'arceusgrass', 'arceusground', 'arceusice',
-					'arceuspoison', 'arceuspsychic', 'arceusrock', 'arceussteel', 'arceuswater', 'blaziken', 'darkrai',
-					'deoxys', 'deoxysattack', 'deoxysdefense', 'deoxysspeed', 'dialga', 'genesect', 'giratina', 'giratinaorigin',
-					'groudon', 'hooh', 'kyogre', 'kyuremwhite', 'landorus', 'lugia', 'lunala', 'marshadow', 'mewtwo', 'naganadel',
-					'necrozmadawnwings', 'necrozmaduskmane', 'palkia', 'pheromosa', 'rayquaza', 'reshiram', 'shayminsky',
-					'solgaleo', 'xerneas', 'yveltal', 'zekrom', 'zygarde', 'gengarmega', 'kangaskhanmega', 'lucariomega',
-					'metagrossmega', 'necrozmaultra', 'salamencemega',
-					];
-					if (!this.formatType && dex.gen === 7 && gen7ubers.every(uber => uber in table.metagameBans[format] 
-						&& type === 'header' && id === 'Uber')
-					) return false;
-					const gen6ubers = [
-					'aegislash', 'arceus', 'arceusbug', 'arceusdark', 'arceusdragon', 'arceuselectric', 'arceusfairy',
-					'arceusfighting', 'arceusfire', 'arceusflying', 'arceusghost', 'arceusgrass', 'arceusground', 'arceusice',
-					'arceuspoison', 'arceuspsychic', 'arceusrock', 'arceussteel', 'arceuswater', 'blaziken', 'darkrai',
-					'deoxys', 'deoxysattack', 'deoxysdefense', 'deoxysspeed', 'dialga', 'genesect', 'giratina', 'giratinaorigin',
-					'greninja', 'groudon', 'hooh', 'hoopaunbound', 'kyogre', 'kyuremwhite', 'landorus', 'lugia', 'mewtwo',
-					'palkia', 'rayquaza', 'reshiram', 'shayminsky', 'xerneas', 'yveltal', 'zekrom', 'gengarmega', 'kangaskhanmega',
-					'lucariomega', 'mawilemega', 'sableyemega', 'salamencemega',
-					];
-					if (!this.formatType && dex.gen === 6 && gen6ubers.every(uber => uber in table.metagameBans[format] 
-						&& type === 'header' && id === 'Uber')
-					) return false;
 					return true;
 				});
 			}
+			tierSet = tierSet.filter(([type],i) =>{
+				if(type=== 'pokemon') return true;
+				if (i < tierSet.length-1 && tierSet[i+1][0] === 'pokemon') return true;
+				return false;
+			});
 			if ((format === 'doubles' || format === 'monotype') && this.formatType === 'natdex' && table.metagameBans?.[format]) {
 				tierSet = tierSet.filter(([type, id]) => {
 					if (id in table.metagameBans[format]) return false;

--- a/play.pokemonshowdown.com/src/battle-dex-search.ts
+++ b/play.pokemonshowdown.com/src/battle-dex-search.ts
@@ -1179,8 +1179,7 @@ class BattlePokemonSearch extends BattleTypedSearch<'pokemon'> {
 				});
 			}
 			tierSet = tierSet.filter(([type], i) => {
-				if (type === 'header' && i < tierSet.length - 1 && tierSet[i + 1][0] === 'header')
-					return false;
+				if (type === 'header' && i < tierSet.length - 1 && tierSet[i + 1][0] === 'header') return false;
 				return true;
 			});
 			if ((format === 'doubles' || format === 'monotype') && this.formatType === 'natdex' && table.metagameBans?.[format]) {

--- a/play.pokemonshowdown.com/src/battle-dex-search.ts
+++ b/play.pokemonshowdown.com/src/battle-dex-search.ts
@@ -1178,10 +1178,10 @@ class BattlePokemonSearch extends BattleTypedSearch<'pokemon'> {
 					return true;
 				});
 			}
-			tierSet = tierSet.filter(([type],i) =>{
-				if(type=== 'pokemon') return true;
-				if (i < tierSet.length-1 && tierSet[i+1][0] === 'pokemon') return true;
-				return false;
+			tierSet = tierSet.filter(([type], i) => {
+				if (type === 'header' && i < tierSet.length - 1 && tierSet[i + 1][0] === 'header')
+					return false;
+				return true;
 			});
 			if ((format === 'doubles' || format === 'monotype') && this.formatType === 'natdex' && table.metagameBans?.[format]) {
 				tierSet = tierSet.filter(([type, id]) => {


### PR DESCRIPTION
Currently the Ubers header displays even if no Ubers mons are legal, leading to a useless header(pictured below in biomechmons builder). This gets rid of that.
<img width="633" height="737" alt="image" src="https://github.com/user-attachments/assets/582285ed-a54f-4e0c-96ce-28ddba5a1968" />
