### PR TITLE
Remove empty move lines from set export

### DIFF
--- a/play.pokemonshowdown.com/src/battle-teams.ts
+++ b/play.pokemonshowdown.com/src/battle-teams.ts
@@ -328,9 +328,6 @@ export const Teams = new class {
 					text += `- ${move || ''}\n`;
 				}
 			}
-			for (let i = set.moves?.length || 0; i < 4; i++) {
-				text += `- \n`;
-			}
 		}
 
 		// stats
@@ -400,9 +397,6 @@ export const Teams = new class {
 					move = !newFormat ? `${move}[${hpType}]` : `${move}${hpType}`;
 				}
 				text += `- ${move}\n`;
-			}
-			for (let i = set.moves?.length || 0; i < 4; i++) {
-				text += `- \n`;
 			}
 		}
 


### PR DESCRIPTION
Currently, export set always adds at least 4 dashes to the moves section, which causes empty dashes to show up when using sets like Fake Out + Last Resort. This simply removes that behavior.

<img width="1771" height="1190" alt="image" src="https://github.com/user-attachments/assets/0242e78e-9d4d-4521-b62e-fd07cf48e0d4" />
