### PR TITLE
Teambuilder: Match mega/primal formes when searching teams

### DIFF
--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -480,11 +480,15 @@
 						var pokemon = team.team.split(']').map(function (el) {
 							return toID(PSUtils.splitFirst(el, '|')[0]);
 						});
-						var searchVal = this.curSearchVal.split(',').map(function (el) {
-							return toID(el);
+						var searchGroups = this.curSearchVal.split(',').map(function (el) {
+							return Storage.expandSearchTermAlts(toID(el));
 						});
-						var meetsCriteria = searchVal.every(function (el) {
-							return team.team.indexOf(el) > -1 || pokemon.includes(el);
+						var meetsCriteria = searchGroups.every(function (alts) {
+							for (var ai = 0; ai < alts.length; ai++) {
+								var alt = alts[ai];
+								if (team.team.indexOf(alt) > -1 || pokemon.includes(alt)) return true;
+							}
+							return false;
 						});
 						if (!meetsCriteria) continue;
 					}

--- a/play.pokemonshowdown.com/js/storage.js
+++ b/play.pokemonshowdown.com/js/storage.js
@@ -766,6 +766,56 @@ Storage.unpackLine = function (line) {
 	};
 };
 
+Storage.expandSearchTermAlts = function (id) {
+	var alts = [id];
+	if (!id || !window.Dex) return alts;
+	var addForme = function (forme) {
+		if (!forme || !forme.exists) return;
+		alts.push(toID(forme.name));
+		if (forme.requiredItems) {
+			for (var i = 0; i < forme.requiredItems.length; i++) {
+				alts.push(toID(forme.requiredItems[i]));
+			}
+		}
+	};
+	var addBaseFormes = function (base) {
+		if (!base || !base.exists || !base.otherFormes) return;
+		for (var i = 0; i < base.otherFormes.length; i++) {
+			var forme = Dex.species.get(base.otherFormes[i]);
+			if (forme.isMega || forme.isPrimal) addForme(forme);
+		}
+	};
+	var species = Dex.species.get(id);
+	if (species.exists) {
+		if (species.isMega || species.isPrimal) {
+			alts.push(toID(species.baseSpecies));
+			addForme(species);
+		} else {
+			addBaseFormes(species);
+		}
+	} else {
+		var prefixes = ['mega', 'primal'];
+		for (var p = 0; p < prefixes.length; p++) {
+			if (id.indexOf(prefixes[p]) === 0 && id.length > prefixes[p].length) {
+				var base = Dex.species.get(id.slice(prefixes[p].length));
+				if (base.exists) {
+					alts.push(base.id);
+					addBaseFormes(base);
+					break;
+				}
+			}
+		}
+	}
+	var item = Dex.items.get(id);
+	if (item.exists && item.megaStone) {
+		for (var baseName in item.megaStone) {
+			alts.push(toID(baseName));
+			alts.push(toID(item.megaStone[baseName]));
+		}
+	}
+	return alts;
+};
+
 Storage.packAllTeams = function (teams) {
 	return teams.map(function (team) {
 		return (

--- a/play.pokemonshowdown.com/src/panel-teambuilder.tsx
+++ b/play.pokemonshowdown.com/src/panel-teambuilder.tsx
@@ -217,18 +217,68 @@ class TeambuilderRoom extends PSRoom {
 			};
 		}
 	}
+	searchAlts: string[][] = [];
 	updateSearch = (value: string) => {
 		if (!value) {
 			this.searchTerms = [];
+			this.searchAlts = [];
 		} else {
 			this.searchTerms = value.split(",").map(q => q.trim().toLowerCase());
+			this.searchAlts = this.searchTerms.map(term => expandSearchTermAlts(toID(term)));
 		}
 	};
 	matchesSearch = (team: Team) => {
 		if (this.searchTerms.length === 0) return true;
 		const normalized = team.packedTeam.toLowerCase();
-		return this.searchTerms.every(term => normalized.includes(term));
+		return this.searchAlts.every(alts => alts.some(alt => normalized.includes(alt)));
 	};
+}
+
+function expandSearchTermAlts(id: ID): string[] {
+	const alts: string[] = [id];
+	if (!id) return alts;
+	const addForme = (forme: ReturnType<typeof Dex.species.get>) => {
+		if (!forme.exists) return;
+		alts.push(toID(forme.name));
+		if (forme.requiredItems) {
+			for (const item of forme.requiredItems) alts.push(toID(item));
+		}
+	};
+	const addBaseFormes = (base: ReturnType<typeof Dex.species.get>) => {
+		if (!base.exists || !base.otherFormes) return;
+		for (const formeName of base.otherFormes) {
+			const forme = Dex.species.get(formeName);
+			if (forme.isMega || forme.isPrimal) addForme(forme);
+		}
+	};
+	const species = Dex.species.get(id);
+	if (species.exists) {
+		if (species.isMega || species.isPrimal) {
+			alts.push(toID(species.baseSpecies));
+			addForme(species);
+		} else {
+			addBaseFormes(species);
+		}
+	} else {
+		for (const prefix of ['mega', 'primal']) {
+			if (id.startsWith(prefix) && id.length > prefix.length) {
+				const base = Dex.species.get(id.slice(prefix.length));
+				if (base.exists) {
+					alts.push(base.id);
+					addBaseFormes(base);
+					break;
+				}
+			}
+		}
+	}
+	const item = Dex.items.get(id);
+	if (item.exists && item.megaStone) {
+		for (const baseName in item.megaStone) {
+			alts.push(toID(baseName));
+			alts.push(toID(item.megaStone[baseName]));
+		}
+	}
+	return alts;
 }
 
 class TeambuilderPanel extends PSRoomPanel<TeambuilderRoom> {


### PR DESCRIPTION
fixes #1354.

right now the team search treats a pokemon and its mega/primal forme as different ids, so a team that stores `Diancie + Diancite` doesn't show up when you search "mega diancie", and a team that stores `Diancie-Mega` directly (BH/AG etc) doesn't show up when you search "diancie".

this implements zarel's suggestion in the issue thread: each search term gets expanded to a small set of alternates, and the team matches if any one of them hits.

for each search term `id`:
- if `id` resolves to a base species with a mega/primal forme, also accept that forme's id and required item(s)
- if `id` resolves to a mega/primal forme, also accept its base species id and required item(s)
- if `id` starts with `mega`/`primal` and the suffix resolves to a base species, do the above on that base
- if `id` resolves to an item with a `megaStone` field, also accept the base species + mega forme ids

covers both the legacy js teambuilder (`Storage.expandSearchTermAlts` in storage.js, called from client-teambuilder.js) and the preact panel (same logic inlined in panel-teambuilder.tsx). worked through diancie, charizard x/y, primal kyogre, and ultra-style hackmons formes locally.