### PR TITLE
Update usually useless move logic

### DIFF
--- a/play.pokemonshowdown.com/src/battle-dex-search.ts
+++ b/play.pokemonshowdown.com/src/battle-dex-search.ts
@@ -1552,6 +1552,12 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 		if (itemid === 'blastoisinite') abilityid = 'megalauncher' as ID;
 		if (itemid === 'aerodactylite') abilityid = 'toughclaws' as ID;
 		if (itemid === 'glalitite') abilityid = 'refrigerate' as ID;
+		if (itemid === 'feraligite') abilityid = 'dragonize' as ID;
+		if (['gardevoirite', 'altarianite'].includes(itemid)) abilityid = 'pixilate' as ID;
+		if (['pinsirite', 'salamenceite'].includes(itemid)) abilityid = 'aerilate' as ID;
+		if (itemid === 'banettite') abilityid = 'prankster' as ID;
+
+		const TYPE_CHANGING_ABILITIES = ['aerilate', 'dragonize', 'galvanize', 'normalize', 'pixilate', 'refrigerate'] as ID[];
 
 		switch (id) {
 		case 'fakeout': case 'flamecharge': case 'nuzzle': case 'poweruppunch': case 'trailblaze':
@@ -1560,6 +1566,12 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 			return ['desolateland', 'drought', 'chlorophyll', 'orichalcumpulse'].includes(abilityid) || itemid === 'powerherb';
 		case 'dynamicpunch': case 'grasswhistle': case 'inferno': case 'sing':
 			return abilityid === 'noguard';
+		case 'raindance': case 'sunnyday':
+			return dex.gen < 4 || (this.isDoubles && abilityid === 'prankster');
+		case 'electricterrain': case 'grassyterrain': case 'psychicterrain':
+			return this.isDoubles && abilityid === 'prankster';
+		case 'charm': case 'cottonspore': case 'eerieimpulse': case 'faketears': case 'featherdance': case 'metalsound': case 'scaryface': case 'screech':
+			return this.isDoubles && abilityid === 'prankster';
 		case 'heatcrash': case 'heavyslam':
 			return species.weightkg >= (species.evos ? 75 : 130);
 		case 'aerialace':
@@ -1579,12 +1591,14 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 				['iceface', 'unburden'].includes(abilityid);
 		case 'bulletseed':
 			return ['skilllink', 'technician'].includes(abilityid);
+		case 'celebrate':
+			return itemid === 'normaliumz';
 		case 'chillingwater':
 			return !moves.includes('scald');
 		case 'counter': case 'mirrorcoat':
 			return species.baseStats.hp >= 65;
 		case 'dazzlinggleam':
-			return !moves.includes('alluringvoice') || this.formatType?.includes('doubles');
+			return !moves.includes('alluringvoice') || this.isDoubles;
 		case 'darkvoid':
 			return dex.gen < 7;
 		case 'dualwingbeat':
@@ -1592,9 +1606,11 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 		case 'electroshot':
 			return true;
 		case 'feint':
-			return abilityid === 'refrigerate';
+			return TYPE_CHANGING_ABILITIES.includes(abilityid);
 		case 'futuresight':
-			return dex.gen > 5;
+			return dex.gen > 5 && !this.isDoubles;
+		case 'gigaimpact':
+			return TYPE_CHANGING_ABILITIES.includes(abilityid);
 		case 'grassyglide':
 			return abilityid === 'grassysurge';
 		case 'gyroball':
@@ -1625,6 +1641,8 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 			return species.baseSpecies === 'Unown';
 		case 'hyperspacefury':
 			return species.id === 'hoopaunbound';
+		case 'hyperbeam':
+			return TYPE_CHANGING_ABILITIES.includes(abilityid);
 		case 'hypnosis':
 			return (dex.gen < 4 && !moves.includes('sleeppowder')) || (dex.gen > 6 && abilityid === 'baddreams');
 		case 'icepunch':
@@ -1648,7 +1666,7 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 		case 'jumpkick':
 			return !moves.includes('highjumpkick') && !moves.includes('axekick');
 		case 'lastresort':
-			return set && set.moves.length < 3;
+			return set && set.moves.length < 3 || itemid === 'eeviumz';
 		case 'leafblade':
 			return true;
 		case 'leechlife':
@@ -1673,8 +1691,10 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 			return (!moves.includes('poltergeist') && !moves.includes('shadowclaw')) || this.isDoubles;
 		case 'poisonfang':
 			return species.types.includes('Poison') && !moves.includes('gunkshot') && !moves.includes('poisonjab');
-		case 'raindance':
-			return dex.gen < 4;
+		case 'pollenpuff':
+			return !moves.includes('bugbuzz') || this.isDoubles;
+		case 'quash':
+			return this.isDoubles && abilityid === 'prankster';
 		case 'relicsong':
 			return species.id === 'meloetta';
 		case 'refresh':
@@ -1703,8 +1723,6 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 			return (!moves.includes('earthquake') && !moves.includes('drillrun')) || this.isDoubles;
 		case 'stunspore':
 			return !moves.includes('thunderwave');
-		case 'sunnyday':
-			return dex.gen < 4;
 		case 'technoblast':
 			return dex.gen > 5 && itemid.endsWith('drive') || itemid === 'dousedrive';
 		case 'teleport':
@@ -1724,6 +1742,8 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 			return species.baseStats.spe <= 100;
 		case 'wildcharge':
 			return !moves.includes('supercellslam');
+		case 'xscissor':
+			return abilityid === 'sharpness' || dex.gen < 7 || (!moves.includes('leechlife') && !moves.includes('lunge'));
 		case 'zapcannon':
 			return abilityid === 'noguard' || (dex.gen < 4 && !moves.includes('thunderwave'));
 		}
@@ -1763,10 +1783,10 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 		'accelerock', 'acrobatics', 'aquacutter', 'avalanche', 'barbbarrage', 'bonemerang', 'bouncybubble', 'bulletpunch', 'buzzybuzz', 'ceaselessedge', 'circlethrow', 'clearsmog', 'doubleironbash', 'dragondarts', 'dragontail', 'drainingkiss', 'endeavor', 'facade', 'firefang', 'flipturn', 'flowertrick', 'freezedry', 'frustration', 'geargrind', 'gigadrain', 'grassknot', 'gyroball', 'icefang', 'iceshard', 'iciclespear', 'infernalparade', 'knockoff', 'lastrespects', 'lowkick', 'machpunch', 'mortalspin', 'mysticalpower', 'naturesmadness', 'nightshade', 'nuzzle', 'pikapapow', 'populationbomb', 'psychocut', 'psyshieldbash', 'pursuit', 'quickattack', 'ragefist', 'rapidspin', 'return', 'rockblast', 'ruination', 'saltcure', 'scorchingsands', 'seismictoss', 'shadowclaw', 'shadowsneak', 'sizzlyslide', 'stoneaxe', 'storedpower', 'stormthrow', 'suckerpunch', 'superfang', 'surgingstrikes', 'tachyoncutter', 'tailslap', 'thunderclap', 'tripleaxel', 'tripledive', 'twinbeam', 'uturn', 'vacuumwave', 'veeveevolley', 'voltswitch', 'watershuriken', 'weatherball',
 	] as ID[] as readonly ID[];
 	static readonly BAD_STRONG_MOVES = [
-		'belch', 'burnup', 'crushclaw', 'dragonrush', 'dreameater', 'eggbomb', 'firepledge', 'flyingpress', 'futuresight', 'grasspledge', 'hyperbeam', 'hyperfang', 'hyperspacehole', 'jawlock', 'landswrath', 'megakick', 'megapunch', 'mistyexplosion', 'muddywater', 'nightdaze', 'pollenpuff', 'rockclimb', 'selfdestruct', 'shelltrap', 'skyuppercut', 'slam', 'strength', 'submission', 'synchronoise', 'takedown', 'thrash', 'uproar', 'waterpledge',
+		'belch', 'burnup', 'crushclaw', 'dragonrush', 'dreameater', 'eggbomb', 'firepledge', 'flyingpress', 'futuresight', 'grasspledge', 'hyperbeam', 'hyperfang', 'hyperspacehole', 'jawlock', 'landswrath', 'megakick', 'megapunch', 'mistyexplosion', 'muddywater', 'nightdaze', 'rockclimb', 'selfdestruct', 'shelltrap', 'skyuppercut', 'slam', 'strength', 'submission', 'synchronoise', 'takedown', 'thrash', 'uproar', 'waterpledge',
 	] as ID[] as readonly ID[];
 	static readonly GOOD_DOUBLES_MOVES = [
-		'allyswitch', 'bulldoze', 'coaching', 'electroweb', 'faketears', 'fling', 'followme', 'healpulse', 'helpinghand', 'junglehealing', 'lifedew', 'lunarblessing', 'muddywater', 'pollenpuff', 'psychup', 'ragepowder', 'safeguard', 'skillswap', 'snipeshot', 'wideguard', 'decorate', 'snarl',
+		'afteryou', 'allyswitch', 'beatup', 'breakingswipe', 'bulldoze', 'coaching', 'decorate', 'electroweb', 'entrainment', 'firepledge', 'fling', 'followme', 'grasspledge', 'healpulse', 'helpinghand', 'imprison', 'junglehealing', 'lifedew', 'lunarblessing', 'muddywater', 'psychup', 'ragepowder', 'safeguard', 'skillswap', 'snarl', 'snipeshot', 'stringshot', 'strugglebug', 'waterpledge', 'wideguard',
 	] as ID[] as readonly ID[];
 	getBaseResults() {
 		if (!this.species) return this.getDefaultResults();

--- a/play.pokemonshowdown.com/src/battle-dex-search.ts
+++ b/play.pokemonshowdown.com/src/battle-dex-search.ts
@@ -1551,19 +1551,41 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 		if (itemid === 'pidgeotite') abilityid = 'noguard' as ID;
 		if (itemid === 'blastoisinite') abilityid = 'megalauncher' as ID;
 		if (itemid === 'aerodactylite') abilityid = 'toughclaws' as ID;
+		if (itemid === 'banettite') abilityid = 'prankster' as ID;
+
 		if (itemid === 'glalitite') abilityid = 'refrigerate' as ID;
 		if (itemid === 'feraligite') abilityid = 'dragonize' as ID;
 		if (['gardevoirite', 'altarianite'].includes(itemid)) abilityid = 'pixilate' as ID;
 		if (['pinsirite', 'salamenceite'].includes(itemid)) abilityid = 'aerilate' as ID;
-		if (itemid === 'banettite') abilityid = 'prankster' as ID;
 
+		if (itemid === 'charizarditey') abilityid = 'drought' as ID;
+		if (itemid === 'houndoominite') abilityid = 'solarpower' as ID;
+		if (itemid === 'meganiumite') abilityid = 'megasol' as ID;
+		if (itemid === 'redorb') abilityid = 'desolateland' as ID;
+
+		if (itemid === 'swampertite') abilityid = 'swiftswim' as ID;
+		if (itemid === 'blueorb') abilityid = 'primordialsea' as ID;
+
+		if (itemid === 'tyranitarite') abilityid = 'sandstream' as ID;
+		if (['steelixite', 'garchompite'].includes(itemid)) abilityid = 'sandforce' as ID;
+
+		if (['abomasite', 'frosslassite'].includes(itemid)) abilityid = 'snowwarning' as ID;
+
+		const SUN_RELATED_ABILITIES = ['chlorophyll', 'desolateland', 'drought', 'megasol', 'orichalcumpulse', 'solarpower'] as ID[];
+		const RAIN_RELATED_ABILITIES = ['drizzle', 'dryskin', 'primordialsea', 'raindish', 'swiftswim'] as ID[];
+		const SAND_RELATED_ABILITIES = ['sandforce', 'sandrush', 'sandspit', 'sandstream', 'sandveil'] as ID[];
+		const SNOW_RELATED_ABILITIES = ['icebody', 'slushrush', 'snowcloak', 'snowwarning'] as ID[];
 		const TYPE_CHANGING_ABILITIES = ['aerilate', 'dragonize', 'galvanize', 'normalize', 'pixilate', 'refrigerate'] as ID[];
 
 		switch (id) {
 		case 'fakeout': case 'flamecharge': case 'nuzzle': case 'poweruppunch': case 'trailblaze':
 			return abilityid !== 'sheerforce';
 		case 'solarbeam': case 'solarblade':
-			return ['desolateland', 'drought', 'chlorophyll', 'orichalcumpulse'].includes(abilityid) || itemid === 'powerherb';
+			return SUN_RELATED_ABILITIES.includes(abilityid) || itemid === 'powerherb';
+		case 'hurricane': case 'thunder':
+			return !SUN_RELATED_ABILITIES.includes(abilityid);
+		case 'moonlight': case 'morningsun': case 'synthesis':
+			return !(RAIN_RELATED_ABILITIES.includes(abilityid) || SAND_RELATED_ABILITIES.includes(abilityid) || SNOW_RELATED_ABILITIES.includes(abilityid));
 		case 'dynamicpunch': case 'grasswhistle': case 'inferno': case 'sing':
 			return abilityid === 'noguard';
 		case 'raindance': case 'sunnyday':
@@ -1574,10 +1596,13 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 			return this.isDoubles && abilityid === 'prankster';
 		case 'heatcrash': case 'heavyslam':
 			return species.weightkg >= (species.evos ? 75 : 130);
+
 		case 'aerialace':
 			return ['technician', 'toughclaws'].includes(abilityid) && !moves.includes('bravebird');
 		case 'ancientpower':
 			return ['serenegrace', 'technician'].includes(abilityid) || !moves.includes('powergem');
+		case 'auroraveil':
+			return SNOW_RELATED_ABILITIES.includes(abilityid)
 		case 'aquajet':
 			return !moves.includes('jetpunch');
 		case 'aurawheel':
@@ -1604,7 +1629,7 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 		case 'dualwingbeat':
 			return abilityid === 'technician' || !moves.includes('drillpeck');
 		case 'electroshot':
-			return true;
+			return RAIN_RELATED_ABILITIES.includes(abilityid) || species.id === 'archaludon';
 		case 'feint':
 			return TYPE_CHANGING_ABILITIES.includes(abilityid);
 		case 'futuresight':
@@ -1613,6 +1638,8 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 			return TYPE_CHANGING_ABILITIES.includes(abilityid);
 		case 'grassyglide':
 			return abilityid === 'grassysurge';
+		case 'growth':
+			return SUN_RELATED_ABILITIES.includes(abilityid);
 		case 'gyroball':
 			return species.baseStats.spe <= 60;
 		case 'headbutt':


### PR DESCRIPTION
Some (mostly doubles-centric) "usually useless moves" changes:

- Mark the following moves are not useless in doubles if the user has Prankster:
  - Offensive weather and terrain setting moves (Sunny Day, Rain Dance, Grassy Terrain, Electric Terrain, Psychic Terrain)
  - Moves that harshly drop a stat: Charm, Cotton Spore, Eerie Impulse, Fake Tears, Feather Dance, Metal Sound, Scary Face, Screech
  - Quash
- Add the following moves to the "good doubles moves" list:
  - Spread stat-dropping moves: Breaking Swipe, Struggle Bug, String Shot
  - Pledge moves: Fire Pledge, Water Pledge, Grass Pledge
  - Miscellaneous support moves: After You, Beat Up, Entrainment, Imprison
- Mark Hyper Beam and Giga Impact as not useless if the user has a type changing ability. Also apply this to Feint (which previously only applied to Refrigerate)
- Mark Future Sight as useless in doubles
- Mark Pollen Puff as useless in singles only if the user can't learn Bug Buzz
- Mark X-Scissor as useless post generation 7 if the user doesn't have Sharpness and they also learn Lunge or Leech Life
- Mark Last Resort as not useless if the user is holding Eevium Z
- Mark Celebrate as not useless if the user is holding Normalium Z

Update: edited logic for weather related moves:

- Add Mega Sol and Solar Power as sun-related abilities, and also add lists for abilities related to other weather conditions
- Mark Growth as not useless and Hurricane and Thunder as useless with a sun-related ability
- Mark Moonlight, Morning Sun, and Synthesis as useless with a sand-related ability
- Mark Electro Shot as useless without a rain-related ability unless the user is Archaludon (perhaps relevant in STABmons)
- Mark Aurora Veil as useless without a snow-related ability