### PR TITLE
Include natures in OTS pastes for Champions

### DIFF
--- a/play.pokemonshowdown.com/src/oldclient/client-teambuilder.js
+++ b/play.pokemonshowdown.com/src/oldclient/client-teambuilder.js
@@ -917,7 +917,7 @@
 			$('label[name=editMessage]').hide();
 		},
 		pokepasteExport: function (type) {
-			var team = Storage.exportTeam(this.curSetList, type === 'openteamsheet');
+			var team = Storage.exportTeam(this.curSetList, type.includes("openteamsheet"), type === "openteamsheetnatures");
 			if (!team) return app.addPopupMessage("Add a Pokémon to your team before uploading it!");
 			document.getElementById("pasteData").value = team;
 			document.getElementById("pasteTitle").value = this.curTeam.name;
@@ -1274,7 +1274,9 @@
 				buf += '</p>';
 				buf += '<p><button name="pokepasteExport" type="submit" class="button exportbutton"><i class="fa fa-upload"></i> Upload to PokePaste</button></p>';
 				if (this.curTeam.format.includes('vgc')) {
-					buf += '<p><button name="pokepasteExport" value="openteamsheet" type="submit" class="button exportbutton"><i class="fa fa-upload"></i> Upload to PokePaste (Open Team Sheet)</button></p>';
+					buf += '<p><button name="pokepasteExport" value="';
+					buf += this.curTeam.format.includes("champions") ? 'openteamsheetnatures' : 'openteamsheet';
+					buf += '" type="submit" class="button exportbutton"><i class="fa fa-upload"></i> Upload to PokePaste (Open Team Sheet)</button></p>';
 				}
 				buf += '</form></div>';
 			}

--- a/play.pokemonshowdown.com/src/oldclient/storage.js
+++ b/play.pokemonshowdown.com/src/oldclient/storage.js
@@ -1383,7 +1383,7 @@ Storage.exportFolder = function (folder) {
 	}
 	return buf;
 };
-Storage.exportTeam = function (team, hidestats) {
+Storage.exportTeam = function (team, hidestats, shownatures) {
 	if (!team) return "";
 	if (typeof team === 'string') {
 		if (team.indexOf('\n') >= 0) return team;
@@ -1430,6 +1430,11 @@ Storage.exportTeam = function (team, hidestats) {
 		if (curSet.teraType) {
 			text += 'Tera Type: ' + curSet.teraType + '  \n';
 		}
+
+		if (hidestats && shownatures && curSet.nature) {
+			text += '' + curSet.nature + ' Nature' + "  \n";
+		}
+
 		if (!hidestats) {
 			var first = true;
 			if (curSet.evs) {


### PR DESCRIPTION
This change includes natures in pokepaste OTS uploads for champions formats vgc only. If the format is a VGC format, but not champions, it will behave like previous and not include natures.

Let me know if there's a better way to implement this - the linter didn't like my original approach.

Example uploads (you can verify the format used):
* [`gen9championsvgc2026mb` OTS](https://pokepast.es/e746786de315910c) - includes natures
* [`gen9championsvgc2026mb` full paste](https://pokepast.es/f70af5097b9a1d81) - includes natures only once
* [`gen9vgc2025regi` OTS](https://pokepast.es/bd97d628fd180b69) - does not include natures
* [`gen9vgc2025regi` Full paste](https://pokepast.es/a40e8959e49aa2aa) includes natures only once

Addresses an issue from the server repo:
https://github.com/smogon/pokemon-showdown/issues/12249