### PR TITLE
Don't include "Ability: No Ability" in team exports

### DIFF
--- a/play.pokemonshowdown.com/js/storage.js
+++ b/play.pokemonshowdown.com/js/storage.js
@@ -1400,7 +1400,7 @@ Storage.exportTeam = function (team, hidestats) {
 			text += ' @ ' + curSet.item;
 		}
 		text += "  \n";
-		if (curSet.ability) {
+		if (curSet.ability && curSet.ability !== 'No Ability') {
 			text += 'Ability: ' + curSet.ability + "  \n";
 		}
 		if (curSet.level && curSet.level !== 100) {


### PR DESCRIPTION
fixes #2216 (reported by @davidstone).

the legacy client's team export in \`js/storage.js\` printed an \`Ability: <ability>\` line whenever the set had any ability string, including the literal \`\"No Ability\"\` placeholder used for Gen 1/2 Pokemon. result was every past-gen team export had a useless \`Ability: No Ability\` line on every set.

the newer Preact-side \`exportSet\` in \`src/battle-teams.ts:316\` already has this guard:
\`\`\`ts
} else if (set.ability && set.ability !== 'No Ability') {
  text += \`Ability: \${set.ability}\n\`;
}
\`\`\`

this just brings the legacy path in line — same condition, single line change.

re: #2215 in the same area — leaving that one alone since @Zarel commented there that he's tracking it for the Preact client rewrite (needs separate handling of \"default vs intentionally maxed\" EVs), so it'd be stepping on that work.

## test plan

- [x] \`npm run lint\` — clean
- [x] \`npx tsc\` — clean
- [x] \`node build\` — clean