### PR TITLE
Mega Meowstic F base abilities showing incorrectly in team builder

### DIFF
--- a/play.pokemonshowdown.com/src/battle-dex-search.ts
+++ b/play.pokemonshowdown.com/src/battle-dex-search.ts
@@ -1390,7 +1390,7 @@ class BattleAbilitySearch extends BattleTypedSearch<'ability'> {
 
 		if (species.isMega) {
 			abilitySet.unshift(['html', `Will be <strong>${species.abilities['0']}</strong> after Mega Evolving.`]);
-			species = dex.species.get(species.baseSpecies);
+			species = dex.species.get(species.changesFrom || species.baseSpecies);
 		}
 		abilitySet.push(['ability', toID(species.abilities['0'])]);
 		if (species.abilities['1']) {


### PR DESCRIPTION
This is my first time contributing, so I hope I am following the process ok.

I debugged and fixed this issue.
https://www.smogon.com/forums/threads/female-mega-meowstic-shows-base-forme-with-incorrect-ability.3785036/

Cause:
When base form abilities are loaded in the team builder they default to base species. Since Meowstic is the base species, but diverges from Meowstic-F it created a new edge case.

Fix:
Use changesFrom first when getting the species for a mega evolution when doing an ability search. This requires no changes to the pokedex data since battleOnly was already set to Meowstic-F for Mega Meowstic-F. 

Falls back to baseSpecies when changeForm is undefined so it does not effect other Megas. 

<img width="872" height="655" alt="image" src="https://github.com/user-attachments/assets/2d95a3c3-1f0b-4ee1-9c75-2e6af2abd9d9" />

<img width="873" height="546" alt="image" src="https://github.com/user-attachments/assets/844efaeb-8206-45d2-9bc0-58b31a466498" />

<img width="873" height="611" alt="image" src="https://github.com/user-attachments/assets/acf474ea-1bf9-4f0c-8b21-253540aaedef" />
