### PR TITLE
Teambuilder: Removes Tera button in formats with Terastal clause

### DIFF
--- a/play.pokemonshowdown.com/src/battle-dex-search.ts
+++ b/play.pokemonshowdown.com/src/battle-dex-search.ts
@@ -584,6 +584,7 @@ abstract class BattleTypedSearch<T extends SearchType> {
 		'nfe' | 'ssdlc1' | 'ssdlc1doubles' | 'predlc' | 'predlcdoubles' | 'svdlc1' | 'svdlc1doubles' | 'stadium' | 'lc' |
 		'champions' | 'natdexchampions' | null = null;
 	isDoubles = false;
+	terastalClause = false;
 
 	/**
 	 * Cached copy of what the results list would be with only base filters
@@ -605,6 +606,7 @@ abstract class BattleTypedSearch<T extends SearchType> {
 
 		this.baseResults = null;
 		this.baseIllegalResults = null;
+		this.terastalClause = !!BattleFormats[format]?.terastalClause;
 
 		if (format.startsWith('gen')) {
 			const gen = (Number(format.charAt(3)) || 6);
@@ -1720,6 +1722,8 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 		case 'temperflare':
 			return (!moves.includes('flareblitz') && !moves.includes('pyroball') && !moves.includes('sacredfire') &&
 				!moves.includes('bitterblade') && !moves.includes('firepunch')) || this.isDoubles;
+		case 'terablast':
+			return !this.terastalClause;
 		case 'terrainpulse': case 'waterpulse':
 			return ['megalauncher', 'technician'].includes(abilityid) && !moves.includes('originpulse');
 		case 'thief':

--- a/play.pokemonshowdown.com/src/battle-dex-search.ts
+++ b/play.pokemonshowdown.com/src/battle-dex-search.ts
@@ -1723,7 +1723,7 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 			return (!moves.includes('flareblitz') && !moves.includes('pyroball') && !moves.includes('sacredfire') &&
 				!moves.includes('bitterblade') && !moves.includes('firepunch')) || this.isDoubles;
 		case 'terablast':
-			return !this.terastalClause;
+			return !this.terastalClause && dex.gen === 9;
 		case 'terrainpulse': case 'waterpulse':
 			return ['megalauncher', 'technician'].includes(abilityid) && !moves.includes('originpulse');
 		case 'thief':

--- a/play.pokemonshowdown.com/src/battle-team-editor.tsx
+++ b/play.pokemonshowdown.com/src/battle-team-editor.tsx
@@ -67,6 +67,7 @@ export class TeamEditorState extends PSModel {
 	isNatDex = false;
 	isBDSP = false;
 	isChampions = false;
+	terastalClause = false;
 	formeLegality: 'normal' | 'hackmons' | 'custom' = 'normal';
 	abilityLegality: 'normal' | 'hackmons' = 'normal';
 	defaultLevel = 100;
@@ -100,6 +101,7 @@ export class TeamEditorState extends PSModel {
 		this.isNatDex = formatid.includes('nationaldex') || formatid.includes('natdex');
 		this.isBDSP = formatid.includes('bdsp');
 		this.isChampions = formatid.includes('champions');
+		this.terastalClause = !!BattleFormats[formatid]?.terastalClause;
 		if (formatid.includes('almostanyability') || formatid.includes('aaa')) {
 			this.abilityLegality = 'hackmons';
 		} else {
@@ -497,7 +499,7 @@ export class TeamEditorState extends PSModel {
 	};
 	hpTypeMatters(set: Dex.PokemonSet): boolean {
 		if (this.gen < 2) return false;
-		if (this.gen > 7) return false;
+		if (this.gen > 7 && !this.isNatDex) return false;
 		for (const move of set.moves) {
 			const moveid = toID(move);
 			if (moveid.startsWith('hiddenpower')) return true;
@@ -1681,7 +1683,7 @@ class TeamTextbox extends preact.Component<{
 			<span class="detailcell">
 				<label>Shiny</label>{set.shiny ? 'Yes' : '\u2014'}
 			</span>
-			{editor.gen === 9 && !editor.isChampions ? (
+			{editor.gen === 9 && !editor.terastalClause && !editor.isChampions ? (
 				<span class="detailcell">
 					<label>Tera</label><PSIcon type={set.teraType || species.requiredTeraType || species.types[0]} />
 				</span>
@@ -2011,7 +2013,7 @@ class TeamWizard extends preact.Component<{
 								<strong class="label">Shiny</strong> {}
 								{set.shiny ? <img src={`${Dex.resourcePrefix}sprites/misc/shiny.png`} width={22} height={22} alt="Yes" /> : '\u2014'}
 							</span>}
-							{editor.gen === 9 && !editor.isChampions && <span class="detailcell">
+							{editor.gen === 9 && !editor.terastalClause && !editor.isChampions && <span class="detailcell">
 								<strong class="label">Tera</strong> {}
 								<PSIcon type={set.teraType || species.requiredTeraType || species.types[0]} />
 							</span>}
@@ -3164,7 +3166,7 @@ class DetailsForm extends preact.Component<{
 						))}
 					</select></label>
 				</p>}
-				{editor.gen === 9 && !editor.isChampions && <p>
+				{editor.gen === 9 && !editor.terastalClause && !editor.isChampions && <p>
 					<label class="label" title="Tera Type">
 						Tera Type: {}
 						{species.requiredTeraType && editor.formeLegality === 'normal' ? (

--- a/play.pokemonshowdown.com/src/panel-mainmenu.tsx
+++ b/play.pokemonshowdown.com/src/panel-mainmenu.tsx
@@ -264,6 +264,7 @@ export class MainMenuRoom extends PSRoom {
 				let bestOfDefault = false;
 				let teraPreviewDefault = false;
 				let itemClauseDefault = false;
+				let terastalClause = false;
 				let team: 'preset' | null = null;
 				let teambuilderLevel: number | null = null;
 				let lastCommaIndex = name.lastIndexOf(',');
@@ -279,6 +280,7 @@ export class MainMenuRoom extends PSRoom {
 					if (code & 64) bestOfDefault = true;
 					if (code & 128) teraPreviewDefault = true;
 					if (code & 256) itemClauseDefault = true;
+					if (code & 512) terastalClause = true;
 				} else {
 					// Backwards compatibility: late 0.9.0 -> 0.10.0
 					if (name.substr(name.length - 2) === ',#') { // preset teams
@@ -343,6 +345,7 @@ export class MainMenuRoom extends PSRoom {
 					bestOfDefault,
 					teraPreviewDefault,
 					itemClauseDefault,
+					terastalClause,
 					rated: searchShow && id.substr(4, 7) !== 'unrated',
 					teambuilderLevel,
 					partner,

--- a/play.pokemonshowdown.com/src/panel-teamdropdown.tsx
+++ b/play.pokemonshowdown.com/src/panel-teamdropdown.tsx
@@ -357,6 +357,7 @@ export interface FormatData {
 	bestOfDefault?: boolean;
 	teraPreviewDefault?: boolean;
 	itemClauseDefault?: boolean;
+	terastalClause?: boolean;
 	rated: boolean;
 	teambuilderLevel?: number | null;
 	partner?: boolean;


### PR DESCRIPTION
Also moves Tera Blast to Usually Useless in formats with Tera Clause, and adds HP type button to NatDex.

Requires https://github.com/smogon/pokemon-showdown/pull/12132