### PR TITLE
Add client-side persistent status support

### DIFF
--- a/play.pokemonshowdown.com/src/client-connection.ts
+++ b/play.pokemonshowdown.com/src/client-connection.ts
@@ -215,6 +215,7 @@ export class PSConnection {
 		for (const msg of queue) this.send(msg);
 
 		PS.prefs.doAutojoin();
+		PS.prefs.setPersistentStatus();
 
 		PS.update();
 	}

--- a/play.pokemonshowdown.com/src/client-main.ts
+++ b/play.pokemonshowdown.com/src/client-main.ts
@@ -173,6 +173,8 @@ class PSPrefs extends PSStreamModel<string | null> {
 		language?: string,
 	} = {};
 
+	persistentstatus: string | null = null;
+
 	// PREFS END HERE
 
 	storageEngine: 'localStorage' | 'iframeLocalStorage' | '' = '';
@@ -343,6 +345,12 @@ class PSPrefs extends PSStreamModel<string | null> {
 			if (room.type === 'battle') {
 				room.connect();
 			}
+		}
+	}
+	setPersistentStatus() {
+		let persistentStatus = PS.prefs.persistentstatus;
+		if (persistentStatus) {
+			PS.send(`/noreply /status ${persistentStatus}`);
 		}
 	}
 }
@@ -1753,8 +1761,30 @@ export class PSRoom extends PSStreamModel<Args | null> implements RoomOptions {
 				this.add('||/afd off - Disable April Fools\' Day jokes until the next refresh, and set /afd default.');
 				this.add('||/afd never - Disable April Fools\' Day jokes permanently.');
 				return;
+			case 'persistentstatus':
+				this.add('||/persistentstatus [status] - Set your status automatically on login from the current device.');
+				return;
+			case 'clearpersistentstatus':
+				this.add('||/clearpersistentstatus - Clear the persistent status from the current device.');
+				return;
 			default:
 				return true;
+			}
+		},
+		'persistentstatus'(target) {
+			if (target) {
+				PS.prefs.set('persistentstatus', target);
+				this.send(`/status ${target}`);
+			} else {
+				this.handleSend('/help persistentstatus');
+			}
+		},
+		'clearpersistentstatus'(target) {
+			if (target) {
+				this.handleSend('/help clearpersistentstatus');
+			} else {
+				PS.prefs.set('persistentstatus', null);
+				this.send('/clearstatus');
 			}
 		},
 		'autojoin,cmd,crq,query'() {


### PR DESCRIPTION
Added `persistentstatus` and `clearpersistentstatus` client-side commands, as well as a `persistentstatus` pref. Automatically send `/noreply /status <persistentstatus>` on connection.

This adds the ability to set a persistent status, per-client, without the need for any server-side changes and without altering the current temporary status functionality.