### PR TITLE
Teambuilder: Properly truncate long ability names

### DIFF
--- a/play.pokemonshowdown.com/src/battle-searchresults.tsx
+++ b/play.pokemonshowdown.com/src/battle-searchresults.tsx
@@ -199,7 +199,7 @@ export class PSSearchResults extends preact.Component<{
 				href={`${this.URL_ROOT}abilities/${id}`} class={id === this.abilityId ? 'cur' : ''}
 				data-target="push" data-entry={`ability|${ability.name}`}
 			>
-				<span class="col namecol">{id ? this.renderName(ability.name, matchStart, matchEnd) : <i>(no ability)</i>}</span>
+				<span class="col abilitynamecol">{id ? this.renderName(ability.name, matchStart, matchEnd) : <i>(no ability)</i>}</span>
 
 				{errorMessage}
 

--- a/play.pokemonshowdown.com/style/battle-search.css
+++ b/play.pokemonshowdown.com/style/battle-search.css
@@ -171,6 +171,16 @@
 	color: #000000;
 	font-size: 10pt;
 }
+.dexlist .abilitynamecol {
+	padding-top: 6px;
+	height: 23px;
+	width: 152px;
+	color: #000000;
+	font-size: 10pt;
+	text-wrap: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
+}
 .dexlist .pokemonnamecol {
 	padding-top: 6px;
 	height: 23px;


### PR DESCRIPTION
Abilities like supreme overlord and water compaction currently get squished when being searched and it looks kinda jarring. This changes the ability CSS to match the move column width and also have the text trail off if that's still not enough.

Here's what it looks like before and after the changes:
<img width="382" height="294" alt="image" src="https://github.com/user-attachments/assets/66d3200d-59a7-4854-8a57-65f2b0ecd35c" />

<img width="445" height="303" alt="image" src="https://github.com/user-attachments/assets/a1d8ae74-ee00-4405-bcb7-448099e54b36" />
