### PR TITLE
Add Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /pokemonshowdown.com/cms
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /desktop
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Add `.github/dependabot.yml` to enable automated dependency updates via Dependabot.

### What

Dependabot will open weekly PRs to keep dependencies current across all detected package ecosystems:

- **npm** — root `/`, `/desktop`, `/pokemonshowdown.com/cms`
- **Composer** — root `/`
- **GitHub Actions** — root `/`

Updates are grouped per ecosystem (one PR per ecosystem per week) to keep review noise low.

### Why

Without automated update tooling, dependencies drift behind upstream releases and known CVEs accumulate unnoticed. Dependabot is the lowest-friction option for GitHub-hosted projects and requires no additional tooling or CI configuration.

---

This change was generated by [Autar](https://autar.ai) and reviewed by a human before submission.
