### PR TITLE
Declaration that a Pokemon is trying to switch should happen before pursuit goes off.

### DIFF
--- a/play.pokemonshowdown.com/src/battle.ts
+++ b/play.pokemonshowdown.com/src/battle.ts
@@ -931,6 +931,14 @@ export class Side {
 		}
 		this.battle.scene.animSummon(pokemon, slot, true);
 	}
+	// I DECLARE SWITCHOUT!!!
+	declareSwitchOut(pokemon: Pokemon, kwArgs: KWArgs, slot = pokemon.slot) {
+		const effect = Dex.getEffect(kwArgs.from);
+		if (!['batonpass', 'zbatonpass', 'shedtail', 'teleport'].includes(effect.id) &&
+			!(this.battle.tier.includes(`Relay Race`) && !effect.id)) {
+			this.battle.log(['switchout', pokemon.ident], { from: effect.id });
+		}
+	}
 	switchOut(pokemon: Pokemon, kwArgs: KWArgs, slot = pokemon.slot) {
 		const effect = Dex.getEffect(kwArgs.from);
 		if (!['batonpass', 'zbatonpass'].includes(effect.id) &&
@@ -943,10 +951,6 @@ export class Side {
 		} else {
 			pokemon.removeVolatile('transform' as ID);
 			pokemon.removeVolatile('formechange' as ID);
-		}
-		if (!['batonpass', 'zbatonpass', 'shedtail', 'teleport'].includes(effect.id) &&
-			!(this.battle.tier.includes(`Relay Race`) && !effect.id)) {
-			this.battle.log(['switchout', pokemon.ident], { from: effect.id });
 		}
 		pokemon.statusData.toxicTurns = 0;
 		if (this.battle.gen === 5) pokemon.statusData.sleepTurns = 0;
@@ -3751,6 +3755,15 @@ export class Battle {
 				if (set.teraType) pokemon.teraType = set.teraType;
 			}
 			this.log(args, kwArgs);
+			break;
+		}
+		// Happens prior to the BeforeSwitchOut event. So we can add the switch declaration to the battle log before things like pursuit happen.
+		case 'preswitch': {
+			let poke = this.getSwitchedPokemon(args[1], args[2]);
+			let slot = poke.slot;
+			if (poke.side.active[slot]) {
+				poke.side.declareSwitchOut(poke.side.active[slot], kwArgs);
+			}
 			break;
 		}
 		case 'switch': case 'drag': case 'replace': {


### PR DESCRIPTION
**Bug Report**
https://www.smogon.com/forums/threads/bug-report-client.3785313/
When a Pokemon is attempting to switch the message that the pokemon is withdrawing should happen before pursuit goes off.
Proof of interaction in Ultra Sun
https://youtu.be/XUlAr1TjSMo?t=855

**Fix**
Added preswitch as a major detail update
Declare switchout text in preswitch to allow it to show before pursuit happens.
[Gen9NationalDexDoubles-2026-07-19-bumathelesser-pursuittest (3).html](https://github.com/user-attachments/files/30169111/Gen9NationalDexDoubles-2026-07-19-bumathelesser-pursuittest.3.html)

**Related Simulator PR**
https://github.com/smogon/pokemon-showdown/pull/12181




