### PR TITLE
Battle: Refresh weather on details change

### DIFF
--- a/play.pokemonshowdown.com/src/battle.ts
+++ b/play.pokemonshowdown.com/src/battle.ts
@@ -2556,6 +2556,7 @@ export class Battle {
 			poke.searchid = args[1].substr(0, 2) + args[1].substr(args[1].indexOf(':')) + '|' + args[2];
 
 			this.scene.animTransform(poke, true, true);
+			this.scene.updateWeather();
 			this.log(args, kwArgs);
 			break;
 		}

--- a/test/battle.test.js
+++ b/test/battle.test.js
@@ -88,6 +88,47 @@ describe('Battle', () => {
 
 		assert.deepEqual(p1leafeon.moveTrack, [['Knock Off', 1]]);
 	});
+
+	it('should refresh weather after a details change updates an active ability', () => {
+		global.BattlePokedex = {
+			drampa: {
+				num: 780,
+				name: 'Drampa',
+				types: ['Normal', 'Dragon'],
+				abilities: { 0: 'Berserk', 1: 'Sap Sipper', H: 'Cloud Nine' },
+			},
+			drampamega: {
+				num: 780,
+				name: 'Drampa-Mega',
+				baseSpecies: 'Drampa',
+				forme: 'Mega',
+				types: ['Normal', 'Dragon'],
+				abilities: { 0: 'Berserk' },
+			},
+		};
+
+		const battle = new Battle({ debug: true });
+		battle.add('|gen|9');
+		battle.add('|switch|p1a: Drampa|Drampa, L100|100/100');
+		battle.add('|-ability|p1a: Drampa|Cloud Nine');
+		battle.add('|-weather|RainDance');
+		assert.equal(battle.abilityActive('Cloud Nine'), true);
+
+		let weatherUpdates = 0;
+		battle.scene.updateWeather = () => weatherUpdates++;
+		const weatherState = [battle.weather, battle.weatherMinTimeLeft, battle.weatherTimeLeft];
+
+		battle.add('|detailschange|p1a: Drampa|Drampa-Mega, L100');
+
+		assert.equal(battle.p1.active[0].ability, 'Berserk');
+		assert.equal(battle.abilityActive('Cloud Nine'), false);
+		assert.equal(weatherUpdates, 1);
+		assert.deepEqual(
+			[battle.weather, battle.weatherMinTimeLeft, battle.weatherTimeLeft],
+			weatherState
+		);
+		delete global.BattlePokedex;
+	});
 });
 
 describe('Text parser', () => {


### PR DESCRIPTION
Refreshes the weather display after an active Pokémon's details change, fixing Cloud Nine remaining visually active after Drampa Mega Evolves.

Fixes #2677

Tested with `npm test` and the reported replay.
