### PR TITLE
Teambuilder: detect Champions VGC as doubles

### DIFF
--- a/play.pokemonshowdown.com/src/battle-dex-search.ts
+++ b/play.pokemonshowdown.com/src/battle-dex-search.ts
@@ -745,7 +745,12 @@ abstract class BattleTypedSearch<T extends SearchType> {
 			if (format.startsWith('natdex') || format.startsWith('nationaldex')) this.formatType = 'natdexchampions';
 			if (format.startsWith('natdex')) format = format.slice(6) as ID;
 			if (format.startsWith('nationaldex')) format = format.slice(11) as ID;
-			if (format.startsWith('vgc') || format.startsWith('bss')) format = 'ubers' as ID;
+			if (format.startsWith('vgc')) {
+				this.isDoubles = true;
+				format = 'ubers' as ID;
+			} else if (format.startsWith('bss')) {
+				format = 'ubers' as ID;
+			}
 			if (format.endsWith('draft')) format = 'ag' as ID;
 		}
 		if (format.startsWith('vgc')) {

--- a/test/battle-dex-search.test.js
+++ b/test/battle-dex-search.test.js
@@ -1,0 +1,32 @@
+const assert = require('assert').strict;
+const fs = require('fs');
+const path = require('path');
+const {describe, it} = require('node:test');
+const vm = require('vm');
+
+global.Config = {routes: {dex: 'dex.pokemonshowdown.com'}};
+global.TL = {term: {noitem: '(localized no item)', noability: '(localized no ability)', moves: 'Moves'}};
+global.preact = {Component: function () {}};
+
+const jsPath = (name) => path.resolve(__dirname, '../play.pokemonshowdown.com/js', name);
+vm.runInThisContext(
+	`${fs.readFileSync(jsPath('battle-dex-data.js'), 'utf8')}`,
+	{filename: jsPath('battle-dex-data.js')}
+);
+vm.runInThisContext(
+	`${fs.readFileSync(jsPath('battle-dex.js'), 'utf8')}`,
+	{filename: jsPath('battle-dex.js')}
+);
+vm.runInThisContext(
+	`${fs.readFileSync(jsPath('battle-dex-search.js'), 'utf8')}`,
+	{filename: jsPath('battle-dex-search.js')}
+);
+
+describe('BattleMoveSearch', () => {
+	it('should detect Champions VGC as a doubles format', () => {
+		// plain VGC already sets isDoubles
+		assert.equal(new BattleMoveSearch('move', 'vgc').isDoubles, true);
+		// the Champions VGC formats must too
+		assert.equal(new BattleMoveSearch('move', 'championsvgc').isDoubles, true);
+	});
+});


### PR DESCRIPTION
# Description

The Champions branch of the format parser consumes the `vgc`/`bss` suffix without recording whether the format is doubles, so `moveIsNotUseless` treats Champions VGC as singles and mislists doubles-only moves like Life Dew. Set `isDoubles` for the `vgc` variants, mirroring the plain `vgc` handler below.

Fixes #2724
