### PR TITLE
Item ratings

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -678,12 +678,12 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 			case 0:
 				badItems.push(id);
 				break;
-			case -1: //Ability to hardcode user-specific items just in case an OM or something needs it
+			case -1: // Ability to hardcode user-specific items just in case an OM or something needs it
 				specificItems.push(id);
 				break;
 			default:
 				if (
-					item.name.startsWith("TR") || item.name.endsWith(" Ball") || item.name.endsWith(" Fossil") || 
+					item.name.startsWith("TR") || item.name.endsWith(" Ball") || item.name.endsWith(" Fossil") ||
 					item.name.startsWith("Fossilized ") || item.name.endsWith(" Sweet") || item.name.endsWith(" Apple")
 				) {
 					badItems.push(id);

--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -641,8 +641,6 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 		const specificItems = [['header', "Pok\u00e9mon-specific items"]];
 		const poorItems = [['header', "Usually useless items"]];
 		const badItems = [['header', "Useless items"]];
-		const unreleasedItems = [];
-		if (genNum === 6) unreleasedItems.push(['header', "Unreleased"]);
 		for (const id of itemList) {
 			const item = Dex.mod(gen).items.get(id);
 			if (item.gen > genNum) {
@@ -687,12 +685,6 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 					item.name.startsWith("Fossilized ") || item.name.endsWith(" Sweet") || item.name.endsWith(" Apple")
 				) {
 					badItems.push(id);
-				} else if (item.name.endsWith(" Gem") && item.name !== "Normal Gem") {
-					if (genNum >= 6) {
-						unreleasedItems.push(id);
-					} else {
-						goodItems.push(id);
-					}
 				} else if (item.itemUser) {
 					specificItems.push(id);
 				} else if (item.megaStone) {
@@ -707,7 +699,6 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 		items.push(...specificItems);
 		items.push(...poorItems);
 		items.push(...badItems);
-		items.push(...unreleasedItems);
 	}
 
 	//

--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -665,208 +665,27 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 				const banlist = Dex.formats.getRuleTable(Dex.formats.get(gen + 'metronomebattle'));
 				if (banlist.isBanned('item:' + item.id)) continue;
 			}
-			switch (id) {
-			// mainstays
-			case 'choiceband':
-			case 'choicespecs':
-			case 'eviolite':
+			switch (item.rating) {
+			case 3:
 				greatItems.push(id);
 				break;
-			// great everywhere but metronome
-			case 'leftovers':
-			case 'lifeorb':
-			case 'choicescarf':
-			case 'assaultvest':
-			case 'focussash':
-			case 'powerherb':
-			case 'rockyhelmet':
-				if (!isMetBattle) greatItems.push(id);
-				else goodItems.push(id);
+			case 2:
+				goodItems.push(id);
 				break;
-			// just singles
-			case 'airballoon':
-			case 'loadeddice':
-			case 'heavydutyboots':
-			case 'expertbelt':
-			case 'salacberry':
-				if (isDoubles || isMetBattle) goodItems.push(id);
-				else greatItems.push(id);
+			case 1:
+				poorItems.push(id);
 				break;
-			// just doubles
-			case 'safetygoggles':
-			case 'ejectbutton':
-			case 'ejectpack':
-				if (isDoubles) greatItems.push(id);
-				else goodItems.push(id);
-				break;
-			// doubles + metronome
-			case 'covertcloak':
-			case 'clearamulet':
-			case 'weaknesspolicy':
-				if (isDoubles || isMetBattle) greatItems.push(id);
-				else goodItems.push(id);
-				break;
-			// metronome only
-			case 'mirrorherb':
-				if (isMetBattle) greatItems.push(id);
-				else goodItems.push(id);
-				break;
-			// generation specific
-			case 'mentalherb':
-				if (isMetBattle) goodItems.push(id);
-				else if (genNum > 4) greatItems.push(id);
-				else poorItems.push(id);
-				break;
-			case 'lumberry':
-				if (genNum === 2 || genNum > 6) goodItems.push(id);
-				else greatItems.push(id);
-				break;
-			case 'sitrusberry':
-				if (genNum > 3 && (genNum < 7 || isDoubles)) greatItems.push(id);
-				else if (genNum > 6) goodItems.push(id);
-				else poorItems.push(id);
-				break;
-			case 'aguavberry':
-			case 'figyberry':
-			case 'iapapaberry':
-			case 'magoberry':
-			case 'wikiberry':
-				if (genNum === 7) greatItems.push(id);
-				else if (genNum >= 8) goodItems.push(id);
-				else poorItems.push(id);
-				break;
-			case 'berryjuice':
-				if (genNum === 2) poorItems.push(id);
-				else goodItems.push(id);
-				break;
-			case 'dragonfang':
-				if (genNum === 2) badItems.push(id);
-				else goodItems.push(id);
-				break;
-			case 'dragonscale':
-				if (genNum === 2) goodItems.push(id);
-				else badItems.push(id);
-				break;
-			case 'mail':
-				if (genNum >= 6) unreleasedItems.push(id);
-				else goodItems.push(id);
-				break;
-			// Legendaries
-			case 'adamantorb':
-			case 'griseousorb':
-			case 'lustrousorb':
-			case 'blueorb':
-			case 'redorb':
-			case 'souldew':
-			// falls through
-			// Other
-			case 'leek':
-			case 'stick':
-			case 'thickclub':
-			case 'lightball':
-			case 'luckypunch':
-			case 'quickpowder':
-			case 'metalpowder':
-			case 'deepseascale':
-			case 'deepseatooth':
-				specificItems.push(id);
-				break;
-			// Fling-only
-			case 'rarebone':
-			case 'belueberry':
-			case 'blukberry':
-			case 'cornnberry':
-			case 'durinberry':
-			case 'hondewberry':
-			case 'magostberry':
-			case 'nanabberry':
-			case 'nomelberry':
-			case 'pamtreberry':
-			case 'pinapberry':
-			case 'pomegberry':
-			case 'qualotberry':
-			case 'rabutaberry':
-			case 'razzberry':
-			case 'spelonberry':
-			case 'tamatoberry':
-			case 'watmelberry':
-			case 'wepearberry':
-			case 'energypowder':
-			case 'electirizer':
-			case 'oldamber':
-			case 'dawnstone':
-			case 'dubiousdisc':
-			case 'duskstone':
-			case 'firestone':
-			case 'icestone':
-			case 'leafstone':
-			case 'magmarizer':
-			case 'moonstone':
-			case 'ovalstone':
-			case 'prismscale':
-			case 'protector':
-			case 'reapercloth':
-			case 'sachet':
-			case 'shinystone':
-			case 'sunstone':
-			case 'thunderstone':
-			case 'upgrade':
-			case 'waterstone':
-			case 'whippeddream':
-			case 'bottlecap':
-			case 'goldbottlecap':
-			case 'galaricacuff':
-			case 'chippedpot':
-			case 'crackedpot':
-			case 'galaricawreath':
-			case 'auspiciousarmor':
-			case 'maliciousarmor':
-			case 'masterpieceteacup':
-			case 'metalalloy':
-			case 'unremarkableteacup':
-			case 'bignugget':
+			case 0:
 				badItems.push(id);
 				break;
-			// outclassed items
-			case 'aspearberry':
-			case 'bindingband':
-			case 'cheriberry':
-			case 'destinyknot':
-			case 'enigmaberry':
-			case 'floatstone':
-			case 'ironball':
-			case 'jabocaberry':
-			case 'oranberry':
-			case 'machobrace':
-			case 'pechaberry':
-			case 'persimberry':
-			case 'poweranklet':
-			case 'powerband':
-			case 'powerbelt':
-			case 'powerbracer':
-			case 'powerlens':
-			case 'powerweight':
-			case 'rawstberry':
-			case 'ringtarget':
-			case 'rowapberry':
-			case 'bigroot':
-			case 'focusband':
-			// gen 2
-			case 'psncureberry':
-			case 'przcureberry':
-			case 'burntberry':
-			case 'bitterberry':
-			case 'iceberry':
-			case 'berry':
-				poorItems.push(id);
+			case -1: //Ability to hardcode user-specific items just in case an OM or something needs it
+				specificItems.push(id);
 				break;
 			default:
 				if (
-					item.name.endsWith(" Ball") || item.name.endsWith(" Fossil") || item.name.startsWith("Fossilized ") ||
-					item.name.endsWith(" Sweet") || item.name.endsWith(" Apple")
+					item.name.startsWith("TR") || item.name.endsWith(" Ball") || item.name.endsWith(" Fossil") || 
+					item.name.startsWith("Fossilized ") || item.name.endsWith(" Sweet") || item.name.endsWith(" Apple")
 				) {
-					badItems.push(id);
-				} else if (item.name.startsWith("TR")) {
 					badItems.push(id);
 				} else if (item.name.endsWith(" Gem") && item.name !== "Normal Gem") {
 					if (genNum >= 6) {
@@ -874,12 +693,6 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 					} else {
 						goodItems.push(id);
 					}
-				} else if (item.name.endsWith(" Drive")) {
-					specificItems.push(id);
-				} else if (item.name.endsWith(" Memory")) {
-					specificItems.push(id);
-				} else if (item.name.startsWith("Rusted")) {
-					specificItems.push(id);
 				} else if (item.itemUser) {
 					specificItems.push(id);
 				} else if (item.megaStone) {
@@ -1180,7 +993,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 		'accuracy', 'basePower', 'category', 'desc', 'flags', 'isNonstandard', 'pp', 'priority', 'shortDesc', 'target', 'type',
 	];
 	const overrideAbilityKeys = ['desc', 'flags', 'isNonstandard', 'rating', 'shortDesc'];
-	const overrideItemKeys = ['desc', 'fling', 'isNonstandard', 'naturalGift', 'shortDesc'];
+	const overrideItemKeys = ['desc', 'fling', 'isNonstandard', 'naturalGift', 'rating', 'shortDesc'];
 
 	//
 	// Past gen table

--- a/play.pokemonshowdown.com/src/battle-dex-search.ts
+++ b/play.pokemonshowdown.com/src/battle-dex-search.ts
@@ -1422,9 +1422,9 @@ class BattleItemSearch extends BattleTypedSearch<'item'> {
 		return table.itemSet;
 	}
 	getBaseResults(): SearchRow[] {
-		const results = this.getDefaultResults();
-		if (!this.species) return results;
+		if (!this.species) return this.getDefaultResults();
 		const speciesName = this.dex.species.get(this.species).name;
+		const results = this.getDefaultResults();
 		const speciesSpecific: SearchRow[] = [];
 		const abilitySpecific: SearchRow[] = [];
 		const abilityItem = {
@@ -1434,8 +1434,7 @@ class BattleItemSearch extends BattleTypedSearch<'item'> {
 			// toxicboost: 'toxicorb',
 			// flareboost: 'flameorb',
 		}[toID(this.set?.ability) as string];
-		for (let i = results.length - 1; i > 0; i--) {
-			const row = results[i];
+		for (const row of results) {
 			if (row[0] !== 'item') continue;
 			const item = this.dex.items.get(row[1]);
 			if (item.itemUser?.includes(speciesName)) speciesSpecific.push(row);

--- a/play.pokemonshowdown.com/src/battle-dex-search.ts
+++ b/play.pokemonshowdown.com/src/battle-dex-search.ts
@@ -1424,7 +1424,7 @@ class BattleItemSearch extends BattleTypedSearch<'item'> {
 	getBaseResults(): SearchRow[] {
 		const results = this.getDefaultResults();
 		if (!this.species) return results;
-		const species = this.dex.species.get(this.species);
+		const speciesName = this.dex.species.get(this.species).name;
 		const speciesSpecific: SearchRow[] = [];
 		const abilitySpecific: SearchRow[] = [];
 		const abilityItem = {
@@ -1437,21 +1437,13 @@ class BattleItemSearch extends BattleTypedSearch<'item'> {
 		for (let i = results.length - 1; i > 0; i--) {
 			const row = results[i];
 			if (row[0] !== 'item') continue;
-			const id = row[1];
-			let item = this.dex.items.get(id);
-			if (!item.exists || item.isNonstandard) {
-				if (item.isNonstandard !== "Past" || this.formatType !== 'natdex') {
-					results.splice(i, 1);
-					continue;
-				}
-			}
-			if (item.itemUser?.includes(species.name)) {
-				speciesSpecific.push(row);
-			}
+			const item = this.dex.items.get(row[1]);
+			if (item.itemUser?.includes(speciesName)) speciesSpecific.push(row);
+			if (abilityItem === item.id) abilitySpecific.push(row);
 		}
 		if (speciesSpecific.length) {
 			return [
-				['header', "Specific to " + species.name],
+				['header', "Specific to " + speciesName],
 				...speciesSpecific,
 				...results,
 			];

--- a/play.pokemonshowdown.com/src/battle-dex-search.ts
+++ b/play.pokemonshowdown.com/src/battle-dex-search.ts
@@ -1422,9 +1422,9 @@ class BattleItemSearch extends BattleTypedSearch<'item'> {
 		return table.itemSet;
 	}
 	getBaseResults(): SearchRow[] {
-		if (!this.species) return this.getDefaultResults();
-		const speciesName = this.dex.species.get(this.species).name;
 		const results = this.getDefaultResults();
+		if (!this.species) return results;
+		const species = this.dex.species.get(this.species);
 		const speciesSpecific: SearchRow[] = [];
 		const abilitySpecific: SearchRow[] = [];
 		const abilityItem = {
@@ -1434,15 +1434,24 @@ class BattleItemSearch extends BattleTypedSearch<'item'> {
 			// toxicboost: 'toxicorb',
 			// flareboost: 'flameorb',
 		}[toID(this.set?.ability) as string];
-		for (const row of results) {
+		for (let i = results.length - 1; i > 0; i--) {
+			const row = results[i];
 			if (row[0] !== 'item') continue;
-			const item = this.dex.items.get(row[1]);
-			if (item.itemUser?.includes(speciesName)) speciesSpecific.push(row);
-			if (abilityItem === item.id) abilitySpecific.push(row);
+			const id = row[1];
+			let item = this.dex.items.get(id);
+			if (!item.exists || item.isNonstandard) {
+				if (item.isNonstandard !== "Past" || this.formatType !== 'natdex') {
+					results.splice(i, 1);
+					continue;
+				}
+			}
+			if (item.itemUser?.includes(species.name)) {
+				speciesSpecific.push(row);
+			}
 		}
 		if (speciesSpecific.length) {
 			return [
-				['header', "Specific to " + speciesName],
+				['header', "Specific to " + species.name],
 				...speciesSpecific,
 				...results,
 			];


### PR DESCRIPTION
Adds a rating variable to items to determine which section of the default teambuilder list it appears in, rather than a lengthy, hardcoded switch statement. This variable can be overridden by mods, and all existing ratings across all generations have been applied in the matching [server PR](https://github.com/smogon/pokemon-showdown/pull/11719), which should be accepted at the same time. Items without a rating default to the Items tier, but Pokemon-specific items continue to be determined by itemUser or megaStone, Ability-specific items remain hardcoded since it's currently just Booster Energy (but could certainly be added), and item categories such as Poke Balls and TRs are still automatically listed as Useless. The Unreleased Items section has also been removed, since it was coded only to appear in Gen 6 and it would always be empty since its items (the Gems) were Illegal and therefore don't display in the list.

For ease of documentation, here is the ratings list:
3: Popular items
2: Items (default, but can be applied manually)
1: Usually useless items
0: Useless items
-1: Manual addition to Pokemon-specific items in case it's needed