### PR TITLE
Preact: Add New Game button for ladder battles

### DIFF
--- a/play.pokemonshowdown.com/src/panel-battle.tsx
+++ b/play.pokemonshowdown.com/src/panel-battle.tsx
@@ -11,7 +11,7 @@ import {
 } from "./client-main";
 import { PSIcon, PSPanelWrapper, PSRoomPanel } from "./panels";
 import { ChatLog, ChatRoom, ChatTextEntry, ChatUserList } from "./panel-chat";
-import { FormatDropdown } from "./panel-mainmenu";
+import { FormatDropdown, type BattleSearch } from "./panel-mainmenu";
 import { Battle, type Pokemon, type ServerPokemon } from "./battle";
 import { BattleScene } from "./battle-animations";
 import { Dex, toID, type ID } from "./battle-dex";
@@ -155,6 +155,29 @@ export class BattleRoom extends ChatRoom {
 		* null = initializing, we don't know yet */
 	rejoining: boolean | null = null;
 	overlayActive: 'move' | 'switch' | null = null;
+	search: BattleSearch | null = null;
+	searchFormat = '';
+	searchRated: string | boolean = false;
+
+	override receiveLine(args: Args) {
+		switch (args[0]) {
+		case 'tier':
+			this.searchFormat = args[1];
+			break;
+		case 'rated':
+			this.searchRated = args[1] || true;
+			break;
+		case 'teampreview': case 'start':
+			if (!this.search) {
+				this.search = PS.mainmenu.claimBattleSearch(this.id, {
+					tier: this.searchFormat,
+					rated: this.searchRated,
+				});
+			}
+			break;
+		}
+		return super.receiveLine(args);
+	}
 
 	override interruptClose(explicit?: boolean, elem?: HTMLElement | null) {
 		if (this.isPlaying() || this.requireForfeit) {
@@ -1297,6 +1320,11 @@ class BattlePanel extends PSRoomPanel<BattleRoom> {
 					<button class="button" data-cmd="/close">
 						<strong>Main menu</strong><br /><small>(closes this battle)</small>
 					</button> {}
+					{room.search && <>
+						<button class="button" onClick={this.handleNewGame}>
+							<strong>New Game</strong><br /><small>(closes this battle)</small>
+						</button> {}
+					</>}
 					<button class="button" data-cmd={`/closeand /challenge ${room.battle.farSide.id},${room.battle.tier}`}>
 						<strong>Rematch</strong><br /><small>(closes this battle)</small>
 					</button>
@@ -1311,6 +1339,17 @@ class BattlePanel extends PSRoomPanel<BattleRoom> {
 			)}
 		</div>;
 	}
+	handleNewGame = (e: MouseEvent) => {
+		const room = this.props.room;
+		if (!room.search) return;
+		if (!PS.user.named) {
+			PS.join('login' as RoomID, { parentElem: e.currentTarget as HTMLElement });
+			return;
+		}
+		PS.mainmenu.startSearchWithTeam(
+			room.search.format, room.search.packedTeam, e.currentTarget as HTMLElement, room.id
+		);
+	};
 
 	handleDownloadReplay = (e: MouseEvent) => {
 		let room = this.props.room;

--- a/play.pokemonshowdown.com/src/panel-battle.tsx
+++ b/play.pokemonshowdown.com/src/panel-battle.tsx
@@ -1318,16 +1318,17 @@ class BattlePanel extends PSRoomPanel<BattleRoom> {
 			{room.side ? (
 				<p>
 					<button class="button" data-cmd="/close">
-						<strong>Main menu</strong><br /><small>(closes this battle)</small>
+						<strong>Main menu</strong>
 					</button> {}
 					{room.search && <>
 						<button class="button" onClick={this.handleNewGame}>
-							<strong>New Game</strong><br /><small>(closes this battle)</small>
+							<strong>New Game</strong>
 						</button> {}
 					</>}
 					<button class="button" data-cmd={`/closeand /challenge ${room.battle.farSide.id},${room.battle.tier}`}>
-						<strong>Rematch</strong><br /><small>(closes this battle)</small>
+						<strong>Rematch</strong>
 					</button>
+					<br /><small>(closes this battle)</small>
 				</p>
 			) : (
 				<p>

--- a/play.pokemonshowdown.com/src/panel-chat-tournament.tsx
+++ b/play.pokemonshowdown.com/src/panel-chat-tournament.tsx
@@ -289,6 +289,7 @@ export class ChatTournament extends PSModel {
 
 			case 'battlestart': {
 				const roomid = toRoomid(data[2]);
+				PS.mainmenu.rejectBattleSearch(roomid as RoomID);
 				this.tryAdd(`|uhtml|tournament-${roomid}|<div class="tournament-message-battlestart"><a href="${roomid}" class="ilink">Tournament battle between ${BattleLog.escapeHTML(data[0])} and ${BattleLog.escapeHTML(data[1])} started.</a></div>`);
 				break;
 			}

--- a/play.pokemonshowdown.com/src/panel-mainmenu.tsx
+++ b/play.pokemonshowdown.com/src/panel-mainmenu.tsx
@@ -10,7 +10,7 @@ import { PSLoginServer } from "./client-connection";
 import { PSBackground } from "./client-core";
 import { Config, PS, PSRoom, type PSRoomFocusOptions, type RoomID, type RoomOptions, type Team } from "./client-main";
 import { PSIcon, PSPanelErrorBoundary, PSPanelWrapper, PSRoomPanel, PSView, ReconnectTimer } from "./panels";
-import type { BattlesRoom } from "./panel-battle";
+import type { BattleRoom, BattlesRoom } from "./panel-battle";
 import type { ChatRoom } from "./panel-chat";
 import type { LadderFormatRoom } from "./panel-ladder";
 import type { RoomsRoom } from "./panel-rooms";
@@ -22,6 +22,28 @@ import { BattleLog } from "./battle-log"; // optional
 export type RoomInfo = {
 	title: string, id?: RoomID, desc?: string, userCount?: number, section?: string, privacy?: 'hidden',
 	spotlight?: string, subRooms?: string[],
+};
+
+export type BattleSearch = {
+	format: string,
+	packedTeam: string,
+};
+
+type PendingBattleSearch = BattleSearch & {
+	rated: boolean,
+	games: Record<RoomID, true>,
+	closeRoomid: RoomID | null,
+};
+
+type BattleSearchCandidate = BattleSearch & {
+	rated: boolean,
+	allowRenames: boolean,
+	closeRoomid: RoomID | null,
+};
+
+type BattleSearchResult = {
+	tier: string,
+	rated: string | boolean,
 };
 
 export class MainMenuRoom extends PSRoom {
@@ -44,10 +66,13 @@ export class MainMenuRoom extends PSRoom {
 		chat?: RoomInfo[],
 		sectionTitles?: string[],
 	} = {};
-	searchCountdown: { format: string, packedTeam: string, countdown: number, timer: number } | null = null;
+	searchCountdown: BattleSearch & { countdown: number, timer: number, closeRoomid: RoomID | null } | null = null;
 	/** used to track the moment between "search sent" and "server acknowledged search sent" */
 	teamSent: string | null = null;
 	search: { searching: string[], games: Record<RoomID, string> | null } = { searching: [], games: null };
+	pendingSearch: PendingBattleSearch | null = null;
+	pendingSearchClearTimer: number | null = null;
+	battleSearches: Record<RoomID, BattleSearchCandidate | undefined> = {};
 	disallowSpectators: boolean | null = PS.prefs.disallowspectators;
 	lastChallenged: number | null = null;
 	constructor(options: RoomOptions) {
@@ -68,35 +93,48 @@ export class MainMenuRoom extends PSRoom {
 		return '';
 	}
 	startSearch = (format: string, team?: Team, parentElem?: HTMLElement | null) => {
+		return this.startSearchWithTeam(format, team ? team.packedTeam : '', parentElem);
+	};
+	startSearchWithTeam = (
+		format: string, packedTeam: string, parentElem?: HTMLElement | null, closeRoomid: RoomID | null = null
+	) => {
 		PS.requestNotifications();
-		if (this.searchCountdown) {
+		if (PS.isOffline) {
+			PS.alert("You are offline.", { parentElem });
+			return false;
+		} else if (this.searchCountdown) {
 			PS.alert("Wait for this countdown to finish first...", { parentElem });
-			return;
-		} else if (this.search.searching.includes(format)) {
-			PS.alert(`You're already searching for a ${BattleLog.formatName(format)} battle...`, { parentElem });
-			return;
+			return false;
+		} else if (this.searchingFormat()) {
+			const searchingFormat = this.searchingFormat()!;
+			PS.alert(`You're already searching for a ${BattleLog.formatName(searchingFormat)} battle...`, { parentElem });
+			return false;
 		}
 		this.searchCountdown = {
 			format,
-			packedTeam: team?.packedTeam || '',
+			packedTeam,
+			closeRoomid,
 			countdown: 3,
 			timer: setInterval(this.doSearchCountdown, 1000),
 		};
 		this.update(null);
+		return true;
 	};
 	searchingFormat() {
-		return this.searchCountdown?.format || this.teamSent ||
+		return this.searchCountdown?.format || this.teamSent || this.pendingSearch?.format ||
 			this.search.searching?.[this.search.searching.length - 1] || null;
 	}
 	cancelSearch = () => {
 		if (this.searchCountdown) {
 			clearTimeout(this.searchCountdown.timer);
 			this.searchCountdown = null;
+			this.clearPendingSearch();
 			this.update(null);
 			return true;
 		}
-		if (this.teamSent || this.search.searching?.length) {
+		if (this.teamSent || this.pendingSearch || this.search.searching?.length) {
 			this.teamSent = null;
+			this.clearPendingSearch();
 			PS.send(`/cancelsearch`);
 			this.update(null);
 			return true;
@@ -115,11 +153,108 @@ export class MainMenuRoom extends PSRoom {
 		this.update(null);
 	};
 	doSearch = (search: NonNullable<typeof this.searchCountdown>) => {
+		if (PS.isOffline) {
+			PS.alert("You are offline.");
+			return;
+		}
+		const searchingFormat = this.search.searching?.[this.search.searching.length - 1];
+		if (searchingFormat) {
+			PS.alert(`You're already searching for a ${BattleLog.formatName(searchingFormat)} battle...`);
+			return;
+		}
+		const games: Record<RoomID, true> = {};
+		for (const roomid in this.search.games || {}) {
+			games[roomid as RoomID] = true;
+		}
+		this.clearPendingSearch();
+		this.pendingSearch = {
+			format: search.format,
+			packedTeam: search.packedTeam,
+			rated: BattleFormats[toID(search.format)]?.rated !== false,
+			games,
+			closeRoomid: search.closeRoomid,
+		};
 		this.teamSent = search.format;
 		const privacy = this.adjustPrivacy();
 		PS.send(`/utm ${search.packedTeam}`);
 		PS.send(`${privacy}/search ${search.format}`);
 	};
+	clearPendingSearch = () => {
+		if (this.pendingSearchClearTimer !== null) clearTimeout(this.pendingSearchClearTimer);
+		this.pendingSearchClearTimer = null;
+		this.pendingSearch = null;
+	};
+	claimBattleSearch(roomid: RoomID, battle: BattleSearchResult) {
+		const search = this.battleSearches[roomid] || null;
+		delete this.battleSearches[roomid];
+		if (!search || toID(battle.tier) !== toID(search.format)) return null;
+
+		const isRatedSearch = search.rated && !search.allowRenames &&
+			battle.rated && battle.rated !== 'Tournament battle';
+		const isUnratedSearch = !search.rated && search.allowRenames && !battle.rated;
+		if (!isRatedSearch && !isUnratedSearch) return null;
+
+		const battleSearch = { format: search.format, packedTeam: search.packedTeam };
+		// Tournament battlestart updates arrive after the battle room initializes.
+		setTimeout(() => {
+			const room = PS.rooms[roomid] as BattleRoom | undefined;
+			if (room?.search === battleSearch) this.closeBattleSearchRoom(search.closeRoomid);
+		}, 1000);
+		return battleSearch;
+	}
+	rejectBattleSearch(roomid: RoomID) {
+		delete this.battleSearches[roomid];
+		const room = PS.rooms[roomid] as BattleRoom | undefined;
+		if (room?.classType !== 'battle' || !room.search) return;
+		room.search = null;
+		room.update(null);
+	}
+	closeBattleSearchRoom(roomid: RoomID | null) {
+		if (!roomid) return;
+		const room = PS.rooms[roomid] as BattleRoom | undefined;
+		if (room?.classType === 'battle' && room.battle?.ended) PS.leave(roomid);
+	}
+	closePendingSearchRoom() {
+		const roomid = this.pendingSearch?.closeRoomid;
+		if (!roomid) return;
+		this.pendingSearch!.closeRoomid = null;
+		this.closeBattleSearchRoom(roomid);
+	}
+	handleSearchUpdate(search: typeof this.search) {
+		for (const roomid in this.battleSearches) {
+			if (!search.games?.[roomid as RoomID]) delete this.battleSearches[roomid as RoomID];
+		}
+		const pendingSearch = this.pendingSearch;
+		if (!pendingSearch) return;
+
+		if (search.searching.includes(toID(pendingSearch.format))) {
+			this.closePendingSearchRoom();
+			if (this.pendingSearchClearTimer !== null) clearTimeout(this.pendingSearchClearTimer);
+			this.pendingSearchClearTimer = null;
+			return;
+		}
+
+		for (const roomid in search.games || {}) {
+			const battleRoomid = roomid as RoomID;
+			if (pendingSearch.games[battleRoomid]) continue;
+			if (!battleRoomid.startsWith(`battle-${toID(pendingSearch.format)}-`)) continue;
+
+			this.battleSearches[battleRoomid] = {
+				format: pendingSearch.format,
+				packedTeam: pendingSearch.packedTeam,
+				rated: pendingSearch.rated,
+				allowRenames: !search.games![battleRoomid].endsWith('*'),
+				closeRoomid: pendingSearch.closeRoomid,
+			};
+			this.clearPendingSearch();
+			return;
+		}
+
+		if (this.pendingSearchClearTimer === null) {
+			// A matched search disappears just before the server adds its new game.
+			this.pendingSearchClearTimer = setTimeout(this.clearPendingSearch, 1000);
+		}
+	}
 	override receiveLine(args: Args) {
 		const [cmd] = args;
 		switch (cmd) {
@@ -183,6 +318,7 @@ export class MainMenuRoom extends PSRoom {
 				const room = PS.rooms[roomid] as ChatRoom | MainMenuRoom;
 				if (room.teamSent) {
 					room.teamSent = null;
+					if (room === this) this.clearPendingSearch();
 					room.update(null);
 				}
 				if (room.type === 'team') (room as any).cancelUpload();
@@ -230,6 +366,7 @@ export class MainMenuRoom extends PSRoom {
 			json = JSON.parse(dataBuf);
 		} catch {}
 		this.search = json;
+		this.handleSearchUpdate(json);
 		this.update(null);
 	}
 	parseFormats(formatsList: string[]) {
@@ -372,6 +509,10 @@ export class MainMenuRoom extends PSRoom {
 		PS.teams.update('format');
 	}
 	handlePM(user1: string, user2: string, message?: string) {
+		const challengeBattle = message?.match(
+			/^\/nonotify .* accepted the challenge, starting &laquo;<a href="\/(battle-[a-z0-9-]+)">/
+		);
+		if (challengeBattle) this.rejectBattleSearch(challengeBattle[1] as RoomID);
 		const userid1 = toID(user1);
 		const userid2 = toID(user2);
 		const pmTarget = PS.user.userid === userid1 ? user2 : user1;


### PR DESCRIPTION
Adds a **New Game** button after a ladder battle ends.

It searches the same format with the exact team used for the original search. The client sends `/utm` again before `/search`, since another battle or tab may have changed the active team.

The button only appears for ladder/search battles, not challenges, tournaments, spectators, or replays. The finished battle closes only after the replacement search is acknowledged or matched.

Following review feedback, **Main menu**, **New Game**, and **Rematch** now share one `(closes this battle)` notice beneath the action row.

Tested with Node 22 using `npm test` (32 passed, 1 skipped). The updated controls were also checked at desktop and mobile widths.

## Screenshots

<img width="1428" height="728" alt="New Game button on desktop" src="https://github.com/user-attachments/assets/a392bf4f-b13e-4670-8490-9a1bac17ae16" />

<img width="390" height="844" alt="New Game button on mobile" src="https://github.com/user-attachments/assets/7364498c-b3a6-4171-9415-8df4121c0786" />

---
> **Continues #2743** — the fork repo backing that PR was accidentally deleted from this account, and GitHub blocks reopening a PR whose submitting repository was deleted (a restore request is being filed with GitHub Support). This PR resumes the identical work from the same commit (`3ed91216624a4eebc54dbc4c739d7c1fe8be797b`); review discussion continues on the original PR.
